### PR TITLE
Bail early

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ matrix:
       env: TARGET=x86_64-apple-darwin
       cache: cargo
     - os: linux
-      rust: 1.20.0
+      rust: 1.21.0
       env: TARGET=x86_64-unknown-linux-gnu
       cache: cargo
     - os: linux

--- a/benches/deflate.rs
+++ b/benches/deflate.rs
@@ -14,7 +14,7 @@ fn deflate_16_bits_strategy_0(b: &mut Bencher) {
     let png = png::PngData::new(&input, false).unwrap();
 
     b.iter(|| {
-        deflate::deflate(png.raw_data.as_ref(), 9, 0, 15)
+        deflate::deflate(png.raw_data.as_ref(), 9, 0, 15, None)
     });
 }
 
@@ -24,7 +24,7 @@ fn deflate_8_bits_strategy_0(b: &mut Bencher) {
     let png = png::PngData::new(&input, false).unwrap();
 
     b.iter(|| {
-        deflate::deflate(png.raw_data.as_ref(), 9, 0, 15)
+        deflate::deflate(png.raw_data.as_ref(), 9, 0, 15, None)
     });
 }
 
@@ -36,7 +36,7 @@ fn deflate_4_bits_strategy_0(b: &mut Bencher) {
     let png = png::PngData::new(&input, false).unwrap();
 
     b.iter(|| {
-        deflate::deflate(png.raw_data.as_ref(), 9, 0, 15)
+        deflate::deflate(png.raw_data.as_ref(), 9, 0, 15, None)
     });
 }
 
@@ -48,7 +48,7 @@ fn deflate_2_bits_strategy_0(b: &mut Bencher) {
     let png = png::PngData::new(&input, false).unwrap();
 
     b.iter(|| {
-        deflate::deflate(png.raw_data.as_ref(), 9, 0, 15)
+        deflate::deflate(png.raw_data.as_ref(), 9, 0, 15, None)
     });
 }
 
@@ -60,7 +60,7 @@ fn deflate_1_bits_strategy_0(b: &mut Bencher) {
     let png = png::PngData::new(&input, false).unwrap();
 
     b.iter(|| {
-        deflate::deflate(png.raw_data.as_ref(), 9, 0, 15)
+        deflate::deflate(png.raw_data.as_ref(), 9, 0, 15, None)
     });
 }
 
@@ -70,7 +70,7 @@ fn deflate_16_bits_strategy_1(b: &mut Bencher) {
     let png = png::PngData::new(&input, false).unwrap();
 
     b.iter(|| {
-        deflate::deflate(png.raw_data.as_ref(), 9, 1, 15)
+        deflate::deflate(png.raw_data.as_ref(), 9, 1, 15, None)
     });
 }
 
@@ -80,7 +80,7 @@ fn deflate_8_bits_strategy_1(b: &mut Bencher) {
     let png = png::PngData::new(&input, false).unwrap();
 
     b.iter(|| {
-        deflate::deflate(png.raw_data.as_ref(), 9, 1, 15)
+        deflate::deflate(png.raw_data.as_ref(), 9, 1, 15, None)
     });
 }
 
@@ -92,7 +92,7 @@ fn deflate_4_bits_strategy_1(b: &mut Bencher) {
     let png = png::PngData::new(&input, false).unwrap();
 
     b.iter(|| {
-        deflate::deflate(png.raw_data.as_ref(), 9, 1, 15)
+        deflate::deflate(png.raw_data.as_ref(), 9, 1, 15, None)
     });
 }
 
@@ -104,7 +104,7 @@ fn deflate_2_bits_strategy_1(b: &mut Bencher) {
     let png = png::PngData::new(&input, false).unwrap();
 
     b.iter(|| {
-        deflate::deflate(png.raw_data.as_ref(), 9, 1, 15)
+        deflate::deflate(png.raw_data.as_ref(), 9, 1, 15, None)
     });
 }
 
@@ -116,7 +116,7 @@ fn deflate_1_bits_strategy_1(b: &mut Bencher) {
     let png = png::PngData::new(&input, false).unwrap();
 
     b.iter(|| {
-        deflate::deflate(png.raw_data.as_ref(), 9, 1, 15)
+        deflate::deflate(png.raw_data.as_ref(), 9, 1, 15, None)
     });
 }
 
@@ -126,7 +126,7 @@ fn deflate_16_bits_strategy_2(b: &mut Bencher) {
     let png = png::PngData::new(&input, false).unwrap();
 
     b.iter(|| {
-        deflate::deflate(png.raw_data.as_ref(), 9, 2, 15)
+        deflate::deflate(png.raw_data.as_ref(), 9, 2, 15, None)
     });
 }
 
@@ -136,7 +136,7 @@ fn deflate_8_bits_strategy_2(b: &mut Bencher) {
     let png = png::PngData::new(&input, false).unwrap();
 
     b.iter(|| {
-        deflate::deflate(png.raw_data.as_ref(), 9, 2, 15)
+        deflate::deflate(png.raw_data.as_ref(), 9, 2, 15, None)
     });
 }
 
@@ -148,7 +148,7 @@ fn deflate_4_bits_strategy_2(b: &mut Bencher) {
     let png = png::PngData::new(&input, false).unwrap();
 
     b.iter(|| {
-        deflate::deflate(png.raw_data.as_ref(), 9, 2, 15)
+        deflate::deflate(png.raw_data.as_ref(), 9, 2, 15, None)
     });
 }
 
@@ -160,7 +160,7 @@ fn deflate_2_bits_strategy_2(b: &mut Bencher) {
     let png = png::PngData::new(&input, false).unwrap();
 
     b.iter(|| {
-        deflate::deflate(png.raw_data.as_ref(), 9, 2, 15)
+        deflate::deflate(png.raw_data.as_ref(), 9, 2, 15, None)
     });
 }
 
@@ -172,7 +172,7 @@ fn deflate_1_bits_strategy_2(b: &mut Bencher) {
     let png = png::PngData::new(&input, false).unwrap();
 
     b.iter(|| {
-        deflate::deflate(png.raw_data.as_ref(), 9, 2, 15)
+        deflate::deflate(png.raw_data.as_ref(), 9, 2, 15, None)
     });
 }
 
@@ -182,7 +182,7 @@ fn deflate_16_bits_strategy_3(b: &mut Bencher) {
     let png = png::PngData::new(&input, false).unwrap();
 
     b.iter(|| {
-        deflate::deflate(png.raw_data.as_ref(), 9, 3, 15)
+        deflate::deflate(png.raw_data.as_ref(), 9, 3, 15, None)
     });
 }
 
@@ -192,7 +192,7 @@ fn deflate_8_bits_strategy_3(b: &mut Bencher) {
     let png = png::PngData::new(&input, false).unwrap();
 
     b.iter(|| {
-        deflate::deflate(png.raw_data.as_ref(), 9, 3, 15)
+        deflate::deflate(png.raw_data.as_ref(), 9, 3, 15, None)
     });
 }
 
@@ -204,7 +204,7 @@ fn deflate_4_bits_strategy_3(b: &mut Bencher) {
     let png = png::PngData::new(&input, false).unwrap();
 
     b.iter(|| {
-        deflate::deflate(png.raw_data.as_ref(), 9, 3, 15)
+        deflate::deflate(png.raw_data.as_ref(), 9, 3, 15, None)
     });
 }
 
@@ -216,7 +216,7 @@ fn deflate_2_bits_strategy_3(b: &mut Bencher) {
     let png = png::PngData::new(&input, false).unwrap();
 
     b.iter(|| {
-        deflate::deflate(png.raw_data.as_ref(), 9, 3, 15)
+        deflate::deflate(png.raw_data.as_ref(), 9, 3, 15, None)
     });
 }
 
@@ -228,7 +228,7 @@ fn deflate_1_bits_strategy_3(b: &mut Bencher) {
     let png = png::PngData::new(&input, false).unwrap();
 
     b.iter(|| {
-        deflate::deflate(png.raw_data.as_ref(), 9, 3, 15)
+        deflate::deflate(png.raw_data.as_ref(), 9, 3, 15, None)
     });
 }
 

--- a/src/atomicmin.rs
+++ b/src/atomicmin.rs
@@ -1,0 +1,32 @@
+use std::sync::atomic::AtomicUsize;
+use std::sync::atomic::Ordering::{SeqCst, Relaxed};
+
+pub struct AtomicMin {
+    val: AtomicUsize,
+}
+
+impl AtomicMin {
+    pub fn new(init: Option<usize>) -> Self {
+        Self {
+            val: AtomicUsize::new(init.unwrap_or(usize::max_value()))
+        }
+    }
+
+    pub fn get(&self) -> Option<usize> {
+        let val = self.val.load(SeqCst);
+        if val == usize::max_value() {None} else {Some(val)}
+    }
+
+    pub fn set_min(&self, new_val: usize) {
+        let mut current_val = self.val.load(Relaxed);
+        loop {
+            if new_val < current_val {
+                if let Err(v) = self.val.compare_exchange(current_val, new_val, SeqCst, Relaxed) {
+                    current_val = v;
+                    continue;
+                }
+            }
+            break;
+        }
+    }
+}

--- a/src/deflate/miniz_stream.rs
+++ b/src/deflate/miniz_stream.rs
@@ -1,10 +1,12 @@
+use error::PngError;
 use miniz_oxide::deflate::core::*;
 
-pub fn compress_to_vec_oxipng(input: &[u8], level: u8, window_bits: i32, strategy: i32) -> Vec<u8> {
+pub fn compress_to_vec_oxipng(input: &[u8], level: u8, window_bits: i32, strategy: i32, max_size: Option<usize>) -> Result<Vec<u8>, PngError> {
     // The comp flags function sets the zlib flag if the window_bits parameter is > 0.
     let flags = create_comp_flags_from_zip_params(level.into(), window_bits, strategy);
     let mut compressor = CompressorOxide::new(flags);
-    let mut output = Vec::with_capacity(input.len() / 2);
+    // if max size is known, then expect that much data (but no more than input.len())
+    let mut output = Vec::with_capacity(max_size.unwrap_or(input.len() / 2).min(input.len()));
     // # Unsafe
     // We trust compress to not read the uninitialized bytes.
     unsafe {
@@ -30,6 +32,11 @@ pub fn compress_to_vec_oxipng(input: &[u8], level: u8, window_bits: i32, strateg
                 break;
             }
             TDEFLStatus::Okay => {
+                if let Some(max) = max_size {
+                    if output.len() > max {
+                        return Err(PngError::DeflatedDataTooLong(output.len()))
+                    }
+                }
                 // We need more space, so extend the vector.
                 if output.len().saturating_sub(out_pos) < 30 {
                     let current_len = output.len();
@@ -48,5 +55,5 @@ pub fn compress_to_vec_oxipng(input: &[u8], level: u8, window_bits: i32, strateg
         }
     }
 
-    output
+    Ok(output)
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -2,29 +2,29 @@ use std::error::Error;
 use std::fmt;
 
 #[derive(Debug, Clone)]
-pub struct PngError {
-    description: String,
+pub enum PngError {
+    Other(Box<str>),
 }
 
 impl Error for PngError {
-    #[inline]
+    // deprecated
     fn description(&self) -> &str {
-        &self.description
+        ""
     }
 }
 
 impl fmt::Display for PngError {
     #[inline]
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description)
+        match self {
+            PngError::Other(s) => f.write_str(s),
+        }
     }
 }
 
 impl PngError {
     #[inline]
     pub fn new(description: &str) -> PngError {
-        PngError {
-            description: description.to_owned(),
-        }
+        PngError::Other(description.into())
     }
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -3,6 +3,7 @@ use std::fmt;
 
 #[derive(Debug, Clone)]
 pub enum PngError {
+    DeflatedDataTooLong(usize),
     Other(Box<str>),
 }
 
@@ -16,8 +17,9 @@ impl Error for PngError {
 impl fmt::Display for PngError {
     #[inline]
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        match self {
-            PngError::Other(s) => f.write_str(s),
+        match *self {
+            PngError::DeflatedDataTooLong(_) => f.write_str("deflated data too long"),
+            PngError::Other(ref s) => f.write_str(s),
         }
     }
 }


### PR DESCRIPTION
Added on top of #103

* Abort deflate early when compressed size exceeds best known size so far. This reduces CPU usage by 10-15%
* Run alpha reductions in parallel, because why not?
* Error struct has changed, so that's technically a breaking change

