### PR TITLE
Enum for stdout writing flag

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ matrix:
       env: TARGET=x86_64-apple-darwin
       cache: cargo
     - os: linux
-      rust: 1.21.0
+      rust: 1.24.0
       env: TARGET=x86_64-unknown-linux-gnu
       cache: cargo
     - os: linux

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ cargo build --release
 cp target/release/oxipng /usr/local/bin
 ```
 
-The current minimum supported Rust version is **1.20.0**. Oxipng may compile on earlier versions of Rust,
+The current minimum supported Rust version is **1.24.0**. Oxipng may compile on earlier versions of Rust,
 but there is no guarantee.
 
 Oxipng follows Semantic Versioning.

--- a/README.template.md
+++ b/README.template.md
@@ -26,7 +26,7 @@ cargo build --release
 cp target/release/oxipng /usr/local/bin
 ```
 
-The current minimum supported Rust version is **1.20.0**. Oxipng may compile on earlier versions of Rust,
+The current minimum supported Rust version is **1.24.0**. Oxipng may compile on earlier versions of Rust,
 but there is no guarantee.
 
 Oxipng follows Semantic Versioning.

--- a/tests/filters.rs
+++ b/tests/filters.rs
@@ -2,26 +2,26 @@ extern crate oxipng;
 
 use oxipng::colors::{BitDepth, ColorType};
 use oxipng::png;
+use oxipng::OutFile;
 use std::collections::HashSet;
 use std::fs::remove_file;
 use std::path::Path;
 use std::path::PathBuf;
 
-fn get_opts(input: &Path) -> oxipng::Options {
+fn get_opts(input: &Path) -> (OutFile, oxipng::Options) {
     let mut options = oxipng::Options::default();
-    options.out_file = Some(input.with_extension("out.png").to_owned());
     options.verbosity = None;
     options.force = true;
     let mut filter = HashSet::new();
     filter.insert(0);
     options.filter = filter;
 
-    options
+    (OutFile::Path(Some(input.with_extension("out.png").to_owned())), options)
 }
 
 fn test_it_converts(
     input: &Path,
-    output: &Path,
+    output: &OutFile,
     opts: &oxipng::Options,
     color_type_in: ColorType,
     bit_depth_in: BitDepth,
@@ -33,10 +33,11 @@ fn test_it_converts(
     assert_eq!(png.ihdr_data.color_type, color_type_in);
     assert_eq!(png.ihdr_data.bit_depth, bit_depth_in);
 
-    match oxipng::optimize(input, opts) {
+    match oxipng::optimize(input, output, opts) {
         Ok(_) => (),
         Err(x) => panic!("{}", x),
     };
+    let output = output.path().unwrap();
     assert!(output.exists());
 
     let png = match png::PngData::new(output, opts.fix_errors) {
@@ -56,10 +57,9 @@ fn test_it_converts(
 #[test]
 fn filter_0_for_rgba_16() {
     let input = PathBuf::from("tests/files/filter_0_for_rgba_16.png");
-    let mut opts = get_opts(&input);
+    let (output, mut opts) = get_opts(&input);
     opts.filter = HashSet::new();
     opts.filter.insert(0);
-    let output = opts.out_file.clone().unwrap();
 
     test_it_converts(
         &input,
@@ -75,10 +75,9 @@ fn filter_0_for_rgba_16() {
 #[test]
 fn filter_1_for_rgba_16() {
     let input = PathBuf::from("tests/files/filter_1_for_rgba_16.png");
-    let mut opts = get_opts(&input);
+    let (output, mut opts) = get_opts(&input);
     opts.filter = HashSet::new();
     opts.filter.insert(1);
-    let output = opts.out_file.clone().unwrap();
 
     test_it_converts(
         &input,
@@ -94,10 +93,9 @@ fn filter_1_for_rgba_16() {
 #[test]
 fn filter_2_for_rgba_16() {
     let input = PathBuf::from("tests/files/filter_2_for_rgba_16.png");
-    let mut opts = get_opts(&input);
+    let (output, mut opts) = get_opts(&input);
     opts.filter = HashSet::new();
     opts.filter.insert(2);
-    let output = opts.out_file.clone().unwrap();
 
     test_it_converts(
         &input,
@@ -113,10 +111,9 @@ fn filter_2_for_rgba_16() {
 #[test]
 fn filter_3_for_rgba_16() {
     let input = PathBuf::from("tests/files/filter_3_for_rgba_16.png");
-    let mut opts = get_opts(&input);
+    let (output, mut opts) = get_opts(&input);
     opts.filter = HashSet::new();
     opts.filter.insert(3);
-    let output = opts.out_file.clone().unwrap();
 
     test_it_converts(
         &input,
@@ -132,10 +129,9 @@ fn filter_3_for_rgba_16() {
 #[test]
 fn filter_4_for_rgba_16() {
     let input = PathBuf::from("tests/files/filter_4_for_rgba_16.png");
-    let mut opts = get_opts(&input);
+    let (output, mut opts) = get_opts(&input);
     opts.filter = HashSet::new();
     opts.filter.insert(4);
-    let output = opts.out_file.clone().unwrap();
 
     test_it_converts(
         &input,
@@ -151,10 +147,9 @@ fn filter_4_for_rgba_16() {
 #[test]
 fn filter_5_for_rgba_16() {
     let input = PathBuf::from("tests/files/filter_5_for_rgba_16.png");
-    let mut opts = get_opts(&input);
+    let (output, mut opts) = get_opts(&input);
     opts.filter = HashSet::new();
     opts.filter.insert(5);
-    let output = opts.out_file.clone().unwrap();
 
     test_it_converts(
         &input,
@@ -170,10 +165,9 @@ fn filter_5_for_rgba_16() {
 #[test]
 fn filter_0_for_rgba_8() {
     let input = PathBuf::from("tests/files/filter_0_for_rgba_8.png");
-    let mut opts = get_opts(&input);
+    let (output, mut opts) = get_opts(&input);
     opts.filter = HashSet::new();
     opts.filter.insert(0);
-    let output = opts.out_file.clone().unwrap();
 
     test_it_converts(
         &input,
@@ -189,10 +183,9 @@ fn filter_0_for_rgba_8() {
 #[test]
 fn filter_1_for_rgba_8() {
     let input = PathBuf::from("tests/files/filter_1_for_rgba_8.png");
-    let mut opts = get_opts(&input);
+    let (output, mut opts) = get_opts(&input);
     opts.filter = HashSet::new();
     opts.filter.insert(1);
-    let output = opts.out_file.clone().unwrap();
 
     test_it_converts(
         &input,
@@ -208,10 +201,9 @@ fn filter_1_for_rgba_8() {
 #[test]
 fn filter_2_for_rgba_8() {
     let input = PathBuf::from("tests/files/filter_2_for_rgba_8.png");
-    let mut opts = get_opts(&input);
+    let (output, mut opts) = get_opts(&input);
     opts.filter = HashSet::new();
     opts.filter.insert(2);
-    let output = opts.out_file.clone().unwrap();
 
     test_it_converts(
         &input,
@@ -227,10 +219,9 @@ fn filter_2_for_rgba_8() {
 #[test]
 fn filter_3_for_rgba_8() {
     let input = PathBuf::from("tests/files/filter_3_for_rgba_8.png");
-    let mut opts = get_opts(&input);
+    let (output, mut opts) = get_opts(&input);
     opts.filter = HashSet::new();
     opts.filter.insert(3);
-    let output = opts.out_file.clone().unwrap();
 
     test_it_converts(
         &input,
@@ -246,10 +237,9 @@ fn filter_3_for_rgba_8() {
 #[test]
 fn filter_4_for_rgba_8() {
     let input = PathBuf::from("tests/files/filter_4_for_rgba_8.png");
-    let mut opts = get_opts(&input);
+    let (output, mut opts) = get_opts(&input);
     opts.filter = HashSet::new();
     opts.filter.insert(4);
-    let output = opts.out_file.clone().unwrap();
 
     test_it_converts(
         &input,
@@ -265,10 +255,9 @@ fn filter_4_for_rgba_8() {
 #[test]
 fn filter_5_for_rgba_8() {
     let input = PathBuf::from("tests/files/filter_5_for_rgba_8.png");
-    let mut opts = get_opts(&input);
+    let (output, mut opts) = get_opts(&input);
     opts.filter = HashSet::new();
     opts.filter.insert(5);
-    let output = opts.out_file.clone().unwrap();
 
     test_it_converts(
         &input,
@@ -284,10 +273,9 @@ fn filter_5_for_rgba_8() {
 #[test]
 fn filter_0_for_rgb_16() {
     let input = PathBuf::from("tests/files/filter_0_for_rgb_16.png");
-    let mut opts = get_opts(&input);
+    let (output, mut opts) = get_opts(&input);
     opts.filter = HashSet::new();
     opts.filter.insert(0);
-    let output = opts.out_file.clone().unwrap();
 
     test_it_converts(
         &input,
@@ -303,10 +291,9 @@ fn filter_0_for_rgb_16() {
 #[test]
 fn filter_1_for_rgb_16() {
     let input = PathBuf::from("tests/files/filter_1_for_rgb_16.png");
-    let mut opts = get_opts(&input);
+    let (output, mut opts) = get_opts(&input);
     opts.filter = HashSet::new();
     opts.filter.insert(1);
-    let output = opts.out_file.clone().unwrap();
 
     test_it_converts(
         &input,
@@ -322,10 +309,9 @@ fn filter_1_for_rgb_16() {
 #[test]
 fn filter_2_for_rgb_16() {
     let input = PathBuf::from("tests/files/filter_2_for_rgb_16.png");
-    let mut opts = get_opts(&input);
+    let (output, mut opts) = get_opts(&input);
     opts.filter = HashSet::new();
     opts.filter.insert(2);
-    let output = opts.out_file.clone().unwrap();
 
     test_it_converts(
         &input,
@@ -341,10 +327,9 @@ fn filter_2_for_rgb_16() {
 #[test]
 fn filter_3_for_rgb_16() {
     let input = PathBuf::from("tests/files/filter_3_for_rgb_16.png");
-    let mut opts = get_opts(&input);
+    let (output, mut opts) = get_opts(&input);
     opts.filter = HashSet::new();
     opts.filter.insert(3);
-    let output = opts.out_file.clone().unwrap();
 
     test_it_converts(
         &input,
@@ -360,10 +345,9 @@ fn filter_3_for_rgb_16() {
 #[test]
 fn filter_4_for_rgb_16() {
     let input = PathBuf::from("tests/files/filter_4_for_rgb_16.png");
-    let mut opts = get_opts(&input);
+    let (output, mut opts) = get_opts(&input);
     opts.filter = HashSet::new();
     opts.filter.insert(4);
-    let output = opts.out_file.clone().unwrap();
 
     test_it_converts(
         &input,
@@ -379,10 +363,9 @@ fn filter_4_for_rgb_16() {
 #[test]
 fn filter_5_for_rgb_16() {
     let input = PathBuf::from("tests/files/filter_5_for_rgb_16.png");
-    let mut opts = get_opts(&input);
+    let (output, mut opts) = get_opts(&input);
     opts.filter = HashSet::new();
     opts.filter.insert(5);
-    let output = opts.out_file.clone().unwrap();
 
     test_it_converts(
         &input,
@@ -398,10 +381,9 @@ fn filter_5_for_rgb_16() {
 #[test]
 fn filter_0_for_rgb_8() {
     let input = PathBuf::from("tests/files/filter_0_for_rgb_8.png");
-    let mut opts = get_opts(&input);
+    let (output, mut opts) = get_opts(&input);
     opts.filter = HashSet::new();
     opts.filter.insert(0);
-    let output = opts.out_file.clone().unwrap();
 
     test_it_converts(
         &input,
@@ -417,10 +399,9 @@ fn filter_0_for_rgb_8() {
 #[test]
 fn filter_1_for_rgb_8() {
     let input = PathBuf::from("tests/files/filter_1_for_rgb_8.png");
-    let mut opts = get_opts(&input);
+    let (output, mut opts) = get_opts(&input);
     opts.filter = HashSet::new();
     opts.filter.insert(1);
-    let output = opts.out_file.clone().unwrap();
 
     test_it_converts(
         &input,
@@ -436,10 +417,9 @@ fn filter_1_for_rgb_8() {
 #[test]
 fn filter_2_for_rgb_8() {
     let input = PathBuf::from("tests/files/filter_2_for_rgb_8.png");
-    let mut opts = get_opts(&input);
+    let (output, mut opts) = get_opts(&input);
     opts.filter = HashSet::new();
     opts.filter.insert(2);
-    let output = opts.out_file.clone().unwrap();
 
     test_it_converts(
         &input,
@@ -455,10 +435,9 @@ fn filter_2_for_rgb_8() {
 #[test]
 fn filter_3_for_rgb_8() {
     let input = PathBuf::from("tests/files/filter_3_for_rgb_8.png");
-    let mut opts = get_opts(&input);
+    let (output, mut opts) = get_opts(&input);
     opts.filter = HashSet::new();
     opts.filter.insert(3);
-    let output = opts.out_file.clone().unwrap();
 
     test_it_converts(
         &input,
@@ -474,10 +453,9 @@ fn filter_3_for_rgb_8() {
 #[test]
 fn filter_4_for_rgb_8() {
     let input = PathBuf::from("tests/files/filter_4_for_rgb_8.png");
-    let mut opts = get_opts(&input);
+    let (output, mut opts) = get_opts(&input);
     opts.filter = HashSet::new();
     opts.filter.insert(4);
-    let output = opts.out_file.clone().unwrap();
 
     test_it_converts(
         &input,
@@ -493,10 +471,9 @@ fn filter_4_for_rgb_8() {
 #[test]
 fn filter_5_for_rgb_8() {
     let input = PathBuf::from("tests/files/filter_5_for_rgb_8.png");
-    let mut opts = get_opts(&input);
+    let (output, mut opts) = get_opts(&input);
     opts.filter = HashSet::new();
     opts.filter.insert(5);
-    let output = opts.out_file.clone().unwrap();
 
     test_it_converts(
         &input,
@@ -512,10 +489,9 @@ fn filter_5_for_rgb_8() {
 #[test]
 fn filter_0_for_grayscale_alpha_16() {
     let input = PathBuf::from("tests/files/filter_0_for_grayscale_alpha_16.png");
-    let mut opts = get_opts(&input);
+    let (output, mut opts) = get_opts(&input);
     opts.filter = HashSet::new();
     opts.filter.insert(0);
-    let output = opts.out_file.clone().unwrap();
 
     test_it_converts(
         &input,
@@ -531,10 +507,9 @@ fn filter_0_for_grayscale_alpha_16() {
 #[test]
 fn filter_1_for_grayscale_alpha_16() {
     let input = PathBuf::from("tests/files/filter_1_for_grayscale_alpha_16.png");
-    let mut opts = get_opts(&input);
+    let (output, mut opts) = get_opts(&input);
     opts.filter = HashSet::new();
     opts.filter.insert(1);
-    let output = opts.out_file.clone().unwrap();
 
     test_it_converts(
         &input,
@@ -550,10 +525,9 @@ fn filter_1_for_grayscale_alpha_16() {
 #[test]
 fn filter_2_for_grayscale_alpha_16() {
     let input = PathBuf::from("tests/files/filter_2_for_grayscale_alpha_16.png");
-    let mut opts = get_opts(&input);
+    let (output, mut opts) = get_opts(&input);
     opts.filter = HashSet::new();
     opts.filter.insert(2);
-    let output = opts.out_file.clone().unwrap();
 
     test_it_converts(
         &input,
@@ -569,10 +543,9 @@ fn filter_2_for_grayscale_alpha_16() {
 #[test]
 fn filter_3_for_grayscale_alpha_16() {
     let input = PathBuf::from("tests/files/filter_3_for_grayscale_alpha_16.png");
-    let mut opts = get_opts(&input);
+    let (output, mut opts) = get_opts(&input);
     opts.filter = HashSet::new();
     opts.filter.insert(3);
-    let output = opts.out_file.clone().unwrap();
 
     test_it_converts(
         &input,
@@ -588,10 +561,9 @@ fn filter_3_for_grayscale_alpha_16() {
 #[test]
 fn filter_4_for_grayscale_alpha_16() {
     let input = PathBuf::from("tests/files/filter_4_for_grayscale_alpha_16.png");
-    let mut opts = get_opts(&input);
+    let (output, mut opts) = get_opts(&input);
     opts.filter = HashSet::new();
     opts.filter.insert(4);
-    let output = opts.out_file.clone().unwrap();
 
     test_it_converts(
         &input,
@@ -607,10 +579,9 @@ fn filter_4_for_grayscale_alpha_16() {
 #[test]
 fn filter_5_for_grayscale_alpha_16() {
     let input = PathBuf::from("tests/files/filter_5_for_grayscale_alpha_16.png");
-    let mut opts = get_opts(&input);
+    let (output, mut opts) = get_opts(&input);
     opts.filter = HashSet::new();
     opts.filter.insert(5);
-    let output = opts.out_file.clone().unwrap();
 
     test_it_converts(
         &input,
@@ -626,10 +597,9 @@ fn filter_5_for_grayscale_alpha_16() {
 #[test]
 fn filter_0_for_grayscale_alpha_8() {
     let input = PathBuf::from("tests/files/filter_0_for_grayscale_alpha_8.png");
-    let mut opts = get_opts(&input);
+    let (output, mut opts) = get_opts(&input);
     opts.filter = HashSet::new();
     opts.filter.insert(0);
-    let output = opts.out_file.clone().unwrap();
 
     test_it_converts(
         &input,
@@ -645,10 +615,9 @@ fn filter_0_for_grayscale_alpha_8() {
 #[test]
 fn filter_1_for_grayscale_alpha_8() {
     let input = PathBuf::from("tests/files/filter_1_for_grayscale_alpha_8.png");
-    let mut opts = get_opts(&input);
+    let (output, mut opts) = get_opts(&input);
     opts.filter = HashSet::new();
     opts.filter.insert(1);
-    let output = opts.out_file.clone().unwrap();
 
     test_it_converts(
         &input,
@@ -664,10 +633,9 @@ fn filter_1_for_grayscale_alpha_8() {
 #[test]
 fn filter_2_for_grayscale_alpha_8() {
     let input = PathBuf::from("tests/files/filter_2_for_grayscale_alpha_8.png");
-    let mut opts = get_opts(&input);
+    let (output, mut opts) = get_opts(&input);
     opts.filter = HashSet::new();
     opts.filter.insert(2);
-    let output = opts.out_file.clone().unwrap();
 
     test_it_converts(
         &input,
@@ -683,10 +651,9 @@ fn filter_2_for_grayscale_alpha_8() {
 #[test]
 fn filter_3_for_grayscale_alpha_8() {
     let input = PathBuf::from("tests/files/filter_3_for_grayscale_alpha_8.png");
-    let mut opts = get_opts(&input);
+    let (output, mut opts) = get_opts(&input);
     opts.filter = HashSet::new();
     opts.filter.insert(3);
-    let output = opts.out_file.clone().unwrap();
 
     test_it_converts(
         &input,
@@ -702,10 +669,9 @@ fn filter_3_for_grayscale_alpha_8() {
 #[test]
 fn filter_4_for_grayscale_alpha_8() {
     let input = PathBuf::from("tests/files/filter_4_for_grayscale_alpha_8.png");
-    let mut opts = get_opts(&input);
+    let (output, mut opts) = get_opts(&input);
     opts.filter = HashSet::new();
     opts.filter.insert(4);
-    let output = opts.out_file.clone().unwrap();
 
     test_it_converts(
         &input,
@@ -721,10 +687,9 @@ fn filter_4_for_grayscale_alpha_8() {
 #[test]
 fn filter_5_for_grayscale_alpha_8() {
     let input = PathBuf::from("tests/files/filter_5_for_grayscale_alpha_8.png");
-    let mut opts = get_opts(&input);
+    let (output, mut opts) = get_opts(&input);
     opts.filter = HashSet::new();
     opts.filter.insert(5);
-    let output = opts.out_file.clone().unwrap();
 
     test_it_converts(
         &input,
@@ -740,10 +705,9 @@ fn filter_5_for_grayscale_alpha_8() {
 #[test]
 fn filter_0_for_grayscale_16() {
     let input = PathBuf::from("tests/files/filter_0_for_grayscale_16.png");
-    let mut opts = get_opts(&input);
+    let (output, mut opts) = get_opts(&input);
     opts.filter = HashSet::new();
     opts.filter.insert(0);
-    let output = opts.out_file.clone().unwrap();
 
     test_it_converts(
         &input,
@@ -759,10 +723,9 @@ fn filter_0_for_grayscale_16() {
 #[test]
 fn filter_1_for_grayscale_16() {
     let input = PathBuf::from("tests/files/filter_1_for_grayscale_16.png");
-    let mut opts = get_opts(&input);
+    let (output, mut opts) = get_opts(&input);
     opts.filter = HashSet::new();
     opts.filter.insert(1);
-    let output = opts.out_file.clone().unwrap();
 
     test_it_converts(
         &input,
@@ -778,10 +741,9 @@ fn filter_1_for_grayscale_16() {
 #[test]
 fn filter_2_for_grayscale_16() {
     let input = PathBuf::from("tests/files/filter_2_for_grayscale_16.png");
-    let mut opts = get_opts(&input);
+    let (output, mut opts) = get_opts(&input);
     opts.filter = HashSet::new();
     opts.filter.insert(2);
-    let output = opts.out_file.clone().unwrap();
 
     test_it_converts(
         &input,
@@ -797,10 +759,9 @@ fn filter_2_for_grayscale_16() {
 #[test]
 fn filter_3_for_grayscale_16() {
     let input = PathBuf::from("tests/files/filter_3_for_grayscale_16.png");
-    let mut opts = get_opts(&input);
+    let (output, mut opts) = get_opts(&input);
     opts.filter = HashSet::new();
     opts.filter.insert(3);
-    let output = opts.out_file.clone().unwrap();
 
     test_it_converts(
         &input,
@@ -816,10 +777,9 @@ fn filter_3_for_grayscale_16() {
 #[test]
 fn filter_4_for_grayscale_16() {
     let input = PathBuf::from("tests/files/filter_4_for_grayscale_16.png");
-    let mut opts = get_opts(&input);
+    let (output, mut opts) = get_opts(&input);
     opts.filter = HashSet::new();
     opts.filter.insert(4);
-    let output = opts.out_file.clone().unwrap();
 
     test_it_converts(
         &input,
@@ -835,10 +795,9 @@ fn filter_4_for_grayscale_16() {
 #[test]
 fn filter_5_for_grayscale_16() {
     let input = PathBuf::from("tests/files/filter_5_for_grayscale_16.png");
-    let mut opts = get_opts(&input);
+    let (output, mut opts) = get_opts(&input);
     opts.filter = HashSet::new();
     opts.filter.insert(5);
-    let output = opts.out_file.clone().unwrap();
 
     test_it_converts(
         &input,
@@ -854,10 +813,9 @@ fn filter_5_for_grayscale_16() {
 #[test]
 fn filter_0_for_grayscale_8() {
     let input = PathBuf::from("tests/files/filter_0_for_grayscale_8.png");
-    let mut opts = get_opts(&input);
+    let (output, mut opts) = get_opts(&input);
     opts.filter = HashSet::new();
     opts.filter.insert(0);
-    let output = opts.out_file.clone().unwrap();
 
     test_it_converts(
         &input,
@@ -873,10 +831,9 @@ fn filter_0_for_grayscale_8() {
 #[test]
 fn filter_1_for_grayscale_8() {
     let input = PathBuf::from("tests/files/filter_1_for_grayscale_8.png");
-    let mut opts = get_opts(&input);
+    let (output, mut opts) = get_opts(&input);
     opts.filter = HashSet::new();
     opts.filter.insert(1);
-    let output = opts.out_file.clone().unwrap();
 
     test_it_converts(
         &input,
@@ -892,10 +849,9 @@ fn filter_1_for_grayscale_8() {
 #[test]
 fn filter_2_for_grayscale_8() {
     let input = PathBuf::from("tests/files/filter_2_for_grayscale_8.png");
-    let mut opts = get_opts(&input);
+    let (output, mut opts) = get_opts(&input);
     opts.filter = HashSet::new();
     opts.filter.insert(2);
-    let output = opts.out_file.clone().unwrap();
 
     test_it_converts(
         &input,
@@ -911,10 +867,9 @@ fn filter_2_for_grayscale_8() {
 #[test]
 fn filter_3_for_grayscale_8() {
     let input = PathBuf::from("tests/files/filter_3_for_grayscale_8.png");
-    let mut opts = get_opts(&input);
+    let (output, mut opts) = get_opts(&input);
     opts.filter = HashSet::new();
     opts.filter.insert(3);
-    let output = opts.out_file.clone().unwrap();
 
     test_it_converts(
         &input,
@@ -930,10 +885,9 @@ fn filter_3_for_grayscale_8() {
 #[test]
 fn filter_4_for_grayscale_8() {
     let input = PathBuf::from("tests/files/filter_4_for_grayscale_8.png");
-    let mut opts = get_opts(&input);
+    let (output, mut opts) = get_opts(&input);
     opts.filter = HashSet::new();
     opts.filter.insert(4);
-    let output = opts.out_file.clone().unwrap();
 
     test_it_converts(
         &input,
@@ -949,10 +903,9 @@ fn filter_4_for_grayscale_8() {
 #[test]
 fn filter_5_for_grayscale_8() {
     let input = PathBuf::from("tests/files/filter_5_for_grayscale_8.png");
-    let mut opts = get_opts(&input);
+    let (output, mut opts) = get_opts(&input);
     opts.filter = HashSet::new();
     opts.filter.insert(5);
-    let output = opts.out_file.clone().unwrap();
 
     test_it_converts(
         &input,
@@ -968,10 +921,9 @@ fn filter_5_for_grayscale_8() {
 #[test]
 fn filter_0_for_palette_4() {
     let input = PathBuf::from("tests/files/filter_0_for_palette_4.png");
-    let mut opts = get_opts(&input);
+    let (output, mut opts) = get_opts(&input);
     opts.filter = HashSet::new();
     opts.filter.insert(0);
-    let output = opts.out_file.clone().unwrap();
 
     test_it_converts(
         &input,
@@ -987,10 +939,9 @@ fn filter_0_for_palette_4() {
 #[test]
 fn filter_1_for_palette_4() {
     let input = PathBuf::from("tests/files/filter_1_for_palette_4.png");
-    let mut opts = get_opts(&input);
+    let (output, mut opts) = get_opts(&input);
     opts.filter = HashSet::new();
     opts.filter.insert(1);
-    let output = opts.out_file.clone().unwrap();
 
     test_it_converts(
         &input,
@@ -1006,10 +957,9 @@ fn filter_1_for_palette_4() {
 #[test]
 fn filter_2_for_palette_4() {
     let input = PathBuf::from("tests/files/filter_2_for_palette_4.png");
-    let mut opts = get_opts(&input);
+    let (output, mut opts) = get_opts(&input);
     opts.filter = HashSet::new();
     opts.filter.insert(2);
-    let output = opts.out_file.clone().unwrap();
 
     test_it_converts(
         &input,
@@ -1025,10 +975,9 @@ fn filter_2_for_palette_4() {
 #[test]
 fn filter_3_for_palette_4() {
     let input = PathBuf::from("tests/files/filter_3_for_palette_4.png");
-    let mut opts = get_opts(&input);
+    let (output, mut opts) = get_opts(&input);
     opts.filter = HashSet::new();
     opts.filter.insert(3);
-    let output = opts.out_file.clone().unwrap();
 
     test_it_converts(
         &input,
@@ -1044,10 +993,9 @@ fn filter_3_for_palette_4() {
 #[test]
 fn filter_4_for_palette_4() {
     let input = PathBuf::from("tests/files/filter_4_for_palette_4.png");
-    let mut opts = get_opts(&input);
+    let (output, mut opts) = get_opts(&input);
     opts.filter = HashSet::new();
     opts.filter.insert(4);
-    let output = opts.out_file.clone().unwrap();
 
     test_it_converts(
         &input,
@@ -1063,10 +1011,9 @@ fn filter_4_for_palette_4() {
 #[test]
 fn filter_5_for_palette_4() {
     let input = PathBuf::from("tests/files/filter_5_for_palette_4.png");
-    let mut opts = get_opts(&input);
+    let (output, mut opts) = get_opts(&input);
     opts.filter = HashSet::new();
     opts.filter.insert(5);
-    let output = opts.out_file.clone().unwrap();
 
     test_it_converts(
         &input,
@@ -1082,10 +1029,9 @@ fn filter_5_for_palette_4() {
 #[test]
 fn filter_0_for_palette_2() {
     let input = PathBuf::from("tests/files/filter_0_for_palette_2.png");
-    let mut opts = get_opts(&input);
+    let (output, mut opts) = get_opts(&input);
     opts.filter = HashSet::new();
     opts.filter.insert(0);
-    let output = opts.out_file.clone().unwrap();
 
     test_it_converts(
         &input,
@@ -1101,10 +1047,9 @@ fn filter_0_for_palette_2() {
 #[test]
 fn filter_1_for_palette_2() {
     let input = PathBuf::from("tests/files/filter_1_for_palette_2.png");
-    let mut opts = get_opts(&input);
+    let (output, mut opts) = get_opts(&input);
     opts.filter = HashSet::new();
     opts.filter.insert(1);
-    let output = opts.out_file.clone().unwrap();
 
     test_it_converts(
         &input,
@@ -1120,10 +1065,9 @@ fn filter_1_for_palette_2() {
 #[test]
 fn filter_2_for_palette_2() {
     let input = PathBuf::from("tests/files/filter_2_for_palette_2.png");
-    let mut opts = get_opts(&input);
+    let (output, mut opts) = get_opts(&input);
     opts.filter = HashSet::new();
     opts.filter.insert(2);
-    let output = opts.out_file.clone().unwrap();
 
     test_it_converts(
         &input,
@@ -1139,10 +1083,9 @@ fn filter_2_for_palette_2() {
 #[test]
 fn filter_3_for_palette_2() {
     let input = PathBuf::from("tests/files/filter_3_for_palette_2.png");
-    let mut opts = get_opts(&input);
+    let (output, mut opts) = get_opts(&input);
     opts.filter = HashSet::new();
     opts.filter.insert(3);
-    let output = opts.out_file.clone().unwrap();
 
     test_it_converts(
         &input,
@@ -1158,10 +1101,9 @@ fn filter_3_for_palette_2() {
 #[test]
 fn filter_4_for_palette_2() {
     let input = PathBuf::from("tests/files/filter_4_for_palette_2.png");
-    let mut opts = get_opts(&input);
+    let (output, mut opts) = get_opts(&input);
     opts.filter = HashSet::new();
     opts.filter.insert(4);
-    let output = opts.out_file.clone().unwrap();
 
     test_it_converts(
         &input,
@@ -1177,10 +1119,9 @@ fn filter_4_for_palette_2() {
 #[test]
 fn filter_5_for_palette_2() {
     let input = PathBuf::from("tests/files/filter_5_for_palette_2.png");
-    let mut opts = get_opts(&input);
+    let (output, mut opts) = get_opts(&input);
     opts.filter = HashSet::new();
     opts.filter.insert(5);
-    let output = opts.out_file.clone().unwrap();
 
     test_it_converts(
         &input,
@@ -1196,10 +1137,9 @@ fn filter_5_for_palette_2() {
 #[test]
 fn filter_0_for_palette_1() {
     let input = PathBuf::from("tests/files/filter_0_for_palette_1.png");
-    let mut opts = get_opts(&input);
+    let (output, mut opts) = get_opts(&input);
     opts.filter = HashSet::new();
     opts.filter.insert(0);
-    let output = opts.out_file.clone().unwrap();
 
     test_it_converts(
         &input,
@@ -1215,10 +1155,9 @@ fn filter_0_for_palette_1() {
 #[test]
 fn filter_1_for_palette_1() {
     let input = PathBuf::from("tests/files/filter_1_for_palette_1.png");
-    let mut opts = get_opts(&input);
+    let (output, mut opts) = get_opts(&input);
     opts.filter = HashSet::new();
     opts.filter.insert(1);
-    let output = opts.out_file.clone().unwrap();
 
     test_it_converts(
         &input,
@@ -1234,10 +1173,9 @@ fn filter_1_for_palette_1() {
 #[test]
 fn filter_2_for_palette_1() {
     let input = PathBuf::from("tests/files/filter_2_for_palette_1.png");
-    let mut opts = get_opts(&input);
+    let (output, mut opts) = get_opts(&input);
     opts.filter = HashSet::new();
     opts.filter.insert(2);
-    let output = opts.out_file.clone().unwrap();
 
     test_it_converts(
         &input,
@@ -1253,10 +1191,9 @@ fn filter_2_for_palette_1() {
 #[test]
 fn filter_3_for_palette_1() {
     let input = PathBuf::from("tests/files/filter_3_for_palette_1.png");
-    let mut opts = get_opts(&input);
+    let (output, mut opts) = get_opts(&input);
     opts.filter = HashSet::new();
     opts.filter.insert(3);
-    let output = opts.out_file.clone().unwrap();
 
     test_it_converts(
         &input,
@@ -1272,10 +1209,9 @@ fn filter_3_for_palette_1() {
 #[test]
 fn filter_4_for_palette_1() {
     let input = PathBuf::from("tests/files/filter_4_for_palette_1.png");
-    let mut opts = get_opts(&input);
+    let (output, mut opts) = get_opts(&input);
     opts.filter = HashSet::new();
     opts.filter.insert(4);
-    let output = opts.out_file.clone().unwrap();
 
     test_it_converts(
         &input,
@@ -1291,10 +1227,9 @@ fn filter_4_for_palette_1() {
 #[test]
 fn filter_5_for_palette_1() {
     let input = PathBuf::from("tests/files/filter_5_for_palette_1.png");
-    let mut opts = get_opts(&input);
+    let (output, mut opts) = get_opts(&input);
     opts.filter = HashSet::new();
     opts.filter.insert(5);
-    let output = opts.out_file.clone().unwrap();
 
     test_it_converts(
         &input,

--- a/tests/interlaced.rs
+++ b/tests/interlaced.rs
@@ -1,5 +1,6 @@
 extern crate oxipng;
 
+use oxipng::OutFile;
 use oxipng::colors::{BitDepth, ColorType};
 use oxipng::png;
 use std::collections::HashSet;
@@ -7,21 +8,20 @@ use std::fs::remove_file;
 use std::path::Path;
 use std::path::PathBuf;
 
-fn get_opts(input: &Path) -> oxipng::Options {
+fn get_opts(input: &Path) -> (OutFile, oxipng::Options) {
     let mut options = oxipng::Options::default();
-    options.out_file = Some(input.with_extension("out.png").to_owned());
     options.verbosity = None;
     options.force = true;
     let mut filter = HashSet::new();
     filter.insert(0);
     options.filter = filter;
 
-    options
+    (OutFile::Path(Some(input.with_extension("out.png").to_owned())), options)
 }
 
 fn test_it_converts(
     input: &Path,
-    output: &Path,
+    output: &OutFile,
     opts: &oxipng::Options,
     color_type_in: ColorType,
     bit_depth_in: BitDepth,
@@ -34,10 +34,11 @@ fn test_it_converts(
     assert_eq!(png.ihdr_data.bit_depth, bit_depth_in);
     assert_eq!(png.ihdr_data.interlaced, 1);
 
-    match oxipng::optimize(input, opts) {
+    match oxipng::optimize(input, output, opts) {
         Ok(_) => (),
         Err(x) => panic!("{}", x),
     };
+    let output = output.path().unwrap();
     assert!(output.exists());
 
     let png = match png::PngData::new(output, opts.fix_errors) {
@@ -57,8 +58,7 @@ fn test_it_converts(
 #[test]
 fn interlaced_rgba_16_should_be_rgba_16() {
     let input = PathBuf::from("tests/files/interlaced_rgba_16_should_be_rgba_16.png");
-    let opts = get_opts(&input);
-    let output = opts.out_file.clone().unwrap();
+    let (output, opts) = get_opts(&input);
 
     test_it_converts(
         &input,
@@ -74,8 +74,7 @@ fn interlaced_rgba_16_should_be_rgba_16() {
 #[test]
 fn interlaced_rgba_16_should_be_rgba_8() {
     let input = PathBuf::from("tests/files/interlaced_rgba_16_should_be_rgba_8.png");
-    let opts = get_opts(&input);
-    let output = opts.out_file.clone().unwrap();
+    let (output, opts) = get_opts(&input);
 
     test_it_converts(
         &input,
@@ -91,8 +90,7 @@ fn interlaced_rgba_16_should_be_rgba_8() {
 #[test]
 fn interlaced_rgba_8_should_be_rgba_8() {
     let input = PathBuf::from("tests/files/interlaced_rgba_8_should_be_rgba_8.png");
-    let opts = get_opts(&input);
-    let output = opts.out_file.clone().unwrap();
+    let (output, opts) = get_opts(&input);
 
     test_it_converts(
         &input,
@@ -108,8 +106,7 @@ fn interlaced_rgba_8_should_be_rgba_8() {
 #[test]
 fn interlaced_rgba_16_should_be_rgb_16() {
     let input = PathBuf::from("tests/files/interlaced_rgba_16_should_be_rgb_16.png");
-    let opts = get_opts(&input);
-    let output = opts.out_file.clone().unwrap();
+    let (output, opts) = get_opts(&input);
 
     test_it_converts(
         &input,
@@ -125,8 +122,7 @@ fn interlaced_rgba_16_should_be_rgb_16() {
 #[test]
 fn interlaced_rgba_16_should_be_rgb_8() {
     let input = PathBuf::from("tests/files/interlaced_rgba_16_should_be_rgb_8.png");
-    let opts = get_opts(&input);
-    let output = opts.out_file.clone().unwrap();
+    let (output, opts) = get_opts(&input);
 
     test_it_converts(
         &input,
@@ -142,8 +138,7 @@ fn interlaced_rgba_16_should_be_rgb_8() {
 #[test]
 fn interlaced_rgba_8_should_be_rgb_8() {
     let input = PathBuf::from("tests/files/interlaced_rgba_8_should_be_rgb_8.png");
-    let opts = get_opts(&input);
-    let output = opts.out_file.clone().unwrap();
+    let (output, opts) = get_opts(&input);
 
     test_it_converts(
         &input,
@@ -159,8 +154,7 @@ fn interlaced_rgba_8_should_be_rgb_8() {
 #[test]
 fn interlaced_rgba_16_should_be_palette_8() {
     let input = PathBuf::from("tests/files/interlaced_rgba_16_should_be_palette_8.png");
-    let opts = get_opts(&input);
-    let output = opts.out_file.clone().unwrap();
+    let (output, opts) = get_opts(&input);
 
     test_it_converts(
         &input,
@@ -176,8 +170,7 @@ fn interlaced_rgba_16_should_be_palette_8() {
 #[test]
 fn interlaced_rgba_8_should_be_palette_8() {
     let input = PathBuf::from("tests/files/interlaced_rgba_8_should_be_palette_8.png");
-    let opts = get_opts(&input);
-    let output = opts.out_file.clone().unwrap();
+    let (output, opts) = get_opts(&input);
 
     test_it_converts(
         &input,
@@ -193,8 +186,7 @@ fn interlaced_rgba_8_should_be_palette_8() {
 #[test]
 fn interlaced_rgba_16_should_be_palette_4() {
     let input = PathBuf::from("tests/files/interlaced_rgba_16_should_be_palette_4.png");
-    let opts = get_opts(&input);
-    let output = opts.out_file.clone().unwrap();
+    let (output, opts) = get_opts(&input);
 
     test_it_converts(
         &input,
@@ -210,8 +202,7 @@ fn interlaced_rgba_16_should_be_palette_4() {
 #[test]
 fn interlaced_rgba_8_should_be_palette_4() {
     let input = PathBuf::from("tests/files/interlaced_rgba_8_should_be_palette_4.png");
-    let opts = get_opts(&input);
-    let output = opts.out_file.clone().unwrap();
+    let (output, opts) = get_opts(&input);
 
     test_it_converts(
         &input,
@@ -227,8 +218,7 @@ fn interlaced_rgba_8_should_be_palette_4() {
 #[test]
 fn interlaced_rgba_16_should_be_palette_2() {
     let input = PathBuf::from("tests/files/interlaced_rgba_16_should_be_palette_2.png");
-    let opts = get_opts(&input);
-    let output = opts.out_file.clone().unwrap();
+    let (output, opts) = get_opts(&input);
 
     test_it_converts(
         &input,
@@ -244,8 +234,7 @@ fn interlaced_rgba_16_should_be_palette_2() {
 #[test]
 fn interlaced_rgba_8_should_be_palette_2() {
     let input = PathBuf::from("tests/files/interlaced_rgba_8_should_be_palette_2.png");
-    let opts = get_opts(&input);
-    let output = opts.out_file.clone().unwrap();
+    let (output, opts) = get_opts(&input);
 
     test_it_converts(
         &input,
@@ -261,8 +250,7 @@ fn interlaced_rgba_8_should_be_palette_2() {
 #[test]
 fn interlaced_rgba_16_should_be_palette_1() {
     let input = PathBuf::from("tests/files/interlaced_rgba_16_should_be_palette_1.png");
-    let opts = get_opts(&input);
-    let output = opts.out_file.clone().unwrap();
+    let (output, opts) = get_opts(&input);
 
     test_it_converts(
         &input,
@@ -278,8 +266,7 @@ fn interlaced_rgba_16_should_be_palette_1() {
 #[test]
 fn interlaced_rgba_8_should_be_palette_1() {
     let input = PathBuf::from("tests/files/interlaced_rgba_8_should_be_palette_1.png");
-    let opts = get_opts(&input);
-    let output = opts.out_file.clone().unwrap();
+    let (output, opts) = get_opts(&input);
 
     test_it_converts(
         &input,
@@ -295,8 +282,7 @@ fn interlaced_rgba_8_should_be_palette_1() {
 #[test]
 fn interlaced_rgba_16_should_be_grayscale_alpha_16() {
     let input = PathBuf::from("tests/files/interlaced_rgba_16_should_be_grayscale_alpha_16.png");
-    let opts = get_opts(&input);
-    let output = opts.out_file.clone().unwrap();
+    let (output, opts) = get_opts(&input);
 
     test_it_converts(
         &input,
@@ -312,8 +298,7 @@ fn interlaced_rgba_16_should_be_grayscale_alpha_16() {
 #[test]
 fn interlaced_rgba_16_should_be_grayscale_alpha_8() {
     let input = PathBuf::from("tests/files/interlaced_rgba_16_should_be_grayscale_alpha_8.png");
-    let opts = get_opts(&input);
-    let output = opts.out_file.clone().unwrap();
+    let (output, opts) = get_opts(&input);
 
     test_it_converts(
         &input,
@@ -329,8 +314,7 @@ fn interlaced_rgba_16_should_be_grayscale_alpha_8() {
 #[test]
 fn interlaced_rgba_8_should_be_grayscale_alpha_8() {
     let input = PathBuf::from("tests/files/interlaced_rgba_8_should_be_grayscale_alpha_8.png");
-    let opts = get_opts(&input);
-    let output = opts.out_file.clone().unwrap();
+    let (output, opts) = get_opts(&input);
 
     test_it_converts(
         &input,
@@ -346,8 +330,7 @@ fn interlaced_rgba_8_should_be_grayscale_alpha_8() {
 #[test]
 fn interlaced_rgba_16_should_be_grayscale_16() {
     let input = PathBuf::from("tests/files/interlaced_rgba_16_should_be_grayscale_16.png");
-    let opts = get_opts(&input);
-    let output = opts.out_file.clone().unwrap();
+    let (output, opts) = get_opts(&input);
 
     test_it_converts(
         &input,
@@ -363,8 +346,7 @@ fn interlaced_rgba_16_should_be_grayscale_16() {
 #[test]
 fn interlaced_rgba_16_should_be_grayscale_8() {
     let input = PathBuf::from("tests/files/interlaced_rgba_16_should_be_grayscale_8.png");
-    let opts = get_opts(&input);
-    let output = opts.out_file.clone().unwrap();
+    let (output, opts) = get_opts(&input);
 
     test_it_converts(
         &input,
@@ -380,8 +362,7 @@ fn interlaced_rgba_16_should_be_grayscale_8() {
 #[test]
 fn interlaced_rgba_8_should_be_grayscale_8() {
     let input = PathBuf::from("tests/files/interlaced_rgba_8_should_be_grayscale_8.png");
-    let opts = get_opts(&input);
-    let output = opts.out_file.clone().unwrap();
+    let (output, opts) = get_opts(&input);
 
     test_it_converts(
         &input,
@@ -397,8 +378,7 @@ fn interlaced_rgba_8_should_be_grayscale_8() {
 #[test]
 fn interlaced_rgb_16_should_be_rgb_16() {
     let input = PathBuf::from("tests/files/interlaced_rgb_16_should_be_rgb_16.png");
-    let opts = get_opts(&input);
-    let output = opts.out_file.clone().unwrap();
+    let (output, opts) = get_opts(&input);
 
     test_it_converts(
         &input,
@@ -414,8 +394,7 @@ fn interlaced_rgb_16_should_be_rgb_16() {
 #[test]
 fn interlaced_rgb_16_should_be_rgb_8() {
     let input = PathBuf::from("tests/files/interlaced_rgb_16_should_be_rgb_8.png");
-    let opts = get_opts(&input);
-    let output = opts.out_file.clone().unwrap();
+    let (output, opts) = get_opts(&input);
 
     test_it_converts(
         &input,
@@ -431,8 +410,7 @@ fn interlaced_rgb_16_should_be_rgb_8() {
 #[test]
 fn interlaced_rgb_8_should_be_rgb_8() {
     let input = PathBuf::from("tests/files/interlaced_rgb_8_should_be_rgb_8.png");
-    let opts = get_opts(&input);
-    let output = opts.out_file.clone().unwrap();
+    let (output, opts) = get_opts(&input);
 
     test_it_converts(
         &input,
@@ -448,8 +426,7 @@ fn interlaced_rgb_8_should_be_rgb_8() {
 #[test]
 fn interlaced_rgb_16_should_be_palette_8() {
     let input = PathBuf::from("tests/files/interlaced_rgb_16_should_be_palette_8.png");
-    let opts = get_opts(&input);
-    let output = opts.out_file.clone().unwrap();
+    let (output, opts) = get_opts(&input);
 
     test_it_converts(
         &input,
@@ -465,8 +442,7 @@ fn interlaced_rgb_16_should_be_palette_8() {
 #[test]
 fn interlaced_rgb_8_should_be_palette_8() {
     let input = PathBuf::from("tests/files/interlaced_rgb_8_should_be_palette_8.png");
-    let opts = get_opts(&input);
-    let output = opts.out_file.clone().unwrap();
+    let (output, opts) = get_opts(&input);
 
     test_it_converts(
         &input,
@@ -482,8 +458,7 @@ fn interlaced_rgb_8_should_be_palette_8() {
 #[test]
 fn interlaced_rgb_16_should_be_palette_4() {
     let input = PathBuf::from("tests/files/interlaced_rgb_16_should_be_palette_4.png");
-    let opts = get_opts(&input);
-    let output = opts.out_file.clone().unwrap();
+    let (output, opts) = get_opts(&input);
 
     test_it_converts(
         &input,
@@ -499,8 +474,7 @@ fn interlaced_rgb_16_should_be_palette_4() {
 #[test]
 fn interlaced_rgb_8_should_be_palette_4() {
     let input = PathBuf::from("tests/files/interlaced_rgb_8_should_be_palette_4.png");
-    let opts = get_opts(&input);
-    let output = opts.out_file.clone().unwrap();
+    let (output, opts) = get_opts(&input);
 
     test_it_converts(
         &input,
@@ -516,8 +490,7 @@ fn interlaced_rgb_8_should_be_palette_4() {
 #[test]
 fn interlaced_rgb_16_should_be_palette_2() {
     let input = PathBuf::from("tests/files/interlaced_rgb_16_should_be_palette_2.png");
-    let opts = get_opts(&input);
-    let output = opts.out_file.clone().unwrap();
+    let (output, opts) = get_opts(&input);
 
     test_it_converts(
         &input,
@@ -533,8 +506,7 @@ fn interlaced_rgb_16_should_be_palette_2() {
 #[test]
 fn interlaced_rgb_8_should_be_palette_2() {
     let input = PathBuf::from("tests/files/interlaced_rgb_8_should_be_palette_2.png");
-    let opts = get_opts(&input);
-    let output = opts.out_file.clone().unwrap();
+    let (output, opts) = get_opts(&input);
 
     test_it_converts(
         &input,
@@ -550,8 +522,7 @@ fn interlaced_rgb_8_should_be_palette_2() {
 #[test]
 fn interlaced_rgb_16_should_be_palette_1() {
     let input = PathBuf::from("tests/files/interlaced_rgb_16_should_be_palette_1.png");
-    let opts = get_opts(&input);
-    let output = opts.out_file.clone().unwrap();
+    let (output, opts) = get_opts(&input);
 
     test_it_converts(
         &input,
@@ -567,8 +538,7 @@ fn interlaced_rgb_16_should_be_palette_1() {
 #[test]
 fn interlaced_rgb_8_should_be_palette_1() {
     let input = PathBuf::from("tests/files/interlaced_rgb_8_should_be_palette_1.png");
-    let opts = get_opts(&input);
-    let output = opts.out_file.clone().unwrap();
+    let (output, opts) = get_opts(&input);
 
     test_it_converts(
         &input,
@@ -584,8 +554,7 @@ fn interlaced_rgb_8_should_be_palette_1() {
 #[test]
 fn interlaced_rgb_16_should_be_grayscale_16() {
     let input = PathBuf::from("tests/files/interlaced_rgb_16_should_be_grayscale_16.png");
-    let opts = get_opts(&input);
-    let output = opts.out_file.clone().unwrap();
+    let (output, opts) = get_opts(&input);
 
     test_it_converts(
         &input,
@@ -601,8 +570,7 @@ fn interlaced_rgb_16_should_be_grayscale_16() {
 #[test]
 fn interlaced_rgb_16_should_be_grayscale_8() {
     let input = PathBuf::from("tests/files/interlaced_rgb_16_should_be_grayscale_8.png");
-    let opts = get_opts(&input);
-    let output = opts.out_file.clone().unwrap();
+    let (output, opts) = get_opts(&input);
 
     test_it_converts(
         &input,
@@ -618,8 +586,7 @@ fn interlaced_rgb_16_should_be_grayscale_8() {
 #[test]
 fn interlaced_rgb_8_should_be_grayscale_8() {
     let input = PathBuf::from("tests/files/interlaced_rgb_8_should_be_grayscale_8.png");
-    let opts = get_opts(&input);
-    let output = opts.out_file.clone().unwrap();
+    let (output, opts) = get_opts(&input);
 
     test_it_converts(
         &input,
@@ -635,8 +602,7 @@ fn interlaced_rgb_8_should_be_grayscale_8() {
 #[test]
 fn interlaced_palette_8_should_be_palette_8() {
     let input = PathBuf::from("tests/files/interlaced_palette_8_should_be_palette_8.png");
-    let opts = get_opts(&input);
-    let output = opts.out_file.clone().unwrap();
+    let (output, opts) = get_opts(&input);
 
     test_it_converts(
         &input,
@@ -652,8 +618,7 @@ fn interlaced_palette_8_should_be_palette_8() {
 #[test]
 fn interlaced_palette_8_should_be_palette_4() {
     let input = PathBuf::from("tests/files/interlaced_palette_8_should_be_palette_4.png");
-    let opts = get_opts(&input);
-    let output = opts.out_file.clone().unwrap();
+    let (output, opts) = get_opts(&input);
 
     test_it_converts(
         &input,
@@ -669,8 +634,7 @@ fn interlaced_palette_8_should_be_palette_4() {
 #[test]
 fn interlaced_palette_4_should_be_palette_4() {
     let input = PathBuf::from("tests/files/interlaced_palette_4_should_be_palette_4.png");
-    let opts = get_opts(&input);
-    let output = opts.out_file.clone().unwrap();
+    let (output, opts) = get_opts(&input);
 
     test_it_converts(
         &input,
@@ -686,8 +650,7 @@ fn interlaced_palette_4_should_be_palette_4() {
 #[test]
 fn interlaced_palette_8_should_be_palette_2() {
     let input = PathBuf::from("tests/files/interlaced_palette_8_should_be_palette_2.png");
-    let opts = get_opts(&input);
-    let output = opts.out_file.clone().unwrap();
+    let (output, opts) = get_opts(&input);
 
     test_it_converts(
         &input,
@@ -703,8 +666,7 @@ fn interlaced_palette_8_should_be_palette_2() {
 #[test]
 fn interlaced_palette_4_should_be_palette_2() {
     let input = PathBuf::from("tests/files/interlaced_palette_4_should_be_palette_2.png");
-    let opts = get_opts(&input);
-    let output = opts.out_file.clone().unwrap();
+    let (output, opts) = get_opts(&input);
 
     test_it_converts(
         &input,
@@ -720,8 +682,7 @@ fn interlaced_palette_4_should_be_palette_2() {
 #[test]
 fn interlaced_palette_2_should_be_palette_2() {
     let input = PathBuf::from("tests/files/interlaced_palette_2_should_be_palette_2.png");
-    let opts = get_opts(&input);
-    let output = opts.out_file.clone().unwrap();
+    let (output, opts) = get_opts(&input);
 
     test_it_converts(
         &input,
@@ -737,8 +698,7 @@ fn interlaced_palette_2_should_be_palette_2() {
 #[test]
 fn interlaced_palette_8_should_be_palette_1() {
     let input = PathBuf::from("tests/files/interlaced_palette_8_should_be_palette_1.png");
-    let opts = get_opts(&input);
-    let output = opts.out_file.clone().unwrap();
+    let (output, opts) = get_opts(&input);
 
     test_it_converts(
         &input,
@@ -754,8 +714,7 @@ fn interlaced_palette_8_should_be_palette_1() {
 #[test]
 fn interlaced_palette_4_should_be_palette_1() {
     let input = PathBuf::from("tests/files/interlaced_palette_4_should_be_palette_1.png");
-    let opts = get_opts(&input);
-    let output = opts.out_file.clone().unwrap();
+    let (output, opts) = get_opts(&input);
 
     test_it_converts(
         &input,
@@ -771,8 +730,7 @@ fn interlaced_palette_4_should_be_palette_1() {
 #[test]
 fn interlaced_palette_2_should_be_palette_1() {
     let input = PathBuf::from("tests/files/interlaced_palette_2_should_be_palette_1.png");
-    let opts = get_opts(&input);
-    let output = opts.out_file.clone().unwrap();
+    let (output, opts) = get_opts(&input);
 
     test_it_converts(
         &input,
@@ -788,8 +746,7 @@ fn interlaced_palette_2_should_be_palette_1() {
 #[test]
 fn interlaced_palette_1_should_be_palette_1() {
     let input = PathBuf::from("tests/files/interlaced_palette_1_should_be_palette_1.png");
-    let opts = get_opts(&input);
-    let output = opts.out_file.clone().unwrap();
+    let (output, opts) = get_opts(&input);
 
     test_it_converts(
         &input,
@@ -806,8 +763,7 @@ fn interlaced_palette_1_should_be_palette_1() {
 fn interlaced_grayscale_alpha_16_should_be_grayscale_alpha_16() {
     let input =
         PathBuf::from("tests/files/interlaced_grayscale_alpha_16_should_be_grayscale_alpha_16.png");
-    let opts = get_opts(&input);
-    let output = opts.out_file.clone().unwrap();
+    let (output, opts) = get_opts(&input);
 
     test_it_converts(
         &input,
@@ -824,8 +780,7 @@ fn interlaced_grayscale_alpha_16_should_be_grayscale_alpha_16() {
 fn interlaced_grayscale_alpha_16_should_be_grayscale_alpha_8() {
     let input =
         PathBuf::from("tests/files/interlaced_grayscale_alpha_16_should_be_grayscale_alpha_8.png");
-    let opts = get_opts(&input);
-    let output = opts.out_file.clone().unwrap();
+    let (output, opts) = get_opts(&input);
 
     test_it_converts(
         &input,
@@ -842,8 +797,7 @@ fn interlaced_grayscale_alpha_16_should_be_grayscale_alpha_8() {
 fn interlaced_grayscale_alpha_8_should_be_grayscale_alpha_8() {
     let input =
         PathBuf::from("tests/files/interlaced_grayscale_alpha_8_should_be_grayscale_alpha_8.png");
-    let opts = get_opts(&input);
-    let output = opts.out_file.clone().unwrap();
+    let (output, opts) = get_opts(&input);
 
     test_it_converts(
         &input,
@@ -860,8 +814,7 @@ fn interlaced_grayscale_alpha_8_should_be_grayscale_alpha_8() {
 fn interlaced_grayscale_alpha_16_should_be_grayscale_16() {
     let input =
         PathBuf::from("tests/files/interlaced_grayscale_alpha_16_should_be_grayscale_16.png");
-    let opts = get_opts(&input);
-    let output = opts.out_file.clone().unwrap();
+    let (output, opts) = get_opts(&input);
 
     test_it_converts(
         &input,
@@ -878,8 +831,7 @@ fn interlaced_grayscale_alpha_16_should_be_grayscale_16() {
 fn interlaced_grayscale_alpha_16_should_be_grayscale_8() {
     let input =
         PathBuf::from("tests/files/interlaced_grayscale_alpha_16_should_be_grayscale_8.png");
-    let opts = get_opts(&input);
-    let output = opts.out_file.clone().unwrap();
+    let (output, opts) = get_opts(&input);
 
     test_it_converts(
         &input,
@@ -895,8 +847,7 @@ fn interlaced_grayscale_alpha_16_should_be_grayscale_8() {
 #[test]
 fn interlaced_grayscale_alpha_8_should_be_grayscale_8() {
     let input = PathBuf::from("tests/files/interlaced_grayscale_alpha_8_should_be_grayscale_8.png");
-    let opts = get_opts(&input);
-    let output = opts.out_file.clone().unwrap();
+    let (output, opts) = get_opts(&input);
 
     test_it_converts(
         &input,
@@ -912,8 +863,7 @@ fn interlaced_grayscale_alpha_8_should_be_grayscale_8() {
 #[test]
 fn interlaced_grayscale_16_should_be_grayscale_16() {
     let input = PathBuf::from("tests/files/interlaced_grayscale_16_should_be_grayscale_16.png");
-    let opts = get_opts(&input);
-    let output = opts.out_file.clone().unwrap();
+    let (output, opts) = get_opts(&input);
 
     test_it_converts(
         &input,
@@ -929,8 +879,7 @@ fn interlaced_grayscale_16_should_be_grayscale_16() {
 #[test]
 fn interlaced_grayscale_16_should_be_grayscale_8() {
     let input = PathBuf::from("tests/files/interlaced_grayscale_16_should_be_grayscale_8.png");
-    let opts = get_opts(&input);
-    let output = opts.out_file.clone().unwrap();
+    let (output, opts) = get_opts(&input);
 
     test_it_converts(
         &input,
@@ -946,8 +895,7 @@ fn interlaced_grayscale_16_should_be_grayscale_8() {
 #[test]
 fn interlaced_grayscale_8_should_be_grayscale_8() {
     let input = PathBuf::from("tests/files/interlaced_grayscale_8_should_be_grayscale_8.png");
-    let opts = get_opts(&input);
-    let output = opts.out_file.clone().unwrap();
+    let (output, opts) = get_opts(&input);
 
     test_it_converts(
         &input,
@@ -963,8 +911,7 @@ fn interlaced_grayscale_8_should_be_grayscale_8() {
 #[test]
 fn interlaced_small_files() {
     let input = PathBuf::from("tests/files/interlaced_small_files.png");
-    let opts = get_opts(&input);
-    let output = opts.out_file.clone().unwrap();
+    let (output, opts) = get_opts(&input);
 
     test_it_converts(
         &input,
@@ -980,8 +927,7 @@ fn interlaced_small_files() {
 #[test]
 fn interlaced_odd_width() {
     let input = PathBuf::from("tests/files/interlaced_odd_width.png");
-    let opts = get_opts(&input);
-    let output = opts.out_file.clone().unwrap();
+    let (output, opts) = get_opts(&input);
 
     test_it_converts(
         &input,

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -1,5 +1,6 @@
 extern crate oxipng;
 
+use oxipng::OutFile;
 use std::default::Default;
 use std::fs::File;
 use std::path::Path;
@@ -49,7 +50,7 @@ fn optimize() {
     let mut opts: oxipng::Options = Default::default();
     opts.verbosity = Some(1);
 
-    let result = oxipng::optimize(Path::new("tests/files/fully_optimized.png"), &opts);
+    let result = oxipng::optimize(Path::new("tests/files/fully_optimized.png"), &OutFile::Path(None), &opts);
     assert!(result.is_ok());
 }
 
@@ -58,7 +59,7 @@ fn optimize_corrupted() {
     let mut opts: oxipng::Options = Default::default();
     opts.verbosity = Some(1);
 
-    let result = oxipng::optimize(Path::new("tests/files/corrupted_header.png"), &opts);
+    let result = oxipng::optimize(Path::new("tests/files/corrupted_header.png"), &OutFile::Path(None), &opts);
     assert!(result.is_err());
 }
 
@@ -67,6 +68,6 @@ fn optimize_apng() {
     let mut opts: oxipng::Options = Default::default();
     opts.verbosity = Some(1);
 
-    let result = oxipng::optimize(Path::new("tests/files/apng_file.png"), &opts);
+    let result = oxipng::optimize(Path::new("tests/files/apng_file.png"), &OutFile::Path(None), &opts);
     assert!(result.is_err());
 }

--- a/tests/reduction.rs
+++ b/tests/reduction.rs
@@ -1,5 +1,6 @@
 extern crate oxipng;
 
+use oxipng::OutFile;
 use oxipng::colors::{AlphaOptim, BitDepth, ColorType};
 use oxipng::png;
 use std::collections::HashSet;
@@ -7,21 +8,20 @@ use std::fs::remove_file;
 use std::path::Path;
 use std::path::PathBuf;
 
-fn get_opts(input: &Path) -> oxipng::Options {
+fn get_opts(input: &Path) -> (OutFile, oxipng::Options) {
     let mut options = oxipng::Options::default();
-    options.out_file = Some(input.with_extension("out.png").to_owned());
     options.verbosity = None;
     options.force = true;
     let mut filter = HashSet::new();
     filter.insert(0);
     options.filter = filter;
 
-    options
+    (OutFile::Path(Some(input.with_extension("out.png").to_owned())), options)
 }
 
 fn test_it_converts(
     input: &Path,
-    output: &Path,
+    output: &OutFile,
     opts: &oxipng::Options,
     color_type_in: ColorType,
     bit_depth_in: BitDepth,
@@ -34,10 +34,11 @@ fn test_it_converts(
     assert_eq!(png.ihdr_data.bit_depth, bit_depth_in);
     assert_eq!(png.ihdr_data.interlaced, 0);
 
-    match oxipng::optimize(input, opts) {
+    match oxipng::optimize(input, output, opts) {
         Ok(_) => (),
         Err(x) => panic!("{}", x),
     };
+    let output = output.path().unwrap();
     assert!(output.exists());
 
     let png = match png::PngData::new(output, opts.fix_errors) {
@@ -57,8 +58,7 @@ fn test_it_converts(
 #[test]
 fn rgba_16_should_be_rgba_16() {
     let input = PathBuf::from("tests/files/rgba_16_should_be_rgba_16.png");
-    let opts = get_opts(&input);
-    let output = opts.out_file.clone().unwrap();
+    let (output, opts) = get_opts(&input);
 
     test_it_converts(
         &input,
@@ -74,8 +74,7 @@ fn rgba_16_should_be_rgba_16() {
 #[test]
 fn rgba_16_should_be_rgba_8() {
     let input = PathBuf::from("tests/files/rgba_16_should_be_rgba_8.png");
-    let opts = get_opts(&input);
-    let output = opts.out_file.clone().unwrap();
+    let (output, opts) = get_opts(&input);
 
     test_it_converts(
         &input,
@@ -91,8 +90,7 @@ fn rgba_16_should_be_rgba_8() {
 #[test]
 fn rgba_8_should_be_rgba_8() {
     let input = PathBuf::from("tests/files/rgba_8_should_be_rgba_8.png");
-    let opts = get_opts(&input);
-    let output = opts.out_file.clone().unwrap();
+    let (output, opts) = get_opts(&input);
 
     test_it_converts(
         &input,
@@ -108,8 +106,7 @@ fn rgba_8_should_be_rgba_8() {
 #[test]
 fn rgba_16_should_be_rgb_16() {
     let input = PathBuf::from("tests/files/rgba_16_should_be_rgb_16.png");
-    let opts = get_opts(&input);
-    let output = opts.out_file.clone().unwrap();
+    let (output, opts) = get_opts(&input);
 
     test_it_converts(
         &input,
@@ -125,8 +122,7 @@ fn rgba_16_should_be_rgb_16() {
 #[test]
 fn rgba_16_should_be_rgb_8() {
     let input = PathBuf::from("tests/files/rgba_16_should_be_rgb_8.png");
-    let opts = get_opts(&input);
-    let output = opts.out_file.clone().unwrap();
+    let (output, opts) = get_opts(&input);
 
     test_it_converts(
         &input,
@@ -142,8 +138,7 @@ fn rgba_16_should_be_rgb_8() {
 #[test]
 fn rgba_8_should_be_rgb_8() {
     let input = PathBuf::from("tests/files/rgba_8_should_be_rgb_8.png");
-    let opts = get_opts(&input);
-    let output = opts.out_file.clone().unwrap();
+    let (output, opts) = get_opts(&input);
 
     test_it_converts(
         &input,
@@ -159,8 +154,7 @@ fn rgba_8_should_be_rgb_8() {
 #[test]
 fn rgba_16_should_be_palette_8() {
     let input = PathBuf::from("tests/files/rgba_16_should_be_palette_8.png");
-    let opts = get_opts(&input);
-    let output = opts.out_file.clone().unwrap();
+    let (output, opts) = get_opts(&input);
 
     test_it_converts(
         &input,
@@ -176,8 +170,7 @@ fn rgba_16_should_be_palette_8() {
 #[test]
 fn rgba_8_should_be_palette_8() {
     let input = PathBuf::from("tests/files/rgba_8_should_be_palette_8.png");
-    let opts = get_opts(&input);
-    let output = opts.out_file.clone().unwrap();
+    let (output, opts) = get_opts(&input);
 
     test_it_converts(
         &input,
@@ -193,8 +186,7 @@ fn rgba_8_should_be_palette_8() {
 #[test]
 fn rgba_16_should_be_palette_4() {
     let input = PathBuf::from("tests/files/rgba_16_should_be_palette_4.png");
-    let opts = get_opts(&input);
-    let output = opts.out_file.clone().unwrap();
+    let (output, opts) = get_opts(&input);
 
     test_it_converts(
         &input,
@@ -210,8 +202,7 @@ fn rgba_16_should_be_palette_4() {
 #[test]
 fn rgba_8_should_be_palette_4() {
     let input = PathBuf::from("tests/files/rgba_8_should_be_palette_4.png");
-    let opts = get_opts(&input);
-    let output = opts.out_file.clone().unwrap();
+    let (output, opts) = get_opts(&input);
 
     test_it_converts(
         &input,
@@ -227,8 +218,7 @@ fn rgba_8_should_be_palette_4() {
 #[test]
 fn rgba_16_should_be_palette_2() {
     let input = PathBuf::from("tests/files/rgba_16_should_be_palette_2.png");
-    let opts = get_opts(&input);
-    let output = opts.out_file.clone().unwrap();
+    let (output, opts) = get_opts(&input);
 
     test_it_converts(
         &input,
@@ -244,8 +234,7 @@ fn rgba_16_should_be_palette_2() {
 #[test]
 fn rgba_8_should_be_palette_2() {
     let input = PathBuf::from("tests/files/rgba_8_should_be_palette_2.png");
-    let opts = get_opts(&input);
-    let output = opts.out_file.clone().unwrap();
+    let (output, opts) = get_opts(&input);
 
     test_it_converts(
         &input,
@@ -261,8 +250,7 @@ fn rgba_8_should_be_palette_2() {
 #[test]
 fn rgba_16_should_be_palette_1() {
     let input = PathBuf::from("tests/files/rgba_16_should_be_palette_1.png");
-    let opts = get_opts(&input);
-    let output = opts.out_file.clone().unwrap();
+    let (output, opts) = get_opts(&input);
 
     test_it_converts(
         &input,
@@ -278,8 +266,7 @@ fn rgba_16_should_be_palette_1() {
 #[test]
 fn rgba_8_should_be_palette_1() {
     let input = PathBuf::from("tests/files/rgba_8_should_be_palette_1.png");
-    let opts = get_opts(&input);
-    let output = opts.out_file.clone().unwrap();
+    let (output, opts) = get_opts(&input);
 
     test_it_converts(
         &input,
@@ -295,8 +282,7 @@ fn rgba_8_should_be_palette_1() {
 #[test]
 fn rgba_16_should_be_grayscale_alpha_16() {
     let input = PathBuf::from("tests/files/rgba_16_should_be_grayscale_alpha_16.png");
-    let opts = get_opts(&input);
-    let output = opts.out_file.clone().unwrap();
+    let (output, opts) = get_opts(&input);
 
     test_it_converts(
         &input,
@@ -312,8 +298,7 @@ fn rgba_16_should_be_grayscale_alpha_16() {
 #[test]
 fn rgba_16_should_be_grayscale_alpha_8() {
     let input = PathBuf::from("tests/files/rgba_16_should_be_grayscale_alpha_8.png");
-    let opts = get_opts(&input);
-    let output = opts.out_file.clone().unwrap();
+    let (output, opts) = get_opts(&input);
 
     test_it_converts(
         &input,
@@ -329,8 +314,7 @@ fn rgba_16_should_be_grayscale_alpha_8() {
 #[test]
 fn rgba_8_should_be_grayscale_alpha_8() {
     let input = PathBuf::from("tests/files/rgba_8_should_be_grayscale_alpha_8.png");
-    let opts = get_opts(&input);
-    let output = opts.out_file.clone().unwrap();
+    let (output, opts) = get_opts(&input);
 
     test_it_converts(
         &input,
@@ -346,8 +330,7 @@ fn rgba_8_should_be_grayscale_alpha_8() {
 #[test]
 fn rgba_16_should_be_grayscale_16() {
     let input = PathBuf::from("tests/files/rgba_16_should_be_grayscale_16.png");
-    let opts = get_opts(&input);
-    let output = opts.out_file.clone().unwrap();
+    let (output, opts) = get_opts(&input);
 
     test_it_converts(
         &input,
@@ -363,8 +346,7 @@ fn rgba_16_should_be_grayscale_16() {
 #[test]
 fn rgba_16_should_be_grayscale_8() {
     let input = PathBuf::from("tests/files/rgba_16_should_be_grayscale_8.png");
-    let opts = get_opts(&input);
-    let output = opts.out_file.clone().unwrap();
+    let (output, opts) = get_opts(&input);
 
     test_it_converts(
         &input,
@@ -380,8 +362,7 @@ fn rgba_16_should_be_grayscale_8() {
 #[test]
 fn rgba_8_should_be_grayscale_8() {
     let input = PathBuf::from("tests/files/rgba_8_should_be_grayscale_8.png");
-    let opts = get_opts(&input);
-    let output = opts.out_file.clone().unwrap();
+    let (output, opts) = get_opts(&input);
 
     test_it_converts(
         &input,
@@ -397,8 +378,7 @@ fn rgba_8_should_be_grayscale_8() {
 #[test]
 fn rgb_16_should_be_rgb_16() {
     let input = PathBuf::from("tests/files/rgb_16_should_be_rgb_16.png");
-    let opts = get_opts(&input);
-    let output = opts.out_file.clone().unwrap();
+    let (output, opts) = get_opts(&input);
 
     test_it_converts(
         &input,
@@ -414,8 +394,7 @@ fn rgb_16_should_be_rgb_16() {
 #[test]
 fn rgb_16_should_be_rgb_8() {
     let input = PathBuf::from("tests/files/rgb_16_should_be_rgb_8.png");
-    let opts = get_opts(&input);
-    let output = opts.out_file.clone().unwrap();
+    let (output, opts) = get_opts(&input);
 
     test_it_converts(
         &input,
@@ -431,8 +410,7 @@ fn rgb_16_should_be_rgb_8() {
 #[test]
 fn rgb_8_should_be_rgb_8() {
     let input = PathBuf::from("tests/files/rgb_8_should_be_rgb_8.png");
-    let opts = get_opts(&input);
-    let output = opts.out_file.clone().unwrap();
+    let (output, opts) = get_opts(&input);
 
     test_it_converts(
         &input,
@@ -448,8 +426,7 @@ fn rgb_8_should_be_rgb_8() {
 #[test]
 fn rgb_16_should_be_palette_8() {
     let input = PathBuf::from("tests/files/rgb_16_should_be_palette_8.png");
-    let opts = get_opts(&input);
-    let output = opts.out_file.clone().unwrap();
+    let (output, opts) = get_opts(&input);
 
     test_it_converts(
         &input,
@@ -465,8 +442,7 @@ fn rgb_16_should_be_palette_8() {
 #[test]
 fn rgb_8_should_be_palette_8() {
     let input = PathBuf::from("tests/files/rgb_8_should_be_palette_8.png");
-    let opts = get_opts(&input);
-    let output = opts.out_file.clone().unwrap();
+    let (output, opts) = get_opts(&input);
 
     test_it_converts(
         &input,
@@ -482,8 +458,7 @@ fn rgb_8_should_be_palette_8() {
 #[test]
 fn rgb_16_should_be_palette_4() {
     let input = PathBuf::from("tests/files/rgb_16_should_be_palette_4.png");
-    let opts = get_opts(&input);
-    let output = opts.out_file.clone().unwrap();
+    let (output, opts) = get_opts(&input);
 
     test_it_converts(
         &input,
@@ -499,8 +474,7 @@ fn rgb_16_should_be_palette_4() {
 #[test]
 fn rgb_8_should_be_palette_4() {
     let input = PathBuf::from("tests/files/rgb_8_should_be_palette_4.png");
-    let opts = get_opts(&input);
-    let output = opts.out_file.clone().unwrap();
+    let (output, opts) = get_opts(&input);
 
     test_it_converts(
         &input,
@@ -516,8 +490,7 @@ fn rgb_8_should_be_palette_4() {
 #[test]
 fn rgb_16_should_be_palette_2() {
     let input = PathBuf::from("tests/files/rgb_16_should_be_palette_2.png");
-    let opts = get_opts(&input);
-    let output = opts.out_file.clone().unwrap();
+    let (output, opts) = get_opts(&input);
 
     test_it_converts(
         &input,
@@ -533,8 +506,7 @@ fn rgb_16_should_be_palette_2() {
 #[test]
 fn rgb_8_should_be_palette_2() {
     let input = PathBuf::from("tests/files/rgb_8_should_be_palette_2.png");
-    let opts = get_opts(&input);
-    let output = opts.out_file.clone().unwrap();
+    let (output, opts) = get_opts(&input);
 
     test_it_converts(
         &input,
@@ -550,8 +522,7 @@ fn rgb_8_should_be_palette_2() {
 #[test]
 fn rgb_16_should_be_palette_1() {
     let input = PathBuf::from("tests/files/rgb_16_should_be_palette_1.png");
-    let opts = get_opts(&input);
-    let output = opts.out_file.clone().unwrap();
+    let (output, opts) = get_opts(&input);
 
     test_it_converts(
         &input,
@@ -567,8 +538,7 @@ fn rgb_16_should_be_palette_1() {
 #[test]
 fn rgb_8_should_be_palette_1() {
     let input = PathBuf::from("tests/files/rgb_8_should_be_palette_1.png");
-    let opts = get_opts(&input);
-    let output = opts.out_file.clone().unwrap();
+    let (output, opts) = get_opts(&input);
 
     test_it_converts(
         &input,
@@ -584,8 +554,7 @@ fn rgb_8_should_be_palette_1() {
 #[test]
 fn rgb_16_should_be_grayscale_16() {
     let input = PathBuf::from("tests/files/rgb_16_should_be_grayscale_16.png");
-    let opts = get_opts(&input);
-    let output = opts.out_file.clone().unwrap();
+    let (output, opts) = get_opts(&input);
 
     test_it_converts(
         &input,
@@ -601,8 +570,7 @@ fn rgb_16_should_be_grayscale_16() {
 #[test]
 fn rgb_16_should_be_grayscale_8() {
     let input = PathBuf::from("tests/files/rgb_16_should_be_grayscale_8.png");
-    let opts = get_opts(&input);
-    let output = opts.out_file.clone().unwrap();
+    let (output, opts) = get_opts(&input);
 
     test_it_converts(
         &input,
@@ -618,8 +586,7 @@ fn rgb_16_should_be_grayscale_8() {
 #[test]
 fn rgb_8_should_be_grayscale_8() {
     let input = PathBuf::from("tests/files/rgb_8_should_be_grayscale_8.png");
-    let opts = get_opts(&input);
-    let output = opts.out_file.clone().unwrap();
+    let (output, opts) = get_opts(&input);
 
     test_it_converts(
         &input,
@@ -635,8 +602,7 @@ fn rgb_8_should_be_grayscale_8() {
 #[test]
 fn palette_8_should_be_palette_8() {
     let input = PathBuf::from("tests/files/palette_8_should_be_palette_8.png");
-    let opts = get_opts(&input);
-    let output = opts.out_file.clone().unwrap();
+    let (output, opts) = get_opts(&input);
 
     test_it_converts(
         &input,
@@ -652,8 +618,7 @@ fn palette_8_should_be_palette_8() {
 #[test]
 fn palette_8_should_be_palette_4() {
     let input = PathBuf::from("tests/files/palette_8_should_be_palette_4.png");
-    let opts = get_opts(&input);
-    let output = opts.out_file.clone().unwrap();
+    let (output, opts) = get_opts(&input);
 
     test_it_converts(
         &input,
@@ -669,8 +634,7 @@ fn palette_8_should_be_palette_4() {
 #[test]
 fn palette_4_should_be_palette_4() {
     let input = PathBuf::from("tests/files/palette_4_should_be_palette_4.png");
-    let opts = get_opts(&input);
-    let output = opts.out_file.clone().unwrap();
+    let (output, opts) = get_opts(&input);
 
     test_it_converts(
         &input,
@@ -686,8 +650,7 @@ fn palette_4_should_be_palette_4() {
 #[test]
 fn palette_8_should_be_palette_2() {
     let input = PathBuf::from("tests/files/palette_8_should_be_palette_2.png");
-    let opts = get_opts(&input);
-    let output = opts.out_file.clone().unwrap();
+    let (output, opts) = get_opts(&input);
 
     test_it_converts(
         &input,
@@ -703,8 +666,7 @@ fn palette_8_should_be_palette_2() {
 #[test]
 fn palette_4_should_be_palette_2() {
     let input = PathBuf::from("tests/files/palette_4_should_be_palette_2.png");
-    let opts = get_opts(&input);
-    let output = opts.out_file.clone().unwrap();
+    let (output, opts) = get_opts(&input);
 
     test_it_converts(
         &input,
@@ -720,8 +682,7 @@ fn palette_4_should_be_palette_2() {
 #[test]
 fn palette_2_should_be_palette_2() {
     let input = PathBuf::from("tests/files/palette_2_should_be_palette_2.png");
-    let opts = get_opts(&input);
-    let output = opts.out_file.clone().unwrap();
+    let (output, opts) = get_opts(&input);
 
     test_it_converts(
         &input,
@@ -737,8 +698,7 @@ fn palette_2_should_be_palette_2() {
 #[test]
 fn palette_8_should_be_palette_1() {
     let input = PathBuf::from("tests/files/palette_8_should_be_palette_1.png");
-    let opts = get_opts(&input);
-    let output = opts.out_file.clone().unwrap();
+    let (output, opts) = get_opts(&input);
 
     test_it_converts(
         &input,
@@ -754,8 +714,7 @@ fn palette_8_should_be_palette_1() {
 #[test]
 fn palette_4_should_be_palette_1() {
     let input = PathBuf::from("tests/files/palette_4_should_be_palette_1.png");
-    let opts = get_opts(&input);
-    let output = opts.out_file.clone().unwrap();
+    let (output, opts) = get_opts(&input);
 
     test_it_converts(
         &input,
@@ -771,8 +730,7 @@ fn palette_4_should_be_palette_1() {
 #[test]
 fn palette_2_should_be_palette_1() {
     let input = PathBuf::from("tests/files/palette_2_should_be_palette_1.png");
-    let opts = get_opts(&input);
-    let output = opts.out_file.clone().unwrap();
+    let (output, opts) = get_opts(&input);
 
     test_it_converts(
         &input,
@@ -788,8 +746,7 @@ fn palette_2_should_be_palette_1() {
 #[test]
 fn palette_1_should_be_palette_1() {
     let input = PathBuf::from("tests/files/palette_1_should_be_palette_1.png");
-    let opts = get_opts(&input);
-    let output = opts.out_file.clone().unwrap();
+    let (output, opts) = get_opts(&input);
 
     test_it_converts(
         &input,
@@ -805,8 +762,7 @@ fn palette_1_should_be_palette_1() {
 #[test]
 fn grayscale_alpha_16_should_be_grayscale_alpha_16() {
     let input = PathBuf::from("tests/files/grayscale_alpha_16_should_be_grayscale_alpha_16.png");
-    let opts = get_opts(&input);
-    let output = opts.out_file.clone().unwrap();
+    let (output, opts) = get_opts(&input);
 
     test_it_converts(
         &input,
@@ -822,8 +778,7 @@ fn grayscale_alpha_16_should_be_grayscale_alpha_16() {
 #[test]
 fn grayscale_alpha_16_should_be_grayscale_alpha_8() {
     let input = PathBuf::from("tests/files/grayscale_alpha_16_should_be_grayscale_alpha_8.png");
-    let opts = get_opts(&input);
-    let output = opts.out_file.clone().unwrap();
+    let (output, opts) = get_opts(&input);
 
     test_it_converts(
         &input,
@@ -839,8 +794,7 @@ fn grayscale_alpha_16_should_be_grayscale_alpha_8() {
 #[test]
 fn grayscale_alpha_8_should_be_grayscale_alpha_8() {
     let input = PathBuf::from("tests/files/grayscale_alpha_8_should_be_grayscale_alpha_8.png");
-    let opts = get_opts(&input);
-    let output = opts.out_file.clone().unwrap();
+    let (output, opts) = get_opts(&input);
 
     test_it_converts(
         &input,
@@ -856,8 +810,7 @@ fn grayscale_alpha_8_should_be_grayscale_alpha_8() {
 #[test]
 fn grayscale_alpha_16_should_be_grayscale_16() {
     let input = PathBuf::from("tests/files/grayscale_alpha_16_should_be_grayscale_16.png");
-    let opts = get_opts(&input);
-    let output = opts.out_file.clone().unwrap();
+    let (output, opts) = get_opts(&input);
 
     test_it_converts(
         &input,
@@ -873,8 +826,7 @@ fn grayscale_alpha_16_should_be_grayscale_16() {
 #[test]
 fn grayscale_alpha_16_should_be_grayscale_8() {
     let input = PathBuf::from("tests/files/grayscale_alpha_16_should_be_grayscale_8.png");
-    let opts = get_opts(&input);
-    let output = opts.out_file.clone().unwrap();
+    let (output, opts) = get_opts(&input);
 
     test_it_converts(
         &input,
@@ -890,8 +842,7 @@ fn grayscale_alpha_16_should_be_grayscale_8() {
 #[test]
 fn grayscale_alpha_8_should_be_grayscale_8() {
     let input = PathBuf::from("tests/files/grayscale_alpha_8_should_be_grayscale_8.png");
-    let opts = get_opts(&input);
-    let output = opts.out_file.clone().unwrap();
+    let (output, opts) = get_opts(&input);
 
     test_it_converts(
         &input,
@@ -907,8 +858,7 @@ fn grayscale_alpha_8_should_be_grayscale_8() {
 #[test]
 fn grayscale_16_should_be_grayscale_16() {
     let input = PathBuf::from("tests/files/grayscale_16_should_be_grayscale_16.png");
-    let opts = get_opts(&input);
-    let output = opts.out_file.clone().unwrap();
+    let (output, opts) = get_opts(&input);
 
     test_it_converts(
         &input,
@@ -924,8 +874,7 @@ fn grayscale_16_should_be_grayscale_16() {
 #[test]
 fn grayscale_16_should_be_grayscale_8() {
     let input = PathBuf::from("tests/files/grayscale_16_should_be_grayscale_8.png");
-    let opts = get_opts(&input);
-    let output = opts.out_file.clone().unwrap();
+    let (output, opts) = get_opts(&input);
 
     test_it_converts(
         &input,
@@ -941,8 +890,7 @@ fn grayscale_16_should_be_grayscale_8() {
 #[test]
 fn grayscale_8_should_be_grayscale_8() {
     let input = PathBuf::from("tests/files/grayscale_8_should_be_grayscale_8.png");
-    let opts = get_opts(&input);
-    let output = opts.out_file.clone().unwrap();
+    let (output, opts) = get_opts(&input);
 
     test_it_converts(
         &input,
@@ -958,8 +906,7 @@ fn grayscale_8_should_be_grayscale_8() {
 #[test]
 fn small_files() {
     let input = PathBuf::from("tests/files/small_files.png");
-    let opts = get_opts(&input);
-    let output = opts.out_file.clone().unwrap();
+    let (output, opts) = get_opts(&input);
 
     test_it_converts(
         &input,
@@ -975,8 +922,7 @@ fn small_files() {
 #[test]
 fn palette_should_be_reduced_with_dupes() {
     let input = PathBuf::from("tests/files/palette_should_be_reduced_with_dupes.png");
-    let opts = get_opts(&input);
-    let output = opts.out_file.clone().unwrap();
+    let (output, opts) = get_opts(&input);
 
     let png = png::PngData::new(&input, opts.fix_errors).unwrap();
 
@@ -984,10 +930,11 @@ fn palette_should_be_reduced_with_dupes() {
     assert_eq!(png.ihdr_data.bit_depth, BitDepth::Eight);
     assert_eq!(png.palette.unwrap().len(), 43 * 3);
 
-    match oxipng::optimize(&input, &opts) {
+    match oxipng::optimize(&input, &output, &opts) {
         Ok(_) => (),
         Err(x) => panic!("{}", x),
     };
+    let output = output.path().unwrap();
     assert!(output.exists());
 
     let png = match png::PngData::new(&output, opts.fix_errors) {
@@ -1008,8 +955,7 @@ fn palette_should_be_reduced_with_dupes() {
 #[test]
 fn palette_should_be_reduced_with_unused() {
     let input = PathBuf::from("tests/files/palette_should_be_reduced_with_unused.png");
-    let opts = get_opts(&input);
-    let output = opts.out_file.clone().unwrap();
+    let (output, opts) = get_opts(&input);
 
     let png = png::PngData::new(&input, opts.fix_errors).unwrap();
 
@@ -1017,10 +963,11 @@ fn palette_should_be_reduced_with_unused() {
     assert_eq!(png.ihdr_data.bit_depth, BitDepth::Eight);
     assert_eq!(png.palette.unwrap().len(), 35 * 3);
 
-    match oxipng::optimize(&input, &opts) {
+    match oxipng::optimize(&input, &output, &opts) {
         Ok(_) => (),
         Err(x) => panic!("{}", x),
     };
+    let output = output.path().unwrap();
     assert!(output.exists());
 
     let png = match png::PngData::new(&output, opts.fix_errors) {
@@ -1041,8 +988,7 @@ fn palette_should_be_reduced_with_unused() {
 #[test]
 fn palette_should_be_reduced_with_both() {
     let input = PathBuf::from("tests/files/palette_should_be_reduced_with_both.png");
-    let opts = get_opts(&input);
-    let output = opts.out_file.clone().unwrap();
+    let (output, opts) = get_opts(&input);
 
     let png = png::PngData::new(&input, opts.fix_errors).unwrap();
 
@@ -1050,10 +996,11 @@ fn palette_should_be_reduced_with_both() {
     assert_eq!(png.ihdr_data.bit_depth, BitDepth::Eight);
     assert_eq!(png.palette.unwrap().len(), 43 * 3);
 
-    match oxipng::optimize(&input, &opts) {
+    match oxipng::optimize(&input, &output, &opts) {
         Ok(_) => (),
         Err(x) => panic!("{}", x),
     };
+    let output = output.path().unwrap();
     assert!(output.exists());
 
     let png = match png::PngData::new(&output, opts.fix_errors) {
@@ -1074,8 +1021,7 @@ fn palette_should_be_reduced_with_both() {
 #[test]
 fn rgba_16_reduce_alpha_black() {
     let input = PathBuf::from("tests/files/rgba_16_reduce_alpha_black.png");
-    let opts = get_opts(&input);
-    let output = opts.out_file.clone().unwrap();
+    let (output, opts) = get_opts(&input);
 
     test_it_converts(
         &input,
@@ -1091,8 +1037,7 @@ fn rgba_16_reduce_alpha_black() {
 #[test]
 fn rgba_8_reduce_alpha_black() {
     let input = PathBuf::from("tests/files/rgba_8_reduce_alpha_black.png");
-    let opts = get_opts(&input);
-    let output = opts.out_file.clone().unwrap();
+    let (output, opts) = get_opts(&input);
 
     test_it_converts(
         &input,
@@ -1108,8 +1053,7 @@ fn rgba_8_reduce_alpha_black() {
 #[test]
 fn grayscale_alpha_16_reduce_alpha_black() {
     let input = PathBuf::from("tests/files/grayscale_alpha_16_reduce_alpha_black.png");
-    let opts = get_opts(&input);
-    let output = opts.out_file.clone().unwrap();
+    let (output, opts) = get_opts(&input);
 
     test_it_converts(
         &input,
@@ -1125,8 +1069,7 @@ fn grayscale_alpha_16_reduce_alpha_black() {
 #[test]
 fn grayscale_alpha_8_reduce_alpha_black() {
     let input = PathBuf::from("tests/files/grayscale_alpha_8_reduce_alpha_black.png");
-    let opts = get_opts(&input);
-    let output = opts.out_file.clone().unwrap();
+    let (output, opts) = get_opts(&input);
 
     test_it_converts(
         &input,
@@ -1142,10 +1085,9 @@ fn grayscale_alpha_8_reduce_alpha_black() {
 #[test]
 fn rgba_16_reduce_alpha_white() {
     let input = PathBuf::from("tests/files/rgba_16_reduce_alpha_white.png");
-    let mut opts = get_opts(&input);
+    let (output, mut opts) = get_opts(&input);
     opts.alphas = HashSet::with_capacity(1);
     opts.alphas.insert(AlphaOptim::White);
-    let output = opts.out_file.clone().unwrap();
 
     test_it_converts(
         &input,
@@ -1161,10 +1103,9 @@ fn rgba_16_reduce_alpha_white() {
 #[test]
 fn rgba_8_reduce_alpha_white() {
     let input = PathBuf::from("tests/files/rgba_8_reduce_alpha_white.png");
-    let mut opts = get_opts(&input);
+    let (output, mut opts) = get_opts(&input);
     opts.alphas = HashSet::with_capacity(1);
     opts.alphas.insert(AlphaOptim::White);
-    let output = opts.out_file.clone().unwrap();
 
     test_it_converts(
         &input,
@@ -1180,10 +1121,9 @@ fn rgba_8_reduce_alpha_white() {
 #[test]
 fn grayscale_alpha_16_reduce_alpha_white() {
     let input = PathBuf::from("tests/files/grayscale_alpha_16_reduce_alpha_white.png");
-    let mut opts = get_opts(&input);
+    let (output, mut opts) = get_opts(&input);
     opts.alphas = HashSet::with_capacity(1);
     opts.alphas.insert(AlphaOptim::White);
-    let output = opts.out_file.clone().unwrap();
 
     test_it_converts(
         &input,
@@ -1199,10 +1139,9 @@ fn grayscale_alpha_16_reduce_alpha_white() {
 #[test]
 fn grayscale_alpha_8_reduce_alpha_white() {
     let input = PathBuf::from("tests/files/grayscale_alpha_8_reduce_alpha_white.png");
-    let mut opts = get_opts(&input);
+    let (output, mut opts) = get_opts(&input);
     opts.alphas = HashSet::with_capacity(1);
     opts.alphas.insert(AlphaOptim::White);
-    let output = opts.out_file.clone().unwrap();
 
     test_it_converts(
         &input,
@@ -1218,10 +1157,9 @@ fn grayscale_alpha_8_reduce_alpha_white() {
 #[test]
 fn rgba_16_reduce_alpha_down() {
     let input = PathBuf::from("tests/files/rgba_16_reduce_alpha_down.png");
-    let mut opts = get_opts(&input);
+    let (output, mut opts) = get_opts(&input);
     opts.alphas = HashSet::with_capacity(1);
     opts.alphas.insert(AlphaOptim::Down);
-    let output = opts.out_file.clone().unwrap();
 
     test_it_converts(
         &input,
@@ -1237,10 +1175,9 @@ fn rgba_16_reduce_alpha_down() {
 #[test]
 fn rgba_8_reduce_alpha_down() {
     let input = PathBuf::from("tests/files/rgba_8_reduce_alpha_down.png");
-    let mut opts = get_opts(&input);
+    let (output, mut opts) = get_opts(&input);
     opts.alphas = HashSet::with_capacity(1);
     opts.alphas.insert(AlphaOptim::Down);
-    let output = opts.out_file.clone().unwrap();
 
     test_it_converts(
         &input,
@@ -1256,10 +1193,9 @@ fn rgba_8_reduce_alpha_down() {
 #[test]
 fn grayscale_alpha_16_reduce_alpha_down() {
     let input = PathBuf::from("tests/files/grayscale_alpha_16_reduce_alpha_down.png");
-    let mut opts = get_opts(&input);
+    let (output, mut opts) = get_opts(&input);
     opts.alphas = HashSet::with_capacity(1);
     opts.alphas.insert(AlphaOptim::Down);
-    let output = opts.out_file.clone().unwrap();
 
     test_it_converts(
         &input,
@@ -1275,10 +1211,9 @@ fn grayscale_alpha_16_reduce_alpha_down() {
 #[test]
 fn grayscale_alpha_8_reduce_alpha_down() {
     let input = PathBuf::from("tests/files/grayscale_alpha_8_reduce_alpha_down.png");
-    let mut opts = get_opts(&input);
+    let (output, mut opts) = get_opts(&input);
     opts.alphas = HashSet::with_capacity(1);
     opts.alphas.insert(AlphaOptim::Down);
-    let output = opts.out_file.clone().unwrap();
 
     test_it_converts(
         &input,
@@ -1294,10 +1229,9 @@ fn grayscale_alpha_8_reduce_alpha_down() {
 #[test]
 fn rgba_16_reduce_alpha_up() {
     let input = PathBuf::from("tests/files/rgba_16_reduce_alpha_up.png");
-    let mut opts = get_opts(&input);
+    let (output, mut opts) = get_opts(&input);
     opts.alphas = HashSet::with_capacity(1);
     opts.alphas.insert(AlphaOptim::Up);
-    let output = opts.out_file.clone().unwrap();
 
     test_it_converts(
         &input,
@@ -1313,10 +1247,9 @@ fn rgba_16_reduce_alpha_up() {
 #[test]
 fn rgba_8_reduce_alpha_up() {
     let input = PathBuf::from("tests/files/rgba_8_reduce_alpha_up.png");
-    let mut opts = get_opts(&input);
+    let (output, mut opts) = get_opts(&input);
     opts.alphas = HashSet::with_capacity(1);
     opts.alphas.insert(AlphaOptim::Up);
-    let output = opts.out_file.clone().unwrap();
 
     test_it_converts(
         &input,
@@ -1332,10 +1265,9 @@ fn rgba_8_reduce_alpha_up() {
 #[test]
 fn grayscale_alpha_16_reduce_alpha_up() {
     let input = PathBuf::from("tests/files/grayscale_alpha_16_reduce_alpha_up.png");
-    let mut opts = get_opts(&input);
+    let (output, mut opts) = get_opts(&input);
     opts.alphas = HashSet::with_capacity(1);
     opts.alphas.insert(AlphaOptim::Up);
-    let output = opts.out_file.clone().unwrap();
 
     test_it_converts(
         &input,
@@ -1351,10 +1283,9 @@ fn grayscale_alpha_16_reduce_alpha_up() {
 #[test]
 fn grayscale_alpha_8_reduce_alpha_up() {
     let input = PathBuf::from("tests/files/grayscale_alpha_8_reduce_alpha_up.png");
-    let mut opts = get_opts(&input);
+    let (output, mut opts) = get_opts(&input);
     opts.alphas = HashSet::with_capacity(1);
     opts.alphas.insert(AlphaOptim::Up);
-    let output = opts.out_file.clone().unwrap();
 
     test_it_converts(
         &input,
@@ -1370,10 +1301,9 @@ fn grayscale_alpha_8_reduce_alpha_up() {
 #[test]
 fn rgba_16_reduce_alpha_left() {
     let input = PathBuf::from("tests/files/rgba_16_reduce_alpha_left.png");
-    let mut opts = get_opts(&input);
+    let (output, mut opts) = get_opts(&input);
     opts.alphas = HashSet::with_capacity(1);
     opts.alphas.insert(AlphaOptim::Left);
-    let output = opts.out_file.clone().unwrap();
 
     test_it_converts(
         &input,
@@ -1389,10 +1319,9 @@ fn rgba_16_reduce_alpha_left() {
 #[test]
 fn rgba_8_reduce_alpha_left() {
     let input = PathBuf::from("tests/files/rgba_8_reduce_alpha_left.png");
-    let mut opts = get_opts(&input);
+    let (output, mut opts) = get_opts(&input);
     opts.alphas = HashSet::with_capacity(1);
     opts.alphas.insert(AlphaOptim::Left);
-    let output = opts.out_file.clone().unwrap();
 
     test_it_converts(
         &input,
@@ -1408,10 +1337,9 @@ fn rgba_8_reduce_alpha_left() {
 #[test]
 fn grayscale_alpha_16_reduce_alpha_left() {
     let input = PathBuf::from("tests/files/grayscale_alpha_16_reduce_alpha_left.png");
-    let mut opts = get_opts(&input);
+    let (output, mut opts) = get_opts(&input);
     opts.alphas = HashSet::with_capacity(1);
     opts.alphas.insert(AlphaOptim::Left);
-    let output = opts.out_file.clone().unwrap();
 
     test_it_converts(
         &input,
@@ -1427,10 +1355,9 @@ fn grayscale_alpha_16_reduce_alpha_left() {
 #[test]
 fn grayscale_alpha_8_reduce_alpha_left() {
     let input = PathBuf::from("tests/files/grayscale_alpha_8_reduce_alpha_left.png");
-    let mut opts = get_opts(&input);
+    let (output, mut opts) = get_opts(&input);
     opts.alphas = HashSet::with_capacity(1);
     opts.alphas.insert(AlphaOptim::Left);
-    let output = opts.out_file.clone().unwrap();
 
     test_it_converts(
         &input,
@@ -1446,10 +1373,9 @@ fn grayscale_alpha_8_reduce_alpha_left() {
 #[test]
 fn rgba_16_reduce_alpha_right() {
     let input = PathBuf::from("tests/files/rgba_16_reduce_alpha_right.png");
-    let mut opts = get_opts(&input);
+    let (output, mut opts) = get_opts(&input);
     opts.alphas = HashSet::with_capacity(1);
     opts.alphas.insert(AlphaOptim::Right);
-    let output = opts.out_file.clone().unwrap();
 
     test_it_converts(
         &input,
@@ -1465,10 +1391,9 @@ fn rgba_16_reduce_alpha_right() {
 #[test]
 fn rgba_8_reduce_alpha_right() {
     let input = PathBuf::from("tests/files/rgba_8_reduce_alpha_right.png");
-    let mut opts = get_opts(&input);
+    let (output, mut opts) = get_opts(&input);
     opts.alphas = HashSet::with_capacity(1);
     opts.alphas.insert(AlphaOptim::Right);
-    let output = opts.out_file.clone().unwrap();
 
     test_it_converts(
         &input,
@@ -1484,10 +1409,9 @@ fn rgba_8_reduce_alpha_right() {
 #[test]
 fn grayscale_alpha_16_reduce_alpha_right() {
     let input = PathBuf::from("tests/files/grayscale_alpha_16_reduce_alpha_right.png");
-    let mut opts = get_opts(&input);
+    let (output, mut opts) = get_opts(&input);
     opts.alphas = HashSet::with_capacity(1);
     opts.alphas.insert(AlphaOptim::Right);
-    let output = opts.out_file.clone().unwrap();
 
     test_it_converts(
         &input,
@@ -1503,10 +1427,9 @@ fn grayscale_alpha_16_reduce_alpha_right() {
 #[test]
 fn grayscale_alpha_8_reduce_alpha_right() {
     let input = PathBuf::from("tests/files/grayscale_alpha_8_reduce_alpha_right.png");
-    let mut opts = get_opts(&input);
+    let (output, mut opts) = get_opts(&input);
     opts.alphas = HashSet::with_capacity(1);
     opts.alphas.insert(AlphaOptim::Right);
-    let output = opts.out_file.clone().unwrap();
 
     test_it_converts(
         &input,


### PR DESCRIPTION
* It's more idiomatic to have one enum than two/three inter-dependent struct fields.
* Backup is not performed when writing to stdout, since it's not necessary. In an unfortunate case of a bash footgun `oxipng foo.png --stdout > foo.png` it wouldn't be able to help anyway.
* Changed `perform_backup()` to use `output_path` rather than `input path`.
* Added cause to error descriptions.
* Removed `out_dir` and clone+mutate workarounds from `Options` in favor of separate, explicit arguments. This makes options purely immutable configuration shared for all files.