### PR TITLE
Fix for passing in filenames that contain commas

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -29,6 +29,7 @@ fn main() {
             .help("File(s) to compress")
             .index(1)
             .multiple(true)
+            .use_delimiter(false)
             .required(true))
         .arg(Arg::with_name("optimization")
             .help("Optimization level - Default: 2")


### PR DESCRIPTION
The versions of clap supported by oxipng seems to default to allowing commas to be used as delimiters for passing a series of values in a single physical command line argument, when parsing for a parameter that accepts multiple values. This prevents oxipng from accepting filenames containing commas (it splits them into segments separated by commas and treats each one as a separate path to a file to process, none of which tend to exist). Fixed this by disabling the comma delimiter behavior for the 'files' argument.