### PR TITLE
Improved limiting of max gzip size

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -506,7 +506,7 @@ fn optimize_png(
             .filter_map(|trial| {
                 let filtered = &filters[&trial.filter];
                 let new_idat = if opts.deflate == Deflaters::Zlib {
-                    deflate::deflate(filtered, trial.compression, trial.strategy, opts.window, best_size.get())
+                    deflate::deflate(filtered, trial.compression, trial.strategy, opts.window, &best_size)
                 } else {
                     deflate::zopfli_deflate(filtered)
                 };

--- a/src/png/mod.rs
+++ b/src/png/mod.rs
@@ -625,7 +625,7 @@ impl PngData {
                             STD_COMPRESSION,
                             STD_STRATEGY,
                             STD_WINDOW,
-                            best_size.get(),
+                            &best_size,
                         ).ok()
                         .as_ref().map(|l| {
                             best_size.set_min(l.len());


### PR DESCRIPTION
Atomically-updated maximum can be checked later, which gives other threads more time to find smaller maximum.