### PR TITLE
Avoid double glob processing on unix

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -363,12 +363,12 @@ dependencies = [
  "clippy 0.0.195 (registry+https://github.com/rust-lang/crates.io-index)",
  "cloudflare-zlib-sys 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "crc 1.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "glob 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "image 0.19.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "itertools 0.7.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "miniz_oxide 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "num_cpus 1.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rayon 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "wild 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "zopfli 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -668,6 +668,14 @@ version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "wild"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "glob 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "winapi"
 version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -784,6 +792,7 @@ dependencies = [
 "checksum utf8-ranges 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "662fab6525a98beff2921d7f61a39e7d59e0b425ebc7d0d9e66d316e55124122"
 "checksum vec_map 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "887b5b631c2ad01628bbbaa7dd4c869f80d3186688f8d0b6f58774fbe324988c"
 "checksum void 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d"
+"checksum wild 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "1b3c8e0da06bb62c6fbfadfa12ee04918fd1d912058d1873b178b957ab3325b5"
 "checksum winapi 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)" = "04e3bd221fcbe8a271359c04f21a76db7d0c6028862d1bb5512d85e1e2eb5bb3"
 "checksum winapi-i686-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
 "checksum winapi-x86_64-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,6 @@ required-features = ["binary"]
 bit-vec = "^0.5.0"
 byteorder = "^1.0.0"
 crc = "^1.2.0"
-glob = "0.2.11"
 itertools = "^0.7.7"
 num_cpus = "^1.0.0"
 rayon = "^1.0.0"
@@ -40,6 +39,10 @@ miniz_oxide = "0.1.2"
 [dependencies.clap]
 optional = true
 version = "^2.10.0"
+
+[dependencies.wild]
+optional = true
+version = "1.0.1"
 
 [dependencies.clippy]
 optional = true
@@ -57,6 +60,7 @@ version = "^0.19.0"
 [features]
 binary = [
     "clap",
+    "wild",
 ]
 default = ["binary"]
 cfzlib = ["cloudflare-zlib-sys"]

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,11 +8,10 @@
 #![deny(missing_debug_implementations, missing_copy_implementations)]
 
 extern crate clap;
-extern crate glob;
+extern crate wild;
 extern crate oxipng;
 
 use clap::{App, Arg, ArgMatches};
-use glob::glob;
 use oxipng::AlphaOptim;
 use oxipng::Deflaters;
 use oxipng::Headers;
@@ -208,7 +207,7 @@ fn main() {
 
     Manually specifying a compression option (zc, zs, etc.) will override the optimization preset,
     regardless of the order you write the arguments.")
-        .get_matches();
+        .get_matches_from(wild::args());
 
     let opts = match parse_opts_into_struct(&matches) {
         Ok(x) => x,
@@ -219,16 +218,8 @@ fn main() {
     };
 
     if let Err(e) = handle_optimization(
-        matches
-            .values_of("files")
-            .unwrap()
-            .map(|pattern| glob(pattern).expect("Failed to parse input file path"))
-            .flat_map(|paths| {
-                paths
-                    .into_iter()
-                    .map(|path| path.expect("Failed to parse input file path"))
-            })
-            .collect(),
+        matches.values_of("files").unwrap()
+            .map(PathBuf::from).collect(),
         &opts,
     ) {
         eprintln!("{}", e);


### PR DESCRIPTION
On unix-like platforms globs are expanded for all arguments before the executable is called, so if user runs:

```sh
oxipng foo*
```

the shell actually runs expanded args:

```rust
["oxipng", "foobar", "foobaz"]
```

which makes processing of glob paths inside the program unnecessary. Also, if there was a file called `foo*` (it's a legal name in Linux), unix tools wouldn't know how to specify just that file, since normal quoting wouldn't be enough:

```sh
oxipng "foo*"
```

because the un-expanded value passed to the program would still be expanded internally. So on unix doing nothing is the best way to support globs :)

Windows is different in that regard. It doesn't expand globs in the shell, and requires programs to handle globs internally. So to get uniform cross-platform support I've used the [wild](https://crates.rs/crates/wild)card crate which adds glob arguments on Windows.


