### PR TITLE
allow listing more than 2 filters (issue 101)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -355,7 +355,6 @@ dependencies = [
  "miniz_oxide 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "num_cpus 1.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rayon 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "regex 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "zopfli 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -478,28 +477,8 @@ dependencies = [
 ]
 
 [[package]]
-name = "regex"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "aho-corasick 0.6.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "memchr 2.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "regex-syntax 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "thread_local 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "utf8-ranges 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
 name = "regex-syntax"
 version = "0.5.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "ucd-util 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "regex-syntax"
-version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "ucd-util 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -764,9 +743,7 @@ dependencies = [
 "checksum redox_syscall 0.1.37 (registry+https://github.com/rust-lang/crates.io-index)" = "0d92eecebad22b767915e4d529f89f28ee96dbbf5a4810d2b844373f136417fd"
 "checksum redox_termios 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "7e891cfe48e9100a70a3b6eb652fef28920c117d366339687bd5576160db0f76"
 "checksum regex 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)" = "9329abc99e39129fcceabd24cf5d85b4671ef7c29c50e972bc5afe32438ec384"
-"checksum regex 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "75ecf88252dce580404a22444fc7d626c01815debba56a7f4f536772a5ff19d3"
 "checksum regex-syntax 0.5.6 (registry+https://github.com/rust-lang/crates.io-index)" = "7d707a4fa2637f2dca2ef9fd02225ec7661fe01a53623c1e6515b6916511f7a7"
-"checksum regex-syntax 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "8f1ac0f60d675cc6cf13a20ec076568254472551051ad5dd050364d70671bf6b"
 "checksum scopeguard 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "94258f53601af11e6a49f722422f6e3425c52b06245a5cf9bc09908b174f5e27"
 "checksum semver 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "1d7eb9ef2c18661902cc47e535f9bc51b78acd254da71d375c2f6720d9a40403"
 "checksum semver-parser 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,14 +50,9 @@ default-features = false
 features = ["png_codec"]
 version = "^0.19.0"
 
-[dependencies.regex]
-optional = true
-version = "^1.0.0"
-
 [features]
 binary = [
     "clap",
-    "regex",
 ]
 default = ["binary"]
 dev = [

--- a/src/main.rs
+++ b/src/main.rs
@@ -439,11 +439,11 @@ fn parse_numeric_range_opts(
     min_value: u8,
     max_value: u8,
 ) -> Result<HashSet<u8>, String> {
-    let error_message = "Not a valid input";
+    const ERROR_MESSAGE: &str = "Not a valid input";
     let mut items = HashSet::new();
 
     // one value
-    if let Some(one_value) = input.parse::<u8>().ok() {
+    if let Ok(one_value) = input.parse::<u8>() {
         if (min_value <= one_value) && (one_value <= max_value) {
             items.insert(one_value);
             return Ok(items);
@@ -453,9 +453,9 @@ fn parse_numeric_range_opts(
     // a range ("A-B")
     let range_values = input.split('-').collect::<Vec<&str>>();
     if range_values.len() == 2 {
-        let first_opt = range_values[0].parse::<u8>().ok();
-        let second_opt = range_values[1].parse::<u8>().ok();
-        if let (Some(first), Some(second)) = (first_opt, second_opt) {
+        let first_opt = range_values[0].parse::<u8>();
+        let second_opt = range_values[1].parse::<u8>();
+        if let (Ok(first), Ok(second)) = (first_opt, second_opt) {
             if min_value <= first && first < second && second <= max_value {
                 for i in first..second + 1 {
                     items.insert(i);
@@ -463,17 +463,23 @@ fn parse_numeric_range_opts(
                 return Ok(items);
             }
         }
+        return Err(ERROR_MESSAGE.to_owned());
     }
 
     // a list ("A,B[,…]")
-    for value in input.split(',') {
-        if let Some(value_int) = value.parse::<u8>().ok() {
-            if (min_value <= value_int) && (value_int <= max_value) && !items.contains(&value_int) {
-                items.insert(value_int);
-                continue;
+    let list_items = input.split(',').collect::<Vec<&str>>();;
+    if list_items.len() > 1 {
+        for value in list_items {
+            if let Ok(value_int) = value.parse::<u8>() {
+                if (min_value <= value_int) && (value_int <= max_value) && !items.contains(&value_int) {
+                    items.insert(value_int);
+                    continue;
+                }
             }
+            return Err(ERROR_MESSAGE.to_owned());
         }
-        return Err(error_message.to_owned());
+        return Ok(items);
     }
-    return Ok(items);
+
+    return Err(ERROR_MESSAGE.to_owned());
 }


### PR DESCRIPTION
https://github.com/shssoichiro/oxipng/issues/101

The only function that's edited is `parse_numeric_range_opts`.

The `regex` crate is not used anymore in main.rs, so if it's not used in other places, it probably can be dropped from dependencies. (It was only used in `parse_numeric_range_opts` and it seems it didn't really simplify the code that much…)  
Also this is my first pull request with Rust code ever, so I could write something silly, please check carefully.