### PR TITLE
Make Rayon an optional dependency, because WASM

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,9 +33,12 @@ crc = "^1.2.0"
 glob = "0.2.11"
 itertools = "^0.7.7"
 num_cpus = "^1.0.0"
-rayon = "^1.0.0"
 zopfli = "^0.3.4"
 miniz_oxide = "0.1.2"
+
+[dependencies.rayon]
+optional = true
+version = "^1.0.0"
 
 [dependencies.clap]
 optional = true
@@ -58,7 +61,8 @@ version = "^0.19.0"
 binary = [
     "clap",
 ]
-default = ["binary"]
+default = ["binary", "parallel"]
+parallel = ["rayon"]
 cfzlib = ["cloudflare-zlib-sys"]
 dev = [
     "nightly-binary",


### PR DESCRIPTION
On WebAssembly, Rayon does not work: the thread pool fails to initialize since threads are stubbed out.

With this and some changes to `miniz_oxide` (for now, described in https://github.com/Frommi/miniz_oxide/issues/26), I've been able to run oxipng in the browser :)

![wayland-screenshot-2018-07-05_16-33-27-fs8](https://user-images.githubusercontent.com/208340/42336879-b7d9b278-808d-11e8-8c9a-b301ff9c340d.png)
