### PR TITLE
DRYyer tests

### DIFF
--- a/tests/filters.rs
+++ b/tests/filters.rs
@@ -20,20 +20,23 @@ fn get_opts(input: &Path) -> (OutFile, oxipng::Options) {
 }
 
 fn test_it_converts(
-    input: &Path,
-    output: &OutFile,
-    opts: &oxipng::Options,
+    input: &str,
+    filter: u8,
     color_type_in: ColorType,
     bit_depth_in: BitDepth,
     color_type_out: ColorType,
     bit_depth_out: BitDepth,
 ) {
-    let png = png::PngData::new(input, opts.fix_errors).unwrap();
+    let input = PathBuf::from(input);
 
+    let (output, mut opts) = get_opts(&input);
+    let png = png::PngData::new(&input, opts.fix_errors).unwrap();
+    opts.filter = HashSet::new();
+    opts.filter.insert(filter);
     assert_eq!(png.ihdr_data.color_type, color_type_in);
     assert_eq!(png.ihdr_data.bit_depth, bit_depth_in);
 
-    match oxipng::optimize(input, output, opts) {
+    match oxipng::optimize(&input, &output, &opts) {
         Ok(_) => (),
         Err(x) => panic!("{}", x),
     };
@@ -56,15 +59,9 @@ fn test_it_converts(
 
 #[test]
 fn filter_0_for_rgba_16() {
-    let input = PathBuf::from("tests/files/filter_0_for_rgba_16.png");
-    let (output, mut opts) = get_opts(&input);
-    opts.filter = HashSet::new();
-    opts.filter.insert(0);
-
     test_it_converts(
-        &input,
-        &output,
-        &opts,
+        "tests/files/filter_0_for_rgba_16.png",
+        0,
         ColorType::RGBA,
         BitDepth::Sixteen,
         ColorType::RGBA,
@@ -74,15 +71,9 @@ fn filter_0_for_rgba_16() {
 
 #[test]
 fn filter_1_for_rgba_16() {
-    let input = PathBuf::from("tests/files/filter_1_for_rgba_16.png");
-    let (output, mut opts) = get_opts(&input);
-    opts.filter = HashSet::new();
-    opts.filter.insert(1);
-
     test_it_converts(
-        &input,
-        &output,
-        &opts,
+        "tests/files/filter_1_for_rgba_16.png",
+        1,
         ColorType::RGBA,
         BitDepth::Sixteen,
         ColorType::RGBA,
@@ -92,15 +83,9 @@ fn filter_1_for_rgba_16() {
 
 #[test]
 fn filter_2_for_rgba_16() {
-    let input = PathBuf::from("tests/files/filter_2_for_rgba_16.png");
-    let (output, mut opts) = get_opts(&input);
-    opts.filter = HashSet::new();
-    opts.filter.insert(2);
-
     test_it_converts(
-        &input,
-        &output,
-        &opts,
+        "tests/files/filter_2_for_rgba_16.png",
+        2,
         ColorType::RGBA,
         BitDepth::Sixteen,
         ColorType::RGBA,
@@ -110,15 +95,9 @@ fn filter_2_for_rgba_16() {
 
 #[test]
 fn filter_3_for_rgba_16() {
-    let input = PathBuf::from("tests/files/filter_3_for_rgba_16.png");
-    let (output, mut opts) = get_opts(&input);
-    opts.filter = HashSet::new();
-    opts.filter.insert(3);
-
     test_it_converts(
-        &input,
-        &output,
-        &opts,
+        "tests/files/filter_3_for_rgba_16.png",
+        3,
         ColorType::RGBA,
         BitDepth::Sixteen,
         ColorType::RGBA,
@@ -128,15 +107,9 @@ fn filter_3_for_rgba_16() {
 
 #[test]
 fn filter_4_for_rgba_16() {
-    let input = PathBuf::from("tests/files/filter_4_for_rgba_16.png");
-    let (output, mut opts) = get_opts(&input);
-    opts.filter = HashSet::new();
-    opts.filter.insert(4);
-
     test_it_converts(
-        &input,
-        &output,
-        &opts,
+        "tests/files/filter_4_for_rgba_16.png",
+        4,
         ColorType::RGBA,
         BitDepth::Sixteen,
         ColorType::RGBA,
@@ -146,15 +119,9 @@ fn filter_4_for_rgba_16() {
 
 #[test]
 fn filter_5_for_rgba_16() {
-    let input = PathBuf::from("tests/files/filter_5_for_rgba_16.png");
-    let (output, mut opts) = get_opts(&input);
-    opts.filter = HashSet::new();
-    opts.filter.insert(5);
-
     test_it_converts(
-        &input,
-        &output,
-        &opts,
+        "tests/files/filter_5_for_rgba_16.png",
+        5,
         ColorType::RGBA,
         BitDepth::Sixteen,
         ColorType::RGBA,
@@ -164,15 +131,9 @@ fn filter_5_for_rgba_16() {
 
 #[test]
 fn filter_0_for_rgba_8() {
-    let input = PathBuf::from("tests/files/filter_0_for_rgba_8.png");
-    let (output, mut opts) = get_opts(&input);
-    opts.filter = HashSet::new();
-    opts.filter.insert(0);
-
     test_it_converts(
-        &input,
-        &output,
-        &opts,
+        "tests/files/filter_0_for_rgba_8.png",
+        0,
         ColorType::RGBA,
         BitDepth::Eight,
         ColorType::RGBA,
@@ -182,15 +143,9 @@ fn filter_0_for_rgba_8() {
 
 #[test]
 fn filter_1_for_rgba_8() {
-    let input = PathBuf::from("tests/files/filter_1_for_rgba_8.png");
-    let (output, mut opts) = get_opts(&input);
-    opts.filter = HashSet::new();
-    opts.filter.insert(1);
-
     test_it_converts(
-        &input,
-        &output,
-        &opts,
+        "tests/files/filter_1_for_rgba_8.png",
+        1,
         ColorType::RGBA,
         BitDepth::Eight,
         ColorType::RGBA,
@@ -200,15 +155,9 @@ fn filter_1_for_rgba_8() {
 
 #[test]
 fn filter_2_for_rgba_8() {
-    let input = PathBuf::from("tests/files/filter_2_for_rgba_8.png");
-    let (output, mut opts) = get_opts(&input);
-    opts.filter = HashSet::new();
-    opts.filter.insert(2);
-
     test_it_converts(
-        &input,
-        &output,
-        &opts,
+        "tests/files/filter_2_for_rgba_8.png",
+        2,
         ColorType::RGBA,
         BitDepth::Eight,
         ColorType::RGBA,
@@ -218,15 +167,9 @@ fn filter_2_for_rgba_8() {
 
 #[test]
 fn filter_3_for_rgba_8() {
-    let input = PathBuf::from("tests/files/filter_3_for_rgba_8.png");
-    let (output, mut opts) = get_opts(&input);
-    opts.filter = HashSet::new();
-    opts.filter.insert(3);
-
     test_it_converts(
-        &input,
-        &output,
-        &opts,
+        "tests/files/filter_3_for_rgba_8.png",
+        3,
         ColorType::RGBA,
         BitDepth::Eight,
         ColorType::RGBA,
@@ -236,15 +179,9 @@ fn filter_3_for_rgba_8() {
 
 #[test]
 fn filter_4_for_rgba_8() {
-    let input = PathBuf::from("tests/files/filter_4_for_rgba_8.png");
-    let (output, mut opts) = get_opts(&input);
-    opts.filter = HashSet::new();
-    opts.filter.insert(4);
-
     test_it_converts(
-        &input,
-        &output,
-        &opts,
+        "tests/files/filter_4_for_rgba_8.png",
+        4,
         ColorType::RGBA,
         BitDepth::Eight,
         ColorType::RGBA,
@@ -254,15 +191,9 @@ fn filter_4_for_rgba_8() {
 
 #[test]
 fn filter_5_for_rgba_8() {
-    let input = PathBuf::from("tests/files/filter_5_for_rgba_8.png");
-    let (output, mut opts) = get_opts(&input);
-    opts.filter = HashSet::new();
-    opts.filter.insert(5);
-
     test_it_converts(
-        &input,
-        &output,
-        &opts,
+        "tests/files/filter_5_for_rgba_8.png",
+        5,
         ColorType::RGBA,
         BitDepth::Eight,
         ColorType::RGBA,
@@ -272,15 +203,9 @@ fn filter_5_for_rgba_8() {
 
 #[test]
 fn filter_0_for_rgb_16() {
-    let input = PathBuf::from("tests/files/filter_0_for_rgb_16.png");
-    let (output, mut opts) = get_opts(&input);
-    opts.filter = HashSet::new();
-    opts.filter.insert(0);
-
     test_it_converts(
-        &input,
-        &output,
-        &opts,
+        "tests/files/filter_0_for_rgb_16.png",
+        0,
         ColorType::RGB,
         BitDepth::Sixteen,
         ColorType::RGB,
@@ -290,15 +215,9 @@ fn filter_0_for_rgb_16() {
 
 #[test]
 fn filter_1_for_rgb_16() {
-    let input = PathBuf::from("tests/files/filter_1_for_rgb_16.png");
-    let (output, mut opts) = get_opts(&input);
-    opts.filter = HashSet::new();
-    opts.filter.insert(1);
-
     test_it_converts(
-        &input,
-        &output,
-        &opts,
+        "tests/files/filter_1_for_rgb_16.png",
+        1,
         ColorType::RGB,
         BitDepth::Sixteen,
         ColorType::RGB,
@@ -308,15 +227,9 @@ fn filter_1_for_rgb_16() {
 
 #[test]
 fn filter_2_for_rgb_16() {
-    let input = PathBuf::from("tests/files/filter_2_for_rgb_16.png");
-    let (output, mut opts) = get_opts(&input);
-    opts.filter = HashSet::new();
-    opts.filter.insert(2);
-
     test_it_converts(
-        &input,
-        &output,
-        &opts,
+        "tests/files/filter_2_for_rgb_16.png",
+        2,
         ColorType::RGB,
         BitDepth::Sixteen,
         ColorType::RGB,
@@ -326,15 +239,9 @@ fn filter_2_for_rgb_16() {
 
 #[test]
 fn filter_3_for_rgb_16() {
-    let input = PathBuf::from("tests/files/filter_3_for_rgb_16.png");
-    let (output, mut opts) = get_opts(&input);
-    opts.filter = HashSet::new();
-    opts.filter.insert(3);
-
     test_it_converts(
-        &input,
-        &output,
-        &opts,
+        "tests/files/filter_3_for_rgb_16.png",
+        3,
         ColorType::RGB,
         BitDepth::Sixteen,
         ColorType::RGB,
@@ -344,15 +251,9 @@ fn filter_3_for_rgb_16() {
 
 #[test]
 fn filter_4_for_rgb_16() {
-    let input = PathBuf::from("tests/files/filter_4_for_rgb_16.png");
-    let (output, mut opts) = get_opts(&input);
-    opts.filter = HashSet::new();
-    opts.filter.insert(4);
-
     test_it_converts(
-        &input,
-        &output,
-        &opts,
+        "tests/files/filter_4_for_rgb_16.png",
+        4,
         ColorType::RGB,
         BitDepth::Sixteen,
         ColorType::RGB,
@@ -362,15 +263,9 @@ fn filter_4_for_rgb_16() {
 
 #[test]
 fn filter_5_for_rgb_16() {
-    let input = PathBuf::from("tests/files/filter_5_for_rgb_16.png");
-    let (output, mut opts) = get_opts(&input);
-    opts.filter = HashSet::new();
-    opts.filter.insert(5);
-
     test_it_converts(
-        &input,
-        &output,
-        &opts,
+        "tests/files/filter_5_for_rgb_16.png",
+        5,
         ColorType::RGB,
         BitDepth::Sixteen,
         ColorType::RGB,
@@ -380,15 +275,9 @@ fn filter_5_for_rgb_16() {
 
 #[test]
 fn filter_0_for_rgb_8() {
-    let input = PathBuf::from("tests/files/filter_0_for_rgb_8.png");
-    let (output, mut opts) = get_opts(&input);
-    opts.filter = HashSet::new();
-    opts.filter.insert(0);
-
     test_it_converts(
-        &input,
-        &output,
-        &opts,
+        "tests/files/filter_0_for_rgb_8.png",
+        0,
         ColorType::RGB,
         BitDepth::Eight,
         ColorType::RGB,
@@ -398,15 +287,9 @@ fn filter_0_for_rgb_8() {
 
 #[test]
 fn filter_1_for_rgb_8() {
-    let input = PathBuf::from("tests/files/filter_1_for_rgb_8.png");
-    let (output, mut opts) = get_opts(&input);
-    opts.filter = HashSet::new();
-    opts.filter.insert(1);
-
     test_it_converts(
-        &input,
-        &output,
-        &opts,
+        "tests/files/filter_1_for_rgb_8.png",
+        1,
         ColorType::RGB,
         BitDepth::Eight,
         ColorType::RGB,
@@ -416,15 +299,9 @@ fn filter_1_for_rgb_8() {
 
 #[test]
 fn filter_2_for_rgb_8() {
-    let input = PathBuf::from("tests/files/filter_2_for_rgb_8.png");
-    let (output, mut opts) = get_opts(&input);
-    opts.filter = HashSet::new();
-    opts.filter.insert(2);
-
     test_it_converts(
-        &input,
-        &output,
-        &opts,
+        "tests/files/filter_2_for_rgb_8.png",
+        2,
         ColorType::RGB,
         BitDepth::Eight,
         ColorType::RGB,
@@ -434,15 +311,9 @@ fn filter_2_for_rgb_8() {
 
 #[test]
 fn filter_3_for_rgb_8() {
-    let input = PathBuf::from("tests/files/filter_3_for_rgb_8.png");
-    let (output, mut opts) = get_opts(&input);
-    opts.filter = HashSet::new();
-    opts.filter.insert(3);
-
     test_it_converts(
-        &input,
-        &output,
-        &opts,
+        "tests/files/filter_3_for_rgb_8.png",
+        3,
         ColorType::RGB,
         BitDepth::Eight,
         ColorType::RGB,
@@ -452,15 +323,9 @@ fn filter_3_for_rgb_8() {
 
 #[test]
 fn filter_4_for_rgb_8() {
-    let input = PathBuf::from("tests/files/filter_4_for_rgb_8.png");
-    let (output, mut opts) = get_opts(&input);
-    opts.filter = HashSet::new();
-    opts.filter.insert(4);
-
     test_it_converts(
-        &input,
-        &output,
-        &opts,
+        "tests/files/filter_4_for_rgb_8.png",
+        4,
         ColorType::RGB,
         BitDepth::Eight,
         ColorType::RGB,
@@ -470,15 +335,9 @@ fn filter_4_for_rgb_8() {
 
 #[test]
 fn filter_5_for_rgb_8() {
-    let input = PathBuf::from("tests/files/filter_5_for_rgb_8.png");
-    let (output, mut opts) = get_opts(&input);
-    opts.filter = HashSet::new();
-    opts.filter.insert(5);
-
     test_it_converts(
-        &input,
-        &output,
-        &opts,
+        "tests/files/filter_5_for_rgb_8.png",
+        5,
         ColorType::RGB,
         BitDepth::Eight,
         ColorType::RGB,
@@ -488,15 +347,9 @@ fn filter_5_for_rgb_8() {
 
 #[test]
 fn filter_0_for_grayscale_alpha_16() {
-    let input = PathBuf::from("tests/files/filter_0_for_grayscale_alpha_16.png");
-    let (output, mut opts) = get_opts(&input);
-    opts.filter = HashSet::new();
-    opts.filter.insert(0);
-
     test_it_converts(
-        &input,
-        &output,
-        &opts,
+        "tests/files/filter_0_for_grayscale_alpha_16.png",
+        0,
         ColorType::GrayscaleAlpha,
         BitDepth::Sixteen,
         ColorType::GrayscaleAlpha,
@@ -506,15 +359,9 @@ fn filter_0_for_grayscale_alpha_16() {
 
 #[test]
 fn filter_1_for_grayscale_alpha_16() {
-    let input = PathBuf::from("tests/files/filter_1_for_grayscale_alpha_16.png");
-    let (output, mut opts) = get_opts(&input);
-    opts.filter = HashSet::new();
-    opts.filter.insert(1);
-
     test_it_converts(
-        &input,
-        &output,
-        &opts,
+        "tests/files/filter_1_for_grayscale_alpha_16.png",
+        1,
         ColorType::GrayscaleAlpha,
         BitDepth::Sixteen,
         ColorType::GrayscaleAlpha,
@@ -524,15 +371,9 @@ fn filter_1_for_grayscale_alpha_16() {
 
 #[test]
 fn filter_2_for_grayscale_alpha_16() {
-    let input = PathBuf::from("tests/files/filter_2_for_grayscale_alpha_16.png");
-    let (output, mut opts) = get_opts(&input);
-    opts.filter = HashSet::new();
-    opts.filter.insert(2);
-
     test_it_converts(
-        &input,
-        &output,
-        &opts,
+        "tests/files/filter_2_for_grayscale_alpha_16.png",
+        2,
         ColorType::GrayscaleAlpha,
         BitDepth::Sixteen,
         ColorType::GrayscaleAlpha,
@@ -542,15 +383,9 @@ fn filter_2_for_grayscale_alpha_16() {
 
 #[test]
 fn filter_3_for_grayscale_alpha_16() {
-    let input = PathBuf::from("tests/files/filter_3_for_grayscale_alpha_16.png");
-    let (output, mut opts) = get_opts(&input);
-    opts.filter = HashSet::new();
-    opts.filter.insert(3);
-
     test_it_converts(
-        &input,
-        &output,
-        &opts,
+        "tests/files/filter_3_for_grayscale_alpha_16.png",
+        3,
         ColorType::GrayscaleAlpha,
         BitDepth::Sixteen,
         ColorType::GrayscaleAlpha,
@@ -560,15 +395,9 @@ fn filter_3_for_grayscale_alpha_16() {
 
 #[test]
 fn filter_4_for_grayscale_alpha_16() {
-    let input = PathBuf::from("tests/files/filter_4_for_grayscale_alpha_16.png");
-    let (output, mut opts) = get_opts(&input);
-    opts.filter = HashSet::new();
-    opts.filter.insert(4);
-
     test_it_converts(
-        &input,
-        &output,
-        &opts,
+        "tests/files/filter_4_for_grayscale_alpha_16.png",
+        4,
         ColorType::GrayscaleAlpha,
         BitDepth::Sixteen,
         ColorType::GrayscaleAlpha,
@@ -578,15 +407,9 @@ fn filter_4_for_grayscale_alpha_16() {
 
 #[test]
 fn filter_5_for_grayscale_alpha_16() {
-    let input = PathBuf::from("tests/files/filter_5_for_grayscale_alpha_16.png");
-    let (output, mut opts) = get_opts(&input);
-    opts.filter = HashSet::new();
-    opts.filter.insert(5);
-
     test_it_converts(
-        &input,
-        &output,
-        &opts,
+        "tests/files/filter_5_for_grayscale_alpha_16.png",
+        5,
         ColorType::GrayscaleAlpha,
         BitDepth::Sixteen,
         ColorType::GrayscaleAlpha,
@@ -596,15 +419,9 @@ fn filter_5_for_grayscale_alpha_16() {
 
 #[test]
 fn filter_0_for_grayscale_alpha_8() {
-    let input = PathBuf::from("tests/files/filter_0_for_grayscale_alpha_8.png");
-    let (output, mut opts) = get_opts(&input);
-    opts.filter = HashSet::new();
-    opts.filter.insert(0);
-
     test_it_converts(
-        &input,
-        &output,
-        &opts,
+        "tests/files/filter_0_for_grayscale_alpha_8.png",
+        0,
         ColorType::GrayscaleAlpha,
         BitDepth::Eight,
         ColorType::GrayscaleAlpha,
@@ -614,15 +431,9 @@ fn filter_0_for_grayscale_alpha_8() {
 
 #[test]
 fn filter_1_for_grayscale_alpha_8() {
-    let input = PathBuf::from("tests/files/filter_1_for_grayscale_alpha_8.png");
-    let (output, mut opts) = get_opts(&input);
-    opts.filter = HashSet::new();
-    opts.filter.insert(1);
-
     test_it_converts(
-        &input,
-        &output,
-        &opts,
+        "tests/files/filter_1_for_grayscale_alpha_8.png",
+        1,
         ColorType::GrayscaleAlpha,
         BitDepth::Eight,
         ColorType::GrayscaleAlpha,
@@ -632,15 +443,9 @@ fn filter_1_for_grayscale_alpha_8() {
 
 #[test]
 fn filter_2_for_grayscale_alpha_8() {
-    let input = PathBuf::from("tests/files/filter_2_for_grayscale_alpha_8.png");
-    let (output, mut opts) = get_opts(&input);
-    opts.filter = HashSet::new();
-    opts.filter.insert(2);
-
     test_it_converts(
-        &input,
-        &output,
-        &opts,
+        "tests/files/filter_2_for_grayscale_alpha_8.png",
+        2,
         ColorType::GrayscaleAlpha,
         BitDepth::Eight,
         ColorType::GrayscaleAlpha,
@@ -650,15 +455,9 @@ fn filter_2_for_grayscale_alpha_8() {
 
 #[test]
 fn filter_3_for_grayscale_alpha_8() {
-    let input = PathBuf::from("tests/files/filter_3_for_grayscale_alpha_8.png");
-    let (output, mut opts) = get_opts(&input);
-    opts.filter = HashSet::new();
-    opts.filter.insert(3);
-
     test_it_converts(
-        &input,
-        &output,
-        &opts,
+        "tests/files/filter_3_for_grayscale_alpha_8.png",
+        3,
         ColorType::GrayscaleAlpha,
         BitDepth::Eight,
         ColorType::GrayscaleAlpha,
@@ -668,15 +467,9 @@ fn filter_3_for_grayscale_alpha_8() {
 
 #[test]
 fn filter_4_for_grayscale_alpha_8() {
-    let input = PathBuf::from("tests/files/filter_4_for_grayscale_alpha_8.png");
-    let (output, mut opts) = get_opts(&input);
-    opts.filter = HashSet::new();
-    opts.filter.insert(4);
-
     test_it_converts(
-        &input,
-        &output,
-        &opts,
+        "tests/files/filter_4_for_grayscale_alpha_8.png",
+        4,
         ColorType::GrayscaleAlpha,
         BitDepth::Eight,
         ColorType::GrayscaleAlpha,
@@ -686,15 +479,9 @@ fn filter_4_for_grayscale_alpha_8() {
 
 #[test]
 fn filter_5_for_grayscale_alpha_8() {
-    let input = PathBuf::from("tests/files/filter_5_for_grayscale_alpha_8.png");
-    let (output, mut opts) = get_opts(&input);
-    opts.filter = HashSet::new();
-    opts.filter.insert(5);
-
     test_it_converts(
-        &input,
-        &output,
-        &opts,
+        "tests/files/filter_5_for_grayscale_alpha_8.png",
+        5,
         ColorType::GrayscaleAlpha,
         BitDepth::Eight,
         ColorType::GrayscaleAlpha,
@@ -704,15 +491,9 @@ fn filter_5_for_grayscale_alpha_8() {
 
 #[test]
 fn filter_0_for_grayscale_16() {
-    let input = PathBuf::from("tests/files/filter_0_for_grayscale_16.png");
-    let (output, mut opts) = get_opts(&input);
-    opts.filter = HashSet::new();
-    opts.filter.insert(0);
-
     test_it_converts(
-        &input,
-        &output,
-        &opts,
+        "tests/files/filter_0_for_grayscale_16.png",
+        0,
         ColorType::Grayscale,
         BitDepth::Sixteen,
         ColorType::Grayscale,
@@ -722,15 +503,9 @@ fn filter_0_for_grayscale_16() {
 
 #[test]
 fn filter_1_for_grayscale_16() {
-    let input = PathBuf::from("tests/files/filter_1_for_grayscale_16.png");
-    let (output, mut opts) = get_opts(&input);
-    opts.filter = HashSet::new();
-    opts.filter.insert(1);
-
     test_it_converts(
-        &input,
-        &output,
-        &opts,
+        "tests/files/filter_1_for_grayscale_16.png",
+        1,
         ColorType::Grayscale,
         BitDepth::Sixteen,
         ColorType::Grayscale,
@@ -740,15 +515,9 @@ fn filter_1_for_grayscale_16() {
 
 #[test]
 fn filter_2_for_grayscale_16() {
-    let input = PathBuf::from("tests/files/filter_2_for_grayscale_16.png");
-    let (output, mut opts) = get_opts(&input);
-    opts.filter = HashSet::new();
-    opts.filter.insert(2);
-
     test_it_converts(
-        &input,
-        &output,
-        &opts,
+        "tests/files/filter_2_for_grayscale_16.png",
+        2,
         ColorType::Grayscale,
         BitDepth::Sixteen,
         ColorType::Grayscale,
@@ -758,15 +527,9 @@ fn filter_2_for_grayscale_16() {
 
 #[test]
 fn filter_3_for_grayscale_16() {
-    let input = PathBuf::from("tests/files/filter_3_for_grayscale_16.png");
-    let (output, mut opts) = get_opts(&input);
-    opts.filter = HashSet::new();
-    opts.filter.insert(3);
-
     test_it_converts(
-        &input,
-        &output,
-        &opts,
+        "tests/files/filter_3_for_grayscale_16.png",
+        3,
         ColorType::Grayscale,
         BitDepth::Sixteen,
         ColorType::Grayscale,
@@ -776,15 +539,9 @@ fn filter_3_for_grayscale_16() {
 
 #[test]
 fn filter_4_for_grayscale_16() {
-    let input = PathBuf::from("tests/files/filter_4_for_grayscale_16.png");
-    let (output, mut opts) = get_opts(&input);
-    opts.filter = HashSet::new();
-    opts.filter.insert(4);
-
     test_it_converts(
-        &input,
-        &output,
-        &opts,
+        "tests/files/filter_4_for_grayscale_16.png",
+        4,
         ColorType::Grayscale,
         BitDepth::Sixteen,
         ColorType::Grayscale,
@@ -794,15 +551,9 @@ fn filter_4_for_grayscale_16() {
 
 #[test]
 fn filter_5_for_grayscale_16() {
-    let input = PathBuf::from("tests/files/filter_5_for_grayscale_16.png");
-    let (output, mut opts) = get_opts(&input);
-    opts.filter = HashSet::new();
-    opts.filter.insert(5);
-
     test_it_converts(
-        &input,
-        &output,
-        &opts,
+        "tests/files/filter_5_for_grayscale_16.png",
+        5,
         ColorType::Grayscale,
         BitDepth::Sixteen,
         ColorType::Grayscale,
@@ -812,15 +563,9 @@ fn filter_5_for_grayscale_16() {
 
 #[test]
 fn filter_0_for_grayscale_8() {
-    let input = PathBuf::from("tests/files/filter_0_for_grayscale_8.png");
-    let (output, mut opts) = get_opts(&input);
-    opts.filter = HashSet::new();
-    opts.filter.insert(0);
-
     test_it_converts(
-        &input,
-        &output,
-        &opts,
+        "tests/files/filter_0_for_grayscale_8.png",
+        0,
         ColorType::Grayscale,
         BitDepth::Eight,
         ColorType::Grayscale,
@@ -830,15 +575,9 @@ fn filter_0_for_grayscale_8() {
 
 #[test]
 fn filter_1_for_grayscale_8() {
-    let input = PathBuf::from("tests/files/filter_1_for_grayscale_8.png");
-    let (output, mut opts) = get_opts(&input);
-    opts.filter = HashSet::new();
-    opts.filter.insert(1);
-
     test_it_converts(
-        &input,
-        &output,
-        &opts,
+        "tests/files/filter_1_for_grayscale_8.png",
+        1,
         ColorType::Grayscale,
         BitDepth::Eight,
         ColorType::Grayscale,
@@ -848,15 +587,9 @@ fn filter_1_for_grayscale_8() {
 
 #[test]
 fn filter_2_for_grayscale_8() {
-    let input = PathBuf::from("tests/files/filter_2_for_grayscale_8.png");
-    let (output, mut opts) = get_opts(&input);
-    opts.filter = HashSet::new();
-    opts.filter.insert(2);
-
     test_it_converts(
-        &input,
-        &output,
-        &opts,
+        "tests/files/filter_2_for_grayscale_8.png",
+        2,
         ColorType::Grayscale,
         BitDepth::Eight,
         ColorType::Grayscale,
@@ -866,15 +599,9 @@ fn filter_2_for_grayscale_8() {
 
 #[test]
 fn filter_3_for_grayscale_8() {
-    let input = PathBuf::from("tests/files/filter_3_for_grayscale_8.png");
-    let (output, mut opts) = get_opts(&input);
-    opts.filter = HashSet::new();
-    opts.filter.insert(3);
-
     test_it_converts(
-        &input,
-        &output,
-        &opts,
+        "tests/files/filter_3_for_grayscale_8.png",
+        3,
         ColorType::Grayscale,
         BitDepth::Eight,
         ColorType::Grayscale,
@@ -884,15 +611,9 @@ fn filter_3_for_grayscale_8() {
 
 #[test]
 fn filter_4_for_grayscale_8() {
-    let input = PathBuf::from("tests/files/filter_4_for_grayscale_8.png");
-    let (output, mut opts) = get_opts(&input);
-    opts.filter = HashSet::new();
-    opts.filter.insert(4);
-
     test_it_converts(
-        &input,
-        &output,
-        &opts,
+        "tests/files/filter_4_for_grayscale_8.png",
+        4,
         ColorType::Grayscale,
         BitDepth::Eight,
         ColorType::Grayscale,
@@ -902,15 +623,9 @@ fn filter_4_for_grayscale_8() {
 
 #[test]
 fn filter_5_for_grayscale_8() {
-    let input = PathBuf::from("tests/files/filter_5_for_grayscale_8.png");
-    let (output, mut opts) = get_opts(&input);
-    opts.filter = HashSet::new();
-    opts.filter.insert(5);
-
     test_it_converts(
-        &input,
-        &output,
-        &opts,
+        "tests/files/filter_5_for_grayscale_8.png",
+        5,
         ColorType::Grayscale,
         BitDepth::Eight,
         ColorType::Grayscale,
@@ -920,15 +635,9 @@ fn filter_5_for_grayscale_8() {
 
 #[test]
 fn filter_0_for_palette_4() {
-    let input = PathBuf::from("tests/files/filter_0_for_palette_4.png");
-    let (output, mut opts) = get_opts(&input);
-    opts.filter = HashSet::new();
-    opts.filter.insert(0);
-
     test_it_converts(
-        &input,
-        &output,
-        &opts,
+        "tests/files/filter_0_for_palette_4.png",
+        0,
         ColorType::Indexed,
         BitDepth::Four,
         ColorType::Indexed,
@@ -938,15 +647,9 @@ fn filter_0_for_palette_4() {
 
 #[test]
 fn filter_1_for_palette_4() {
-    let input = PathBuf::from("tests/files/filter_1_for_palette_4.png");
-    let (output, mut opts) = get_opts(&input);
-    opts.filter = HashSet::new();
-    opts.filter.insert(1);
-
     test_it_converts(
-        &input,
-        &output,
-        &opts,
+        "tests/files/filter_1_for_palette_4.png",
+        1,
         ColorType::Indexed,
         BitDepth::Four,
         ColorType::Indexed,
@@ -956,15 +659,9 @@ fn filter_1_for_palette_4() {
 
 #[test]
 fn filter_2_for_palette_4() {
-    let input = PathBuf::from("tests/files/filter_2_for_palette_4.png");
-    let (output, mut opts) = get_opts(&input);
-    opts.filter = HashSet::new();
-    opts.filter.insert(2);
-
     test_it_converts(
-        &input,
-        &output,
-        &opts,
+        "tests/files/filter_2_for_palette_4.png",
+        2,
         ColorType::Indexed,
         BitDepth::Four,
         ColorType::Indexed,
@@ -974,15 +671,9 @@ fn filter_2_for_palette_4() {
 
 #[test]
 fn filter_3_for_palette_4() {
-    let input = PathBuf::from("tests/files/filter_3_for_palette_4.png");
-    let (output, mut opts) = get_opts(&input);
-    opts.filter = HashSet::new();
-    opts.filter.insert(3);
-
     test_it_converts(
-        &input,
-        &output,
-        &opts,
+        "tests/files/filter_3_for_palette_4.png",
+        3,
         ColorType::Indexed,
         BitDepth::Four,
         ColorType::Indexed,
@@ -992,15 +683,9 @@ fn filter_3_for_palette_4() {
 
 #[test]
 fn filter_4_for_palette_4() {
-    let input = PathBuf::from("tests/files/filter_4_for_palette_4.png");
-    let (output, mut opts) = get_opts(&input);
-    opts.filter = HashSet::new();
-    opts.filter.insert(4);
-
     test_it_converts(
-        &input,
-        &output,
-        &opts,
+        "tests/files/filter_4_for_palette_4.png",
+        4,
         ColorType::Indexed,
         BitDepth::Four,
         ColorType::Indexed,
@@ -1010,15 +695,9 @@ fn filter_4_for_palette_4() {
 
 #[test]
 fn filter_5_for_palette_4() {
-    let input = PathBuf::from("tests/files/filter_5_for_palette_4.png");
-    let (output, mut opts) = get_opts(&input);
-    opts.filter = HashSet::new();
-    opts.filter.insert(5);
-
     test_it_converts(
-        &input,
-        &output,
-        &opts,
+        "tests/files/filter_5_for_palette_4.png",
+        5,
         ColorType::Indexed,
         BitDepth::Four,
         ColorType::Indexed,
@@ -1028,15 +707,9 @@ fn filter_5_for_palette_4() {
 
 #[test]
 fn filter_0_for_palette_2() {
-    let input = PathBuf::from("tests/files/filter_0_for_palette_2.png");
-    let (output, mut opts) = get_opts(&input);
-    opts.filter = HashSet::new();
-    opts.filter.insert(0);
-
     test_it_converts(
-        &input,
-        &output,
-        &opts,
+        "tests/files/filter_0_for_palette_2.png",
+        0,
         ColorType::Indexed,
         BitDepth::Two,
         ColorType::Indexed,
@@ -1046,15 +719,9 @@ fn filter_0_for_palette_2() {
 
 #[test]
 fn filter_1_for_palette_2() {
-    let input = PathBuf::from("tests/files/filter_1_for_palette_2.png");
-    let (output, mut opts) = get_opts(&input);
-    opts.filter = HashSet::new();
-    opts.filter.insert(1);
-
     test_it_converts(
-        &input,
-        &output,
-        &opts,
+        "tests/files/filter_1_for_palette_2.png",
+        1,
         ColorType::Indexed,
         BitDepth::Two,
         ColorType::Indexed,
@@ -1064,15 +731,9 @@ fn filter_1_for_palette_2() {
 
 #[test]
 fn filter_2_for_palette_2() {
-    let input = PathBuf::from("tests/files/filter_2_for_palette_2.png");
-    let (output, mut opts) = get_opts(&input);
-    opts.filter = HashSet::new();
-    opts.filter.insert(2);
-
     test_it_converts(
-        &input,
-        &output,
-        &opts,
+        "tests/files/filter_2_for_palette_2.png",
+        2,
         ColorType::Indexed,
         BitDepth::Two,
         ColorType::Indexed,
@@ -1082,15 +743,9 @@ fn filter_2_for_palette_2() {
 
 #[test]
 fn filter_3_for_palette_2() {
-    let input = PathBuf::from("tests/files/filter_3_for_palette_2.png");
-    let (output, mut opts) = get_opts(&input);
-    opts.filter = HashSet::new();
-    opts.filter.insert(3);
-
     test_it_converts(
-        &input,
-        &output,
-        &opts,
+        "tests/files/filter_3_for_palette_2.png",
+        3,
         ColorType::Indexed,
         BitDepth::Two,
         ColorType::Indexed,
@@ -1100,15 +755,9 @@ fn filter_3_for_palette_2() {
 
 #[test]
 fn filter_4_for_palette_2() {
-    let input = PathBuf::from("tests/files/filter_4_for_palette_2.png");
-    let (output, mut opts) = get_opts(&input);
-    opts.filter = HashSet::new();
-    opts.filter.insert(4);
-
     test_it_converts(
-        &input,
-        &output,
-        &opts,
+        "tests/files/filter_4_for_palette_2.png",
+        4,
         ColorType::Indexed,
         BitDepth::Two,
         ColorType::Indexed,
@@ -1118,15 +767,9 @@ fn filter_4_for_palette_2() {
 
 #[test]
 fn filter_5_for_palette_2() {
-    let input = PathBuf::from("tests/files/filter_5_for_palette_2.png");
-    let (output, mut opts) = get_opts(&input);
-    opts.filter = HashSet::new();
-    opts.filter.insert(5);
-
     test_it_converts(
-        &input,
-        &output,
-        &opts,
+        "tests/files/filter_5_for_palette_2.png",
+        5,
         ColorType::Indexed,
         BitDepth::Two,
         ColorType::Indexed,
@@ -1136,15 +779,9 @@ fn filter_5_for_palette_2() {
 
 #[test]
 fn filter_0_for_palette_1() {
-    let input = PathBuf::from("tests/files/filter_0_for_palette_1.png");
-    let (output, mut opts) = get_opts(&input);
-    opts.filter = HashSet::new();
-    opts.filter.insert(0);
-
     test_it_converts(
-        &input,
-        &output,
-        &opts,
+        "tests/files/filter_0_for_palette_1.png",
+        0,
         ColorType::Indexed,
         BitDepth::One,
         ColorType::Indexed,
@@ -1154,15 +791,9 @@ fn filter_0_for_palette_1() {
 
 #[test]
 fn filter_1_for_palette_1() {
-    let input = PathBuf::from("tests/files/filter_1_for_palette_1.png");
-    let (output, mut opts) = get_opts(&input);
-    opts.filter = HashSet::new();
-    opts.filter.insert(1);
-
     test_it_converts(
-        &input,
-        &output,
-        &opts,
+        "tests/files/filter_1_for_palette_1.png",
+        1,
         ColorType::Indexed,
         BitDepth::One,
         ColorType::Indexed,
@@ -1172,15 +803,9 @@ fn filter_1_for_palette_1() {
 
 #[test]
 fn filter_2_for_palette_1() {
-    let input = PathBuf::from("tests/files/filter_2_for_palette_1.png");
-    let (output, mut opts) = get_opts(&input);
-    opts.filter = HashSet::new();
-    opts.filter.insert(2);
-
     test_it_converts(
-        &input,
-        &output,
-        &opts,
+        "tests/files/filter_2_for_palette_1.png",
+        2,
         ColorType::Indexed,
         BitDepth::One,
         ColorType::Indexed,
@@ -1190,15 +815,9 @@ fn filter_2_for_palette_1() {
 
 #[test]
 fn filter_3_for_palette_1() {
-    let input = PathBuf::from("tests/files/filter_3_for_palette_1.png");
-    let (output, mut opts) = get_opts(&input);
-    opts.filter = HashSet::new();
-    opts.filter.insert(3);
-
     test_it_converts(
-        &input,
-        &output,
-        &opts,
+        "tests/files/filter_3_for_palette_1.png",
+        3,
         ColorType::Indexed,
         BitDepth::One,
         ColorType::Indexed,
@@ -1208,15 +827,9 @@ fn filter_3_for_palette_1() {
 
 #[test]
 fn filter_4_for_palette_1() {
-    let input = PathBuf::from("tests/files/filter_4_for_palette_1.png");
-    let (output, mut opts) = get_opts(&input);
-    opts.filter = HashSet::new();
-    opts.filter.insert(4);
-
     test_it_converts(
-        &input,
-        &output,
-        &opts,
+        "tests/files/filter_4_for_palette_1.png",
+        4,
         ColorType::Indexed,
         BitDepth::One,
         ColorType::Indexed,
@@ -1226,15 +839,9 @@ fn filter_4_for_palette_1() {
 
 #[test]
 fn filter_5_for_palette_1() {
-    let input = PathBuf::from("tests/files/filter_5_for_palette_1.png");
-    let (output, mut opts) = get_opts(&input);
-    opts.filter = HashSet::new();
-    opts.filter.insert(5);
-
     test_it_converts(
-        &input,
-        &output,
-        &opts,
+        "tests/files/filter_5_for_palette_1.png",
+        5,
         ColorType::Indexed,
         BitDepth::One,
         ColorType::Indexed,

--- a/tests/flags.rs
+++ b/tests/flags.rs
@@ -22,20 +22,20 @@ fn get_opts(input: &Path) -> (OutFile, oxipng::Options) {
 }
 
 fn test_it_converts(
-    input: &Path,
-    output: &OutFile,
-    opts: &oxipng::Options,
+    input: PathBuf,
+    output: OutFile,
+    opts: oxipng::Options,
     color_type_in: ColorType,
     bit_depth_in: BitDepth,
     color_type_out: ColorType,
     bit_depth_out: BitDepth,
 ) {
-    let png = png::PngData::new(input, opts.fix_errors).unwrap();
+    let png = png::PngData::new(&input, opts.fix_errors).unwrap();
 
     assert_eq!(png.ihdr_data.color_type, color_type_in);
     assert_eq!(png.ihdr_data.bit_depth, bit_depth_in);
 
-    match oxipng::optimize(input, output, opts) {
+    match oxipng::optimize(&input, &output, &opts) {
         Ok(_) => (),
         Err(x) => panic!("{}", x),
     };
@@ -63,9 +63,9 @@ fn verbose_mode() {
     opts.verbosity = Some(1);
 
     test_it_converts(
-        &input,
-        &output,
-        &opts,
+        input,
+        output,
+        opts,
         ColorType::RGB,
         BitDepth::Eight,
         ColorType::RGB,
@@ -377,9 +377,9 @@ fn preserve_attrs() {
     opts.preserve_attrs = true;
 
     test_it_converts(
-        &input,
-        &output,
-        &opts,
+        input,
+        output,
+        opts,
         ColorType::RGB,
         BitDepth::Eight,
         ColorType::RGB,
@@ -429,9 +429,8 @@ fn zopfli_mode() {
     opts.deflate = Deflaters::Zopfli;
 
     test_it_converts(
-        &input,
-        &output,
-        &opts,
+        input,
+        output, opts,
         ColorType::RGB,
         BitDepth::Eight,
         ColorType::RGB,

--- a/tests/interlaced.rs
+++ b/tests/interlaced.rs
@@ -20,21 +20,21 @@ fn get_opts(input: &Path) -> (OutFile, oxipng::Options) {
 }
 
 fn test_it_converts(
-    input: &Path,
-    output: &OutFile,
-    opts: &oxipng::Options,
+    input: &str,
     color_type_in: ColorType,
     bit_depth_in: BitDepth,
     color_type_out: ColorType,
     bit_depth_out: BitDepth,
 ) {
-    let png = png::PngData::new(input, opts.fix_errors).unwrap();
+    let input = PathBuf::from(input);
+    let (output, opts) = get_opts(&input);
+    let png = png::PngData::new(&input, opts.fix_errors).unwrap();
 
     assert_eq!(png.ihdr_data.color_type, color_type_in);
     assert_eq!(png.ihdr_data.bit_depth, bit_depth_in);
     assert_eq!(png.ihdr_data.interlaced, 1);
 
-    match oxipng::optimize(input, output, opts) {
+    match oxipng::optimize(&input, &output, &opts) {
         Ok(_) => (),
         Err(x) => panic!("{}", x),
     };
@@ -57,13 +57,8 @@ fn test_it_converts(
 
 #[test]
 fn interlaced_rgba_16_should_be_rgba_16() {
-    let input = PathBuf::from("tests/files/interlaced_rgba_16_should_be_rgba_16.png");
-    let (output, opts) = get_opts(&input);
-
     test_it_converts(
-        &input,
-        &output,
-        &opts,
+        "tests/files/interlaced_rgba_16_should_be_rgba_16.png",
         ColorType::RGBA,
         BitDepth::Sixteen,
         ColorType::RGBA,
@@ -73,13 +68,8 @@ fn interlaced_rgba_16_should_be_rgba_16() {
 
 #[test]
 fn interlaced_rgba_16_should_be_rgba_8() {
-    let input = PathBuf::from("tests/files/interlaced_rgba_16_should_be_rgba_8.png");
-    let (output, opts) = get_opts(&input);
-
     test_it_converts(
-        &input,
-        &output,
-        &opts,
+        "tests/files/interlaced_rgba_16_should_be_rgba_8.png",
         ColorType::RGBA,
         BitDepth::Sixteen,
         ColorType::RGBA,
@@ -89,13 +79,8 @@ fn interlaced_rgba_16_should_be_rgba_8() {
 
 #[test]
 fn interlaced_rgba_8_should_be_rgba_8() {
-    let input = PathBuf::from("tests/files/interlaced_rgba_8_should_be_rgba_8.png");
-    let (output, opts) = get_opts(&input);
-
     test_it_converts(
-        &input,
-        &output,
-        &opts,
+        "tests/files/interlaced_rgba_8_should_be_rgba_8.png",
         ColorType::RGBA,
         BitDepth::Eight,
         ColorType::RGBA,
@@ -105,13 +90,8 @@ fn interlaced_rgba_8_should_be_rgba_8() {
 
 #[test]
 fn interlaced_rgba_16_should_be_rgb_16() {
-    let input = PathBuf::from("tests/files/interlaced_rgba_16_should_be_rgb_16.png");
-    let (output, opts) = get_opts(&input);
-
     test_it_converts(
-        &input,
-        &output,
-        &opts,
+        "tests/files/interlaced_rgba_16_should_be_rgb_16.png",
         ColorType::RGBA,
         BitDepth::Sixteen,
         ColorType::RGB,
@@ -121,13 +101,8 @@ fn interlaced_rgba_16_should_be_rgb_16() {
 
 #[test]
 fn interlaced_rgba_16_should_be_rgb_8() {
-    let input = PathBuf::from("tests/files/interlaced_rgba_16_should_be_rgb_8.png");
-    let (output, opts) = get_opts(&input);
-
     test_it_converts(
-        &input,
-        &output,
-        &opts,
+        "tests/files/interlaced_rgba_16_should_be_rgb_8.png",
         ColorType::RGBA,
         BitDepth::Sixteen,
         ColorType::RGB,
@@ -137,13 +112,8 @@ fn interlaced_rgba_16_should_be_rgb_8() {
 
 #[test]
 fn interlaced_rgba_8_should_be_rgb_8() {
-    let input = PathBuf::from("tests/files/interlaced_rgba_8_should_be_rgb_8.png");
-    let (output, opts) = get_opts(&input);
-
     test_it_converts(
-        &input,
-        &output,
-        &opts,
+        "tests/files/interlaced_rgba_8_should_be_rgb_8.png",
         ColorType::RGBA,
         BitDepth::Eight,
         ColorType::RGB,
@@ -153,13 +123,8 @@ fn interlaced_rgba_8_should_be_rgb_8() {
 
 #[test]
 fn interlaced_rgba_16_should_be_palette_8() {
-    let input = PathBuf::from("tests/files/interlaced_rgba_16_should_be_palette_8.png");
-    let (output, opts) = get_opts(&input);
-
     test_it_converts(
-        &input,
-        &output,
-        &opts,
+        "tests/files/interlaced_rgba_16_should_be_palette_8.png",
         ColorType::RGBA,
         BitDepth::Sixteen,
         ColorType::Indexed,
@@ -169,13 +134,8 @@ fn interlaced_rgba_16_should_be_palette_8() {
 
 #[test]
 fn interlaced_rgba_8_should_be_palette_8() {
-    let input = PathBuf::from("tests/files/interlaced_rgba_8_should_be_palette_8.png");
-    let (output, opts) = get_opts(&input);
-
     test_it_converts(
-        &input,
-        &output,
-        &opts,
+        "tests/files/interlaced_rgba_8_should_be_palette_8.png",
         ColorType::RGBA,
         BitDepth::Eight,
         ColorType::Indexed,
@@ -185,13 +145,8 @@ fn interlaced_rgba_8_should_be_palette_8() {
 
 #[test]
 fn interlaced_rgba_16_should_be_palette_4() {
-    let input = PathBuf::from("tests/files/interlaced_rgba_16_should_be_palette_4.png");
-    let (output, opts) = get_opts(&input);
-
     test_it_converts(
-        &input,
-        &output,
-        &opts,
+        "tests/files/interlaced_rgba_16_should_be_palette_4.png",
         ColorType::RGBA,
         BitDepth::Sixteen,
         ColorType::Indexed,
@@ -201,13 +156,8 @@ fn interlaced_rgba_16_should_be_palette_4() {
 
 #[test]
 fn interlaced_rgba_8_should_be_palette_4() {
-    let input = PathBuf::from("tests/files/interlaced_rgba_8_should_be_palette_4.png");
-    let (output, opts) = get_opts(&input);
-
     test_it_converts(
-        &input,
-        &output,
-        &opts,
+        "tests/files/interlaced_rgba_8_should_be_palette_4.png",
         ColorType::RGBA,
         BitDepth::Eight,
         ColorType::Indexed,
@@ -217,13 +167,8 @@ fn interlaced_rgba_8_should_be_palette_4() {
 
 #[test]
 fn interlaced_rgba_16_should_be_palette_2() {
-    let input = PathBuf::from("tests/files/interlaced_rgba_16_should_be_palette_2.png");
-    let (output, opts) = get_opts(&input);
-
     test_it_converts(
-        &input,
-        &output,
-        &opts,
+        "tests/files/interlaced_rgba_16_should_be_palette_2.png",
         ColorType::RGBA,
         BitDepth::Sixteen,
         ColorType::Indexed,
@@ -233,13 +178,8 @@ fn interlaced_rgba_16_should_be_palette_2() {
 
 #[test]
 fn interlaced_rgba_8_should_be_palette_2() {
-    let input = PathBuf::from("tests/files/interlaced_rgba_8_should_be_palette_2.png");
-    let (output, opts) = get_opts(&input);
-
     test_it_converts(
-        &input,
-        &output,
-        &opts,
+        "tests/files/interlaced_rgba_8_should_be_palette_2.png",
         ColorType::RGBA,
         BitDepth::Eight,
         ColorType::Indexed,
@@ -249,13 +189,8 @@ fn interlaced_rgba_8_should_be_palette_2() {
 
 #[test]
 fn interlaced_rgba_16_should_be_palette_1() {
-    let input = PathBuf::from("tests/files/interlaced_rgba_16_should_be_palette_1.png");
-    let (output, opts) = get_opts(&input);
-
     test_it_converts(
-        &input,
-        &output,
-        &opts,
+        "tests/files/interlaced_rgba_16_should_be_palette_1.png",
         ColorType::RGBA,
         BitDepth::Sixteen,
         ColorType::Indexed,
@@ -265,13 +200,8 @@ fn interlaced_rgba_16_should_be_palette_1() {
 
 #[test]
 fn interlaced_rgba_8_should_be_palette_1() {
-    let input = PathBuf::from("tests/files/interlaced_rgba_8_should_be_palette_1.png");
-    let (output, opts) = get_opts(&input);
-
     test_it_converts(
-        &input,
-        &output,
-        &opts,
+        "tests/files/interlaced_rgba_8_should_be_palette_1.png",
         ColorType::RGBA,
         BitDepth::Eight,
         ColorType::Indexed,
@@ -281,13 +211,8 @@ fn interlaced_rgba_8_should_be_palette_1() {
 
 #[test]
 fn interlaced_rgba_16_should_be_grayscale_alpha_16() {
-    let input = PathBuf::from("tests/files/interlaced_rgba_16_should_be_grayscale_alpha_16.png");
-    let (output, opts) = get_opts(&input);
-
     test_it_converts(
-        &input,
-        &output,
-        &opts,
+        "tests/files/interlaced_rgba_16_should_be_grayscale_alpha_16.png",
         ColorType::RGBA,
         BitDepth::Sixteen,
         ColorType::GrayscaleAlpha,
@@ -297,13 +222,8 @@ fn interlaced_rgba_16_should_be_grayscale_alpha_16() {
 
 #[test]
 fn interlaced_rgba_16_should_be_grayscale_alpha_8() {
-    let input = PathBuf::from("tests/files/interlaced_rgba_16_should_be_grayscale_alpha_8.png");
-    let (output, opts) = get_opts(&input);
-
     test_it_converts(
-        &input,
-        &output,
-        &opts,
+        "tests/files/interlaced_rgba_16_should_be_grayscale_alpha_8.png",
         ColorType::RGBA,
         BitDepth::Sixteen,
         ColorType::GrayscaleAlpha,
@@ -313,13 +233,8 @@ fn interlaced_rgba_16_should_be_grayscale_alpha_8() {
 
 #[test]
 fn interlaced_rgba_8_should_be_grayscale_alpha_8() {
-    let input = PathBuf::from("tests/files/interlaced_rgba_8_should_be_grayscale_alpha_8.png");
-    let (output, opts) = get_opts(&input);
-
     test_it_converts(
-        &input,
-        &output,
-        &opts,
+        "tests/files/interlaced_rgba_8_should_be_grayscale_alpha_8.png",
         ColorType::RGBA,
         BitDepth::Eight,
         ColorType::GrayscaleAlpha,
@@ -329,13 +244,8 @@ fn interlaced_rgba_8_should_be_grayscale_alpha_8() {
 
 #[test]
 fn interlaced_rgba_16_should_be_grayscale_16() {
-    let input = PathBuf::from("tests/files/interlaced_rgba_16_should_be_grayscale_16.png");
-    let (output, opts) = get_opts(&input);
-
     test_it_converts(
-        &input,
-        &output,
-        &opts,
+        "tests/files/interlaced_rgba_16_should_be_grayscale_16.png",
         ColorType::RGBA,
         BitDepth::Sixteen,
         ColorType::Grayscale,
@@ -345,13 +255,8 @@ fn interlaced_rgba_16_should_be_grayscale_16() {
 
 #[test]
 fn interlaced_rgba_16_should_be_grayscale_8() {
-    let input = PathBuf::from("tests/files/interlaced_rgba_16_should_be_grayscale_8.png");
-    let (output, opts) = get_opts(&input);
-
     test_it_converts(
-        &input,
-        &output,
-        &opts,
+        "tests/files/interlaced_rgba_16_should_be_grayscale_8.png",
         ColorType::RGBA,
         BitDepth::Sixteen,
         ColorType::Grayscale,
@@ -361,13 +266,8 @@ fn interlaced_rgba_16_should_be_grayscale_8() {
 
 #[test]
 fn interlaced_rgba_8_should_be_grayscale_8() {
-    let input = PathBuf::from("tests/files/interlaced_rgba_8_should_be_grayscale_8.png");
-    let (output, opts) = get_opts(&input);
-
     test_it_converts(
-        &input,
-        &output,
-        &opts,
+        "tests/files/interlaced_rgba_8_should_be_grayscale_8.png",
         ColorType::RGBA,
         BitDepth::Eight,
         ColorType::Grayscale,
@@ -377,13 +277,8 @@ fn interlaced_rgba_8_should_be_grayscale_8() {
 
 #[test]
 fn interlaced_rgb_16_should_be_rgb_16() {
-    let input = PathBuf::from("tests/files/interlaced_rgb_16_should_be_rgb_16.png");
-    let (output, opts) = get_opts(&input);
-
     test_it_converts(
-        &input,
-        &output,
-        &opts,
+        "tests/files/interlaced_rgb_16_should_be_rgb_16.png",
         ColorType::RGB,
         BitDepth::Sixteen,
         ColorType::RGB,
@@ -393,13 +288,8 @@ fn interlaced_rgb_16_should_be_rgb_16() {
 
 #[test]
 fn interlaced_rgb_16_should_be_rgb_8() {
-    let input = PathBuf::from("tests/files/interlaced_rgb_16_should_be_rgb_8.png");
-    let (output, opts) = get_opts(&input);
-
     test_it_converts(
-        &input,
-        &output,
-        &opts,
+        "tests/files/interlaced_rgb_16_should_be_rgb_8.png",
         ColorType::RGB,
         BitDepth::Sixteen,
         ColorType::RGB,
@@ -409,13 +299,8 @@ fn interlaced_rgb_16_should_be_rgb_8() {
 
 #[test]
 fn interlaced_rgb_8_should_be_rgb_8() {
-    let input = PathBuf::from("tests/files/interlaced_rgb_8_should_be_rgb_8.png");
-    let (output, opts) = get_opts(&input);
-
     test_it_converts(
-        &input,
-        &output,
-        &opts,
+        "tests/files/interlaced_rgb_8_should_be_rgb_8.png",
         ColorType::RGB,
         BitDepth::Eight,
         ColorType::RGB,
@@ -425,13 +310,8 @@ fn interlaced_rgb_8_should_be_rgb_8() {
 
 #[test]
 fn interlaced_rgb_16_should_be_palette_8() {
-    let input = PathBuf::from("tests/files/interlaced_rgb_16_should_be_palette_8.png");
-    let (output, opts) = get_opts(&input);
-
     test_it_converts(
-        &input,
-        &output,
-        &opts,
+        "tests/files/interlaced_rgb_16_should_be_palette_8.png",
         ColorType::RGB,
         BitDepth::Sixteen,
         ColorType::Indexed,
@@ -441,13 +321,8 @@ fn interlaced_rgb_16_should_be_palette_8() {
 
 #[test]
 fn interlaced_rgb_8_should_be_palette_8() {
-    let input = PathBuf::from("tests/files/interlaced_rgb_8_should_be_palette_8.png");
-    let (output, opts) = get_opts(&input);
-
     test_it_converts(
-        &input,
-        &output,
-        &opts,
+        "tests/files/interlaced_rgb_8_should_be_palette_8.png",
         ColorType::RGB,
         BitDepth::Eight,
         ColorType::Indexed,
@@ -457,13 +332,8 @@ fn interlaced_rgb_8_should_be_palette_8() {
 
 #[test]
 fn interlaced_rgb_16_should_be_palette_4() {
-    let input = PathBuf::from("tests/files/interlaced_rgb_16_should_be_palette_4.png");
-    let (output, opts) = get_opts(&input);
-
     test_it_converts(
-        &input,
-        &output,
-        &opts,
+        "tests/files/interlaced_rgb_16_should_be_palette_4.png",
         ColorType::RGB,
         BitDepth::Sixteen,
         ColorType::Indexed,
@@ -473,13 +343,8 @@ fn interlaced_rgb_16_should_be_palette_4() {
 
 #[test]
 fn interlaced_rgb_8_should_be_palette_4() {
-    let input = PathBuf::from("tests/files/interlaced_rgb_8_should_be_palette_4.png");
-    let (output, opts) = get_opts(&input);
-
     test_it_converts(
-        &input,
-        &output,
-        &opts,
+        "tests/files/interlaced_rgb_8_should_be_palette_4.png",
         ColorType::RGB,
         BitDepth::Eight,
         ColorType::Indexed,
@@ -489,13 +354,8 @@ fn interlaced_rgb_8_should_be_palette_4() {
 
 #[test]
 fn interlaced_rgb_16_should_be_palette_2() {
-    let input = PathBuf::from("tests/files/interlaced_rgb_16_should_be_palette_2.png");
-    let (output, opts) = get_opts(&input);
-
     test_it_converts(
-        &input,
-        &output,
-        &opts,
+        "tests/files/interlaced_rgb_16_should_be_palette_2.png",
         ColorType::RGB,
         BitDepth::Sixteen,
         ColorType::Indexed,
@@ -505,13 +365,8 @@ fn interlaced_rgb_16_should_be_palette_2() {
 
 #[test]
 fn interlaced_rgb_8_should_be_palette_2() {
-    let input = PathBuf::from("tests/files/interlaced_rgb_8_should_be_palette_2.png");
-    let (output, opts) = get_opts(&input);
-
     test_it_converts(
-        &input,
-        &output,
-        &opts,
+        "tests/files/interlaced_rgb_8_should_be_palette_2.png",
         ColorType::RGB,
         BitDepth::Eight,
         ColorType::Indexed,
@@ -521,13 +376,8 @@ fn interlaced_rgb_8_should_be_palette_2() {
 
 #[test]
 fn interlaced_rgb_16_should_be_palette_1() {
-    let input = PathBuf::from("tests/files/interlaced_rgb_16_should_be_palette_1.png");
-    let (output, opts) = get_opts(&input);
-
     test_it_converts(
-        &input,
-        &output,
-        &opts,
+        "tests/files/interlaced_rgb_16_should_be_palette_1.png",
         ColorType::RGB,
         BitDepth::Sixteen,
         ColorType::Indexed,
@@ -537,13 +387,8 @@ fn interlaced_rgb_16_should_be_palette_1() {
 
 #[test]
 fn interlaced_rgb_8_should_be_palette_1() {
-    let input = PathBuf::from("tests/files/interlaced_rgb_8_should_be_palette_1.png");
-    let (output, opts) = get_opts(&input);
-
     test_it_converts(
-        &input,
-        &output,
-        &opts,
+        "tests/files/interlaced_rgb_8_should_be_palette_1.png",
         ColorType::RGB,
         BitDepth::Eight,
         ColorType::Indexed,
@@ -553,13 +398,8 @@ fn interlaced_rgb_8_should_be_palette_1() {
 
 #[test]
 fn interlaced_rgb_16_should_be_grayscale_16() {
-    let input = PathBuf::from("tests/files/interlaced_rgb_16_should_be_grayscale_16.png");
-    let (output, opts) = get_opts(&input);
-
     test_it_converts(
-        &input,
-        &output,
-        &opts,
+        "tests/files/interlaced_rgb_16_should_be_grayscale_16.png",
         ColorType::RGB,
         BitDepth::Sixteen,
         ColorType::Grayscale,
@@ -569,13 +409,8 @@ fn interlaced_rgb_16_should_be_grayscale_16() {
 
 #[test]
 fn interlaced_rgb_16_should_be_grayscale_8() {
-    let input = PathBuf::from("tests/files/interlaced_rgb_16_should_be_grayscale_8.png");
-    let (output, opts) = get_opts(&input);
-
     test_it_converts(
-        &input,
-        &output,
-        &opts,
+        "tests/files/interlaced_rgb_16_should_be_grayscale_8.png",
         ColorType::RGB,
         BitDepth::Sixteen,
         ColorType::Grayscale,
@@ -585,13 +420,8 @@ fn interlaced_rgb_16_should_be_grayscale_8() {
 
 #[test]
 fn interlaced_rgb_8_should_be_grayscale_8() {
-    let input = PathBuf::from("tests/files/interlaced_rgb_8_should_be_grayscale_8.png");
-    let (output, opts) = get_opts(&input);
-
     test_it_converts(
-        &input,
-        &output,
-        &opts,
+        "tests/files/interlaced_rgb_8_should_be_grayscale_8.png",
         ColorType::RGB,
         BitDepth::Eight,
         ColorType::Grayscale,
@@ -601,13 +431,8 @@ fn interlaced_rgb_8_should_be_grayscale_8() {
 
 #[test]
 fn interlaced_palette_8_should_be_palette_8() {
-    let input = PathBuf::from("tests/files/interlaced_palette_8_should_be_palette_8.png");
-    let (output, opts) = get_opts(&input);
-
     test_it_converts(
-        &input,
-        &output,
-        &opts,
+        "tests/files/interlaced_palette_8_should_be_palette_8.png",
         ColorType::Indexed,
         BitDepth::Eight,
         ColorType::Indexed,
@@ -617,13 +442,8 @@ fn interlaced_palette_8_should_be_palette_8() {
 
 #[test]
 fn interlaced_palette_8_should_be_palette_4() {
-    let input = PathBuf::from("tests/files/interlaced_palette_8_should_be_palette_4.png");
-    let (output, opts) = get_opts(&input);
-
     test_it_converts(
-        &input,
-        &output,
-        &opts,
+        "tests/files/interlaced_palette_8_should_be_palette_4.png",
         ColorType::Indexed,
         BitDepth::Eight,
         ColorType::Indexed,
@@ -633,13 +453,8 @@ fn interlaced_palette_8_should_be_palette_4() {
 
 #[test]
 fn interlaced_palette_4_should_be_palette_4() {
-    let input = PathBuf::from("tests/files/interlaced_palette_4_should_be_palette_4.png");
-    let (output, opts) = get_opts(&input);
-
     test_it_converts(
-        &input,
-        &output,
-        &opts,
+        "tests/files/interlaced_palette_4_should_be_palette_4.png",
         ColorType::Indexed,
         BitDepth::Four,
         ColorType::Indexed,
@@ -649,13 +464,8 @@ fn interlaced_palette_4_should_be_palette_4() {
 
 #[test]
 fn interlaced_palette_8_should_be_palette_2() {
-    let input = PathBuf::from("tests/files/interlaced_palette_8_should_be_palette_2.png");
-    let (output, opts) = get_opts(&input);
-
     test_it_converts(
-        &input,
-        &output,
-        &opts,
+        "tests/files/interlaced_palette_8_should_be_palette_2.png",
         ColorType::Indexed,
         BitDepth::Eight,
         ColorType::Indexed,
@@ -665,13 +475,8 @@ fn interlaced_palette_8_should_be_palette_2() {
 
 #[test]
 fn interlaced_palette_4_should_be_palette_2() {
-    let input = PathBuf::from("tests/files/interlaced_palette_4_should_be_palette_2.png");
-    let (output, opts) = get_opts(&input);
-
     test_it_converts(
-        &input,
-        &output,
-        &opts,
+        "tests/files/interlaced_palette_4_should_be_palette_2.png",
         ColorType::Indexed,
         BitDepth::Four,
         ColorType::Indexed,
@@ -681,13 +486,8 @@ fn interlaced_palette_4_should_be_palette_2() {
 
 #[test]
 fn interlaced_palette_2_should_be_palette_2() {
-    let input = PathBuf::from("tests/files/interlaced_palette_2_should_be_palette_2.png");
-    let (output, opts) = get_opts(&input);
-
     test_it_converts(
-        &input,
-        &output,
-        &opts,
+        "tests/files/interlaced_palette_2_should_be_palette_2.png",
         ColorType::Indexed,
         BitDepth::Two,
         ColorType::Indexed,
@@ -697,13 +497,8 @@ fn interlaced_palette_2_should_be_palette_2() {
 
 #[test]
 fn interlaced_palette_8_should_be_palette_1() {
-    let input = PathBuf::from("tests/files/interlaced_palette_8_should_be_palette_1.png");
-    let (output, opts) = get_opts(&input);
-
     test_it_converts(
-        &input,
-        &output,
-        &opts,
+        "tests/files/interlaced_palette_8_should_be_palette_1.png",
         ColorType::Indexed,
         BitDepth::Eight,
         ColorType::Indexed,
@@ -713,13 +508,8 @@ fn interlaced_palette_8_should_be_palette_1() {
 
 #[test]
 fn interlaced_palette_4_should_be_palette_1() {
-    let input = PathBuf::from("tests/files/interlaced_palette_4_should_be_palette_1.png");
-    let (output, opts) = get_opts(&input);
-
     test_it_converts(
-        &input,
-        &output,
-        &opts,
+        "tests/files/interlaced_palette_4_should_be_palette_1.png",
         ColorType::Indexed,
         BitDepth::Four,
         ColorType::Indexed,
@@ -729,13 +519,8 @@ fn interlaced_palette_4_should_be_palette_1() {
 
 #[test]
 fn interlaced_palette_2_should_be_palette_1() {
-    let input = PathBuf::from("tests/files/interlaced_palette_2_should_be_palette_1.png");
-    let (output, opts) = get_opts(&input);
-
     test_it_converts(
-        &input,
-        &output,
-        &opts,
+        "tests/files/interlaced_palette_2_should_be_palette_1.png",
         ColorType::Indexed,
         BitDepth::Two,
         ColorType::Indexed,
@@ -745,13 +530,8 @@ fn interlaced_palette_2_should_be_palette_1() {
 
 #[test]
 fn interlaced_palette_1_should_be_palette_1() {
-    let input = PathBuf::from("tests/files/interlaced_palette_1_should_be_palette_1.png");
-    let (output, opts) = get_opts(&input);
-
     test_it_converts(
-        &input,
-        &output,
-        &opts,
+        "tests/files/interlaced_palette_1_should_be_palette_1.png",
         ColorType::Indexed,
         BitDepth::One,
         ColorType::Indexed,
@@ -761,14 +541,8 @@ fn interlaced_palette_1_should_be_palette_1() {
 
 #[test]
 fn interlaced_grayscale_alpha_16_should_be_grayscale_alpha_16() {
-    let input =
-        PathBuf::from("tests/files/interlaced_grayscale_alpha_16_should_be_grayscale_alpha_16.png");
-    let (output, opts) = get_opts(&input);
-
     test_it_converts(
-        &input,
-        &output,
-        &opts,
+        "tests/files/interlaced_grayscale_alpha_16_should_be_grayscale_alpha_16.png",
         ColorType::GrayscaleAlpha,
         BitDepth::Sixteen,
         ColorType::GrayscaleAlpha,
@@ -778,14 +552,8 @@ fn interlaced_grayscale_alpha_16_should_be_grayscale_alpha_16() {
 
 #[test]
 fn interlaced_grayscale_alpha_16_should_be_grayscale_alpha_8() {
-    let input =
-        PathBuf::from("tests/files/interlaced_grayscale_alpha_16_should_be_grayscale_alpha_8.png");
-    let (output, opts) = get_opts(&input);
-
     test_it_converts(
-        &input,
-        &output,
-        &opts,
+        "tests/files/interlaced_grayscale_alpha_16_should_be_grayscale_alpha_8.png",
         ColorType::GrayscaleAlpha,
         BitDepth::Sixteen,
         ColorType::GrayscaleAlpha,
@@ -795,14 +563,8 @@ fn interlaced_grayscale_alpha_16_should_be_grayscale_alpha_8() {
 
 #[test]
 fn interlaced_grayscale_alpha_8_should_be_grayscale_alpha_8() {
-    let input =
-        PathBuf::from("tests/files/interlaced_grayscale_alpha_8_should_be_grayscale_alpha_8.png");
-    let (output, opts) = get_opts(&input);
-
     test_it_converts(
-        &input,
-        &output,
-        &opts,
+        "tests/files/interlaced_grayscale_alpha_8_should_be_grayscale_alpha_8.png",
         ColorType::GrayscaleAlpha,
         BitDepth::Eight,
         ColorType::GrayscaleAlpha,
@@ -812,14 +574,8 @@ fn interlaced_grayscale_alpha_8_should_be_grayscale_alpha_8() {
 
 #[test]
 fn interlaced_grayscale_alpha_16_should_be_grayscale_16() {
-    let input =
-        PathBuf::from("tests/files/interlaced_grayscale_alpha_16_should_be_grayscale_16.png");
-    let (output, opts) = get_opts(&input);
-
     test_it_converts(
-        &input,
-        &output,
-        &opts,
+        "tests/files/interlaced_grayscale_alpha_16_should_be_grayscale_16.png",
         ColorType::GrayscaleAlpha,
         BitDepth::Sixteen,
         ColorType::Grayscale,
@@ -829,14 +585,8 @@ fn interlaced_grayscale_alpha_16_should_be_grayscale_16() {
 
 #[test]
 fn interlaced_grayscale_alpha_16_should_be_grayscale_8() {
-    let input =
-        PathBuf::from("tests/files/interlaced_grayscale_alpha_16_should_be_grayscale_8.png");
-    let (output, opts) = get_opts(&input);
-
     test_it_converts(
-        &input,
-        &output,
-        &opts,
+        "tests/files/interlaced_grayscale_alpha_16_should_be_grayscale_8.png",
         ColorType::GrayscaleAlpha,
         BitDepth::Sixteen,
         ColorType::Grayscale,
@@ -846,13 +596,8 @@ fn interlaced_grayscale_alpha_16_should_be_grayscale_8() {
 
 #[test]
 fn interlaced_grayscale_alpha_8_should_be_grayscale_8() {
-    let input = PathBuf::from("tests/files/interlaced_grayscale_alpha_8_should_be_grayscale_8.png");
-    let (output, opts) = get_opts(&input);
-
     test_it_converts(
-        &input,
-        &output,
-        &opts,
+        "tests/files/interlaced_grayscale_alpha_8_should_be_grayscale_8.png",
         ColorType::GrayscaleAlpha,
         BitDepth::Eight,
         ColorType::Grayscale,
@@ -862,13 +607,8 @@ fn interlaced_grayscale_alpha_8_should_be_grayscale_8() {
 
 #[test]
 fn interlaced_grayscale_16_should_be_grayscale_16() {
-    let input = PathBuf::from("tests/files/interlaced_grayscale_16_should_be_grayscale_16.png");
-    let (output, opts) = get_opts(&input);
-
     test_it_converts(
-        &input,
-        &output,
-        &opts,
+        "tests/files/interlaced_grayscale_16_should_be_grayscale_16.png",
         ColorType::Grayscale,
         BitDepth::Sixteen,
         ColorType::Grayscale,
@@ -878,13 +618,8 @@ fn interlaced_grayscale_16_should_be_grayscale_16() {
 
 #[test]
 fn interlaced_grayscale_16_should_be_grayscale_8() {
-    let input = PathBuf::from("tests/files/interlaced_grayscale_16_should_be_grayscale_8.png");
-    let (output, opts) = get_opts(&input);
-
     test_it_converts(
-        &input,
-        &output,
-        &opts,
+        "tests/files/interlaced_grayscale_16_should_be_grayscale_8.png",
         ColorType::Grayscale,
         BitDepth::Sixteen,
         ColorType::Grayscale,
@@ -894,13 +629,8 @@ fn interlaced_grayscale_16_should_be_grayscale_8() {
 
 #[test]
 fn interlaced_grayscale_8_should_be_grayscale_8() {
-    let input = PathBuf::from("tests/files/interlaced_grayscale_8_should_be_grayscale_8.png");
-    let (output, opts) = get_opts(&input);
-
     test_it_converts(
-        &input,
-        &output,
-        &opts,
+        "tests/files/interlaced_grayscale_8_should_be_grayscale_8.png",
         ColorType::Grayscale,
         BitDepth::Eight,
         ColorType::Grayscale,
@@ -910,13 +640,8 @@ fn interlaced_grayscale_8_should_be_grayscale_8() {
 
 #[test]
 fn interlaced_small_files() {
-    let input = PathBuf::from("tests/files/interlaced_small_files.png");
-    let (output, opts) = get_opts(&input);
-
     test_it_converts(
-        &input,
-        &output,
-        &opts,
+        "tests/files/interlaced_small_files.png",
         ColorType::Indexed,
         BitDepth::Eight,
         ColorType::Indexed,
@@ -926,13 +651,8 @@ fn interlaced_small_files() {
 
 #[test]
 fn interlaced_odd_width() {
-    let input = PathBuf::from("tests/files/interlaced_odd_width.png");
-    let (output, opts) = get_opts(&input);
-
     test_it_converts(
-        &input,
-        &output,
-        &opts,
+        "tests/files/interlaced_odd_width.png",
         ColorType::RGB,
         BitDepth::Eight,
         ColorType::RGB,

--- a/tests/reduction.rs
+++ b/tests/reduction.rs
@@ -20,21 +20,25 @@ fn get_opts(input: &Path) -> (OutFile, oxipng::Options) {
 }
 
 fn test_it_converts(
-    input: &Path,
-    output: &OutFile,
-    opts: &oxipng::Options,
+    input: &str,
+    alpha: Option<AlphaOptim>,
     color_type_in: ColorType,
     bit_depth_in: BitDepth,
     color_type_out: ColorType,
     bit_depth_out: BitDepth,
 ) {
-    let png = png::PngData::new(input, opts.fix_errors).unwrap();
+    let input = PathBuf::from(input);
+    let (output, mut opts) = get_opts(&input);
+    if let Some(alpha) = alpha {
+        opts.alphas = [alpha].iter().cloned().collect();
+    }
+    let png = png::PngData::new(&input, opts.fix_errors).unwrap();
 
     assert_eq!(png.ihdr_data.color_type, color_type_in);
     assert_eq!(png.ihdr_data.bit_depth, bit_depth_in);
     assert_eq!(png.ihdr_data.interlaced, 0);
 
-    match oxipng::optimize(input, output, opts) {
+    match oxipng::optimize(&input, &output, &opts) {
         Ok(_) => (),
         Err(x) => panic!("{}", x),
     };
@@ -57,13 +61,9 @@ fn test_it_converts(
 
 #[test]
 fn rgba_16_should_be_rgba_16() {
-    let input = PathBuf::from("tests/files/rgba_16_should_be_rgba_16.png");
-    let (output, opts) = get_opts(&input);
-
     test_it_converts(
-        &input,
-        &output,
-        &opts,
+        "tests/files/rgba_16_should_be_rgba_16.png",
+        None,
         ColorType::RGBA,
         BitDepth::Sixteen,
         ColorType::RGBA,
@@ -73,13 +73,9 @@ fn rgba_16_should_be_rgba_16() {
 
 #[test]
 fn rgba_16_should_be_rgba_8() {
-    let input = PathBuf::from("tests/files/rgba_16_should_be_rgba_8.png");
-    let (output, opts) = get_opts(&input);
-
     test_it_converts(
-        &input,
-        &output,
-        &opts,
+        "tests/files/rgba_16_should_be_rgba_8.png",
+        None,
         ColorType::RGBA,
         BitDepth::Sixteen,
         ColorType::RGBA,
@@ -89,13 +85,9 @@ fn rgba_16_should_be_rgba_8() {
 
 #[test]
 fn rgba_8_should_be_rgba_8() {
-    let input = PathBuf::from("tests/files/rgba_8_should_be_rgba_8.png");
-    let (output, opts) = get_opts(&input);
-
     test_it_converts(
-        &input,
-        &output,
-        &opts,
+        "tests/files/rgba_8_should_be_rgba_8.png",
+        None,
         ColorType::RGBA,
         BitDepth::Eight,
         ColorType::RGBA,
@@ -105,13 +97,9 @@ fn rgba_8_should_be_rgba_8() {
 
 #[test]
 fn rgba_16_should_be_rgb_16() {
-    let input = PathBuf::from("tests/files/rgba_16_should_be_rgb_16.png");
-    let (output, opts) = get_opts(&input);
-
     test_it_converts(
-        &input,
-        &output,
-        &opts,
+        "tests/files/rgba_16_should_be_rgb_16.png",
+        None,
         ColorType::RGBA,
         BitDepth::Sixteen,
         ColorType::RGB,
@@ -121,13 +109,9 @@ fn rgba_16_should_be_rgb_16() {
 
 #[test]
 fn rgba_16_should_be_rgb_8() {
-    let input = PathBuf::from("tests/files/rgba_16_should_be_rgb_8.png");
-    let (output, opts) = get_opts(&input);
-
     test_it_converts(
-        &input,
-        &output,
-        &opts,
+        "tests/files/rgba_16_should_be_rgb_8.png",
+        None,
         ColorType::RGBA,
         BitDepth::Sixteen,
         ColorType::RGB,
@@ -137,13 +121,9 @@ fn rgba_16_should_be_rgb_8() {
 
 #[test]
 fn rgba_8_should_be_rgb_8() {
-    let input = PathBuf::from("tests/files/rgba_8_should_be_rgb_8.png");
-    let (output, opts) = get_opts(&input);
-
     test_it_converts(
-        &input,
-        &output,
-        &opts,
+        "tests/files/rgba_8_should_be_rgb_8.png",
+        None,
         ColorType::RGBA,
         BitDepth::Eight,
         ColorType::RGB,
@@ -153,13 +133,9 @@ fn rgba_8_should_be_rgb_8() {
 
 #[test]
 fn rgba_16_should_be_palette_8() {
-    let input = PathBuf::from("tests/files/rgba_16_should_be_palette_8.png");
-    let (output, opts) = get_opts(&input);
-
     test_it_converts(
-        &input,
-        &output,
-        &opts,
+        "tests/files/rgba_16_should_be_palette_8.png",
+        None,
         ColorType::RGBA,
         BitDepth::Sixteen,
         ColorType::Indexed,
@@ -169,13 +145,9 @@ fn rgba_16_should_be_palette_8() {
 
 #[test]
 fn rgba_8_should_be_palette_8() {
-    let input = PathBuf::from("tests/files/rgba_8_should_be_palette_8.png");
-    let (output, opts) = get_opts(&input);
-
     test_it_converts(
-        &input,
-        &output,
-        &opts,
+        "tests/files/rgba_8_should_be_palette_8.png",
+        None,
         ColorType::RGBA,
         BitDepth::Eight,
         ColorType::Indexed,
@@ -185,13 +157,9 @@ fn rgba_8_should_be_palette_8() {
 
 #[test]
 fn rgba_16_should_be_palette_4() {
-    let input = PathBuf::from("tests/files/rgba_16_should_be_palette_4.png");
-    let (output, opts) = get_opts(&input);
-
     test_it_converts(
-        &input,
-        &output,
-        &opts,
+        "tests/files/rgba_16_should_be_palette_4.png",
+        None,
         ColorType::RGBA,
         BitDepth::Sixteen,
         ColorType::Indexed,
@@ -201,13 +169,9 @@ fn rgba_16_should_be_palette_4() {
 
 #[test]
 fn rgba_8_should_be_palette_4() {
-    let input = PathBuf::from("tests/files/rgba_8_should_be_palette_4.png");
-    let (output, opts) = get_opts(&input);
-
     test_it_converts(
-        &input,
-        &output,
-        &opts,
+        "tests/files/rgba_8_should_be_palette_4.png",
+        None,
         ColorType::RGBA,
         BitDepth::Eight,
         ColorType::Indexed,
@@ -217,13 +181,9 @@ fn rgba_8_should_be_palette_4() {
 
 #[test]
 fn rgba_16_should_be_palette_2() {
-    let input = PathBuf::from("tests/files/rgba_16_should_be_palette_2.png");
-    let (output, opts) = get_opts(&input);
-
     test_it_converts(
-        &input,
-        &output,
-        &opts,
+        "tests/files/rgba_16_should_be_palette_2.png",
+        None,
         ColorType::RGBA,
         BitDepth::Sixteen,
         ColorType::Indexed,
@@ -233,13 +193,9 @@ fn rgba_16_should_be_palette_2() {
 
 #[test]
 fn rgba_8_should_be_palette_2() {
-    let input = PathBuf::from("tests/files/rgba_8_should_be_palette_2.png");
-    let (output, opts) = get_opts(&input);
-
     test_it_converts(
-        &input,
-        &output,
-        &opts,
+        "tests/files/rgba_8_should_be_palette_2.png",
+        None,
         ColorType::RGBA,
         BitDepth::Eight,
         ColorType::Indexed,
@@ -249,13 +205,9 @@ fn rgba_8_should_be_palette_2() {
 
 #[test]
 fn rgba_16_should_be_palette_1() {
-    let input = PathBuf::from("tests/files/rgba_16_should_be_palette_1.png");
-    let (output, opts) = get_opts(&input);
-
     test_it_converts(
-        &input,
-        &output,
-        &opts,
+        "tests/files/rgba_16_should_be_palette_1.png",
+        None,
         ColorType::RGBA,
         BitDepth::Sixteen,
         ColorType::Indexed,
@@ -265,13 +217,9 @@ fn rgba_16_should_be_palette_1() {
 
 #[test]
 fn rgba_8_should_be_palette_1() {
-    let input = PathBuf::from("tests/files/rgba_8_should_be_palette_1.png");
-    let (output, opts) = get_opts(&input);
-
     test_it_converts(
-        &input,
-        &output,
-        &opts,
+        "tests/files/rgba_8_should_be_palette_1.png",
+        None,
         ColorType::RGBA,
         BitDepth::Eight,
         ColorType::Indexed,
@@ -281,13 +229,9 @@ fn rgba_8_should_be_palette_1() {
 
 #[test]
 fn rgba_16_should_be_grayscale_alpha_16() {
-    let input = PathBuf::from("tests/files/rgba_16_should_be_grayscale_alpha_16.png");
-    let (output, opts) = get_opts(&input);
-
     test_it_converts(
-        &input,
-        &output,
-        &opts,
+        "tests/files/rgba_16_should_be_grayscale_alpha_16.png",
+        None,
         ColorType::RGBA,
         BitDepth::Sixteen,
         ColorType::GrayscaleAlpha,
@@ -297,13 +241,9 @@ fn rgba_16_should_be_grayscale_alpha_16() {
 
 #[test]
 fn rgba_16_should_be_grayscale_alpha_8() {
-    let input = PathBuf::from("tests/files/rgba_16_should_be_grayscale_alpha_8.png");
-    let (output, opts) = get_opts(&input);
-
     test_it_converts(
-        &input,
-        &output,
-        &opts,
+        "tests/files/rgba_16_should_be_grayscale_alpha_8.png",
+        None,
         ColorType::RGBA,
         BitDepth::Sixteen,
         ColorType::GrayscaleAlpha,
@@ -313,13 +253,9 @@ fn rgba_16_should_be_grayscale_alpha_8() {
 
 #[test]
 fn rgba_8_should_be_grayscale_alpha_8() {
-    let input = PathBuf::from("tests/files/rgba_8_should_be_grayscale_alpha_8.png");
-    let (output, opts) = get_opts(&input);
-
     test_it_converts(
-        &input,
-        &output,
-        &opts,
+        "tests/files/rgba_8_should_be_grayscale_alpha_8.png",
+        None,
         ColorType::RGBA,
         BitDepth::Eight,
         ColorType::GrayscaleAlpha,
@@ -329,13 +265,9 @@ fn rgba_8_should_be_grayscale_alpha_8() {
 
 #[test]
 fn rgba_16_should_be_grayscale_16() {
-    let input = PathBuf::from("tests/files/rgba_16_should_be_grayscale_16.png");
-    let (output, opts) = get_opts(&input);
-
     test_it_converts(
-        &input,
-        &output,
-        &opts,
+        "tests/files/rgba_16_should_be_grayscale_16.png",
+        None,
         ColorType::RGBA,
         BitDepth::Sixteen,
         ColorType::Grayscale,
@@ -345,13 +277,9 @@ fn rgba_16_should_be_grayscale_16() {
 
 #[test]
 fn rgba_16_should_be_grayscale_8() {
-    let input = PathBuf::from("tests/files/rgba_16_should_be_grayscale_8.png");
-    let (output, opts) = get_opts(&input);
-
     test_it_converts(
-        &input,
-        &output,
-        &opts,
+        "tests/files/rgba_16_should_be_grayscale_8.png",
+        None,
         ColorType::RGBA,
         BitDepth::Sixteen,
         ColorType::Grayscale,
@@ -361,13 +289,9 @@ fn rgba_16_should_be_grayscale_8() {
 
 #[test]
 fn rgba_8_should_be_grayscale_8() {
-    let input = PathBuf::from("tests/files/rgba_8_should_be_grayscale_8.png");
-    let (output, opts) = get_opts(&input);
-
     test_it_converts(
-        &input,
-        &output,
-        &opts,
+        "tests/files/rgba_8_should_be_grayscale_8.png",
+        None,
         ColorType::RGBA,
         BitDepth::Eight,
         ColorType::Grayscale,
@@ -377,13 +301,9 @@ fn rgba_8_should_be_grayscale_8() {
 
 #[test]
 fn rgb_16_should_be_rgb_16() {
-    let input = PathBuf::from("tests/files/rgb_16_should_be_rgb_16.png");
-    let (output, opts) = get_opts(&input);
-
     test_it_converts(
-        &input,
-        &output,
-        &opts,
+        "tests/files/rgb_16_should_be_rgb_16.png",
+        None,
         ColorType::RGB,
         BitDepth::Sixteen,
         ColorType::RGB,
@@ -393,13 +313,9 @@ fn rgb_16_should_be_rgb_16() {
 
 #[test]
 fn rgb_16_should_be_rgb_8() {
-    let input = PathBuf::from("tests/files/rgb_16_should_be_rgb_8.png");
-    let (output, opts) = get_opts(&input);
-
     test_it_converts(
-        &input,
-        &output,
-        &opts,
+        "tests/files/rgb_16_should_be_rgb_8.png",
+        None,
         ColorType::RGB,
         BitDepth::Sixteen,
         ColorType::RGB,
@@ -409,13 +325,9 @@ fn rgb_16_should_be_rgb_8() {
 
 #[test]
 fn rgb_8_should_be_rgb_8() {
-    let input = PathBuf::from("tests/files/rgb_8_should_be_rgb_8.png");
-    let (output, opts) = get_opts(&input);
-
     test_it_converts(
-        &input,
-        &output,
-        &opts,
+        "tests/files/rgb_8_should_be_rgb_8.png",
+        None,
         ColorType::RGB,
         BitDepth::Eight,
         ColorType::RGB,
@@ -425,13 +337,9 @@ fn rgb_8_should_be_rgb_8() {
 
 #[test]
 fn rgb_16_should_be_palette_8() {
-    let input = PathBuf::from("tests/files/rgb_16_should_be_palette_8.png");
-    let (output, opts) = get_opts(&input);
-
     test_it_converts(
-        &input,
-        &output,
-        &opts,
+        "tests/files/rgb_16_should_be_palette_8.png",
+        None,
         ColorType::RGB,
         BitDepth::Sixteen,
         ColorType::Indexed,
@@ -441,13 +349,9 @@ fn rgb_16_should_be_palette_8() {
 
 #[test]
 fn rgb_8_should_be_palette_8() {
-    let input = PathBuf::from("tests/files/rgb_8_should_be_palette_8.png");
-    let (output, opts) = get_opts(&input);
-
     test_it_converts(
-        &input,
-        &output,
-        &opts,
+        "tests/files/rgb_8_should_be_palette_8.png",
+        None,
         ColorType::RGB,
         BitDepth::Eight,
         ColorType::Indexed,
@@ -457,13 +361,9 @@ fn rgb_8_should_be_palette_8() {
 
 #[test]
 fn rgb_16_should_be_palette_4() {
-    let input = PathBuf::from("tests/files/rgb_16_should_be_palette_4.png");
-    let (output, opts) = get_opts(&input);
-
     test_it_converts(
-        &input,
-        &output,
-        &opts,
+        "tests/files/rgb_16_should_be_palette_4.png",
+        None,
         ColorType::RGB,
         BitDepth::Sixteen,
         ColorType::Indexed,
@@ -473,13 +373,9 @@ fn rgb_16_should_be_palette_4() {
 
 #[test]
 fn rgb_8_should_be_palette_4() {
-    let input = PathBuf::from("tests/files/rgb_8_should_be_palette_4.png");
-    let (output, opts) = get_opts(&input);
-
     test_it_converts(
-        &input,
-        &output,
-        &opts,
+        "tests/files/rgb_8_should_be_palette_4.png",
+        None,
         ColorType::RGB,
         BitDepth::Eight,
         ColorType::Indexed,
@@ -489,13 +385,9 @@ fn rgb_8_should_be_palette_4() {
 
 #[test]
 fn rgb_16_should_be_palette_2() {
-    let input = PathBuf::from("tests/files/rgb_16_should_be_palette_2.png");
-    let (output, opts) = get_opts(&input);
-
     test_it_converts(
-        &input,
-        &output,
-        &opts,
+        "tests/files/rgb_16_should_be_palette_2.png",
+        None,
         ColorType::RGB,
         BitDepth::Sixteen,
         ColorType::Indexed,
@@ -505,13 +397,9 @@ fn rgb_16_should_be_palette_2() {
 
 #[test]
 fn rgb_8_should_be_palette_2() {
-    let input = PathBuf::from("tests/files/rgb_8_should_be_palette_2.png");
-    let (output, opts) = get_opts(&input);
-
     test_it_converts(
-        &input,
-        &output,
-        &opts,
+        "tests/files/rgb_8_should_be_palette_2.png",
+        None,
         ColorType::RGB,
         BitDepth::Eight,
         ColorType::Indexed,
@@ -521,13 +409,9 @@ fn rgb_8_should_be_palette_2() {
 
 #[test]
 fn rgb_16_should_be_palette_1() {
-    let input = PathBuf::from("tests/files/rgb_16_should_be_palette_1.png");
-    let (output, opts) = get_opts(&input);
-
     test_it_converts(
-        &input,
-        &output,
-        &opts,
+        "tests/files/rgb_16_should_be_palette_1.png",
+        None,
         ColorType::RGB,
         BitDepth::Sixteen,
         ColorType::Indexed,
@@ -537,13 +421,9 @@ fn rgb_16_should_be_palette_1() {
 
 #[test]
 fn rgb_8_should_be_palette_1() {
-    let input = PathBuf::from("tests/files/rgb_8_should_be_palette_1.png");
-    let (output, opts) = get_opts(&input);
-
     test_it_converts(
-        &input,
-        &output,
-        &opts,
+        "tests/files/rgb_8_should_be_palette_1.png",
+        None,
         ColorType::RGB,
         BitDepth::Eight,
         ColorType::Indexed,
@@ -553,13 +433,9 @@ fn rgb_8_should_be_palette_1() {
 
 #[test]
 fn rgb_16_should_be_grayscale_16() {
-    let input = PathBuf::from("tests/files/rgb_16_should_be_grayscale_16.png");
-    let (output, opts) = get_opts(&input);
-
     test_it_converts(
-        &input,
-        &output,
-        &opts,
+        "tests/files/rgb_16_should_be_grayscale_16.png",
+        None,
         ColorType::RGB,
         BitDepth::Sixteen,
         ColorType::Grayscale,
@@ -569,13 +445,9 @@ fn rgb_16_should_be_grayscale_16() {
 
 #[test]
 fn rgb_16_should_be_grayscale_8() {
-    let input = PathBuf::from("tests/files/rgb_16_should_be_grayscale_8.png");
-    let (output, opts) = get_opts(&input);
-
     test_it_converts(
-        &input,
-        &output,
-        &opts,
+        "tests/files/rgb_16_should_be_grayscale_8.png",
+        None,
         ColorType::RGB,
         BitDepth::Sixteen,
         ColorType::Grayscale,
@@ -585,13 +457,9 @@ fn rgb_16_should_be_grayscale_8() {
 
 #[test]
 fn rgb_8_should_be_grayscale_8() {
-    let input = PathBuf::from("tests/files/rgb_8_should_be_grayscale_8.png");
-    let (output, opts) = get_opts(&input);
-
     test_it_converts(
-        &input,
-        &output,
-        &opts,
+        "tests/files/rgb_8_should_be_grayscale_8.png",
+        None,
         ColorType::RGB,
         BitDepth::Eight,
         ColorType::Grayscale,
@@ -601,13 +469,9 @@ fn rgb_8_should_be_grayscale_8() {
 
 #[test]
 fn palette_8_should_be_palette_8() {
-    let input = PathBuf::from("tests/files/palette_8_should_be_palette_8.png");
-    let (output, opts) = get_opts(&input);
-
     test_it_converts(
-        &input,
-        &output,
-        &opts,
+        "tests/files/palette_8_should_be_palette_8.png",
+        None,
         ColorType::Indexed,
         BitDepth::Eight,
         ColorType::Indexed,
@@ -617,13 +481,9 @@ fn palette_8_should_be_palette_8() {
 
 #[test]
 fn palette_8_should_be_palette_4() {
-    let input = PathBuf::from("tests/files/palette_8_should_be_palette_4.png");
-    let (output, opts) = get_opts(&input);
-
     test_it_converts(
-        &input,
-        &output,
-        &opts,
+        "tests/files/palette_8_should_be_palette_4.png",
+        None,
         ColorType::Indexed,
         BitDepth::Eight,
         ColorType::Indexed,
@@ -633,13 +493,9 @@ fn palette_8_should_be_palette_4() {
 
 #[test]
 fn palette_4_should_be_palette_4() {
-    let input = PathBuf::from("tests/files/palette_4_should_be_palette_4.png");
-    let (output, opts) = get_opts(&input);
-
     test_it_converts(
-        &input,
-        &output,
-        &opts,
+        "tests/files/palette_4_should_be_palette_4.png",
+        None,
         ColorType::Indexed,
         BitDepth::Four,
         ColorType::Indexed,
@@ -649,13 +505,9 @@ fn palette_4_should_be_palette_4() {
 
 #[test]
 fn palette_8_should_be_palette_2() {
-    let input = PathBuf::from("tests/files/palette_8_should_be_palette_2.png");
-    let (output, opts) = get_opts(&input);
-
     test_it_converts(
-        &input,
-        &output,
-        &opts,
+        "tests/files/palette_8_should_be_palette_2.png",
+        None,
         ColorType::Indexed,
         BitDepth::Eight,
         ColorType::Indexed,
@@ -665,13 +517,9 @@ fn palette_8_should_be_palette_2() {
 
 #[test]
 fn palette_4_should_be_palette_2() {
-    let input = PathBuf::from("tests/files/palette_4_should_be_palette_2.png");
-    let (output, opts) = get_opts(&input);
-
     test_it_converts(
-        &input,
-        &output,
-        &opts,
+        "tests/files/palette_4_should_be_palette_2.png",
+        None,
         ColorType::Indexed,
         BitDepth::Four,
         ColorType::Indexed,
@@ -681,13 +529,9 @@ fn palette_4_should_be_palette_2() {
 
 #[test]
 fn palette_2_should_be_palette_2() {
-    let input = PathBuf::from("tests/files/palette_2_should_be_palette_2.png");
-    let (output, opts) = get_opts(&input);
-
     test_it_converts(
-        &input,
-        &output,
-        &opts,
+        "tests/files/palette_2_should_be_palette_2.png",
+        None,
         ColorType::Indexed,
         BitDepth::Two,
         ColorType::Indexed,
@@ -697,13 +541,9 @@ fn palette_2_should_be_palette_2() {
 
 #[test]
 fn palette_8_should_be_palette_1() {
-    let input = PathBuf::from("tests/files/palette_8_should_be_palette_1.png");
-    let (output, opts) = get_opts(&input);
-
     test_it_converts(
-        &input,
-        &output,
-        &opts,
+        "tests/files/palette_8_should_be_palette_1.png",
+        None,
         ColorType::Indexed,
         BitDepth::Eight,
         ColorType::Indexed,
@@ -713,13 +553,9 @@ fn palette_8_should_be_palette_1() {
 
 #[test]
 fn palette_4_should_be_palette_1() {
-    let input = PathBuf::from("tests/files/palette_4_should_be_palette_1.png");
-    let (output, opts) = get_opts(&input);
-
     test_it_converts(
-        &input,
-        &output,
-        &opts,
+        "tests/files/palette_4_should_be_palette_1.png",
+        None,
         ColorType::Indexed,
         BitDepth::Four,
         ColorType::Indexed,
@@ -729,13 +565,9 @@ fn palette_4_should_be_palette_1() {
 
 #[test]
 fn palette_2_should_be_palette_1() {
-    let input = PathBuf::from("tests/files/palette_2_should_be_palette_1.png");
-    let (output, opts) = get_opts(&input);
-
     test_it_converts(
-        &input,
-        &output,
-        &opts,
+        "tests/files/palette_2_should_be_palette_1.png",
+        None,
         ColorType::Indexed,
         BitDepth::Two,
         ColorType::Indexed,
@@ -745,13 +577,9 @@ fn palette_2_should_be_palette_1() {
 
 #[test]
 fn palette_1_should_be_palette_1() {
-    let input = PathBuf::from("tests/files/palette_1_should_be_palette_1.png");
-    let (output, opts) = get_opts(&input);
-
     test_it_converts(
-        &input,
-        &output,
-        &opts,
+        "tests/files/palette_1_should_be_palette_1.png",
+        None,
         ColorType::Indexed,
         BitDepth::One,
         ColorType::Indexed,
@@ -761,13 +589,9 @@ fn palette_1_should_be_palette_1() {
 
 #[test]
 fn grayscale_alpha_16_should_be_grayscale_alpha_16() {
-    let input = PathBuf::from("tests/files/grayscale_alpha_16_should_be_grayscale_alpha_16.png");
-    let (output, opts) = get_opts(&input);
-
     test_it_converts(
-        &input,
-        &output,
-        &opts,
+        "tests/files/grayscale_alpha_16_should_be_grayscale_alpha_16.png",
+        None,
         ColorType::GrayscaleAlpha,
         BitDepth::Sixteen,
         ColorType::GrayscaleAlpha,
@@ -777,13 +601,9 @@ fn grayscale_alpha_16_should_be_grayscale_alpha_16() {
 
 #[test]
 fn grayscale_alpha_16_should_be_grayscale_alpha_8() {
-    let input = PathBuf::from("tests/files/grayscale_alpha_16_should_be_grayscale_alpha_8.png");
-    let (output, opts) = get_opts(&input);
-
     test_it_converts(
-        &input,
-        &output,
-        &opts,
+        "tests/files/grayscale_alpha_16_should_be_grayscale_alpha_8.png",
+        None,
         ColorType::GrayscaleAlpha,
         BitDepth::Sixteen,
         ColorType::GrayscaleAlpha,
@@ -793,13 +613,9 @@ fn grayscale_alpha_16_should_be_grayscale_alpha_8() {
 
 #[test]
 fn grayscale_alpha_8_should_be_grayscale_alpha_8() {
-    let input = PathBuf::from("tests/files/grayscale_alpha_8_should_be_grayscale_alpha_8.png");
-    let (output, opts) = get_opts(&input);
-
     test_it_converts(
-        &input,
-        &output,
-        &opts,
+        "tests/files/grayscale_alpha_8_should_be_grayscale_alpha_8.png",
+        None,
         ColorType::GrayscaleAlpha,
         BitDepth::Eight,
         ColorType::GrayscaleAlpha,
@@ -809,13 +625,9 @@ fn grayscale_alpha_8_should_be_grayscale_alpha_8() {
 
 #[test]
 fn grayscale_alpha_16_should_be_grayscale_16() {
-    let input = PathBuf::from("tests/files/grayscale_alpha_16_should_be_grayscale_16.png");
-    let (output, opts) = get_opts(&input);
-
     test_it_converts(
-        &input,
-        &output,
-        &opts,
+        "tests/files/grayscale_alpha_16_should_be_grayscale_16.png",
+        None,
         ColorType::GrayscaleAlpha,
         BitDepth::Sixteen,
         ColorType::Grayscale,
@@ -825,13 +637,9 @@ fn grayscale_alpha_16_should_be_grayscale_16() {
 
 #[test]
 fn grayscale_alpha_16_should_be_grayscale_8() {
-    let input = PathBuf::from("tests/files/grayscale_alpha_16_should_be_grayscale_8.png");
-    let (output, opts) = get_opts(&input);
-
     test_it_converts(
-        &input,
-        &output,
-        &opts,
+        "tests/files/grayscale_alpha_16_should_be_grayscale_8.png",
+        None,
         ColorType::GrayscaleAlpha,
         BitDepth::Sixteen,
         ColorType::Grayscale,
@@ -841,13 +649,9 @@ fn grayscale_alpha_16_should_be_grayscale_8() {
 
 #[test]
 fn grayscale_alpha_8_should_be_grayscale_8() {
-    let input = PathBuf::from("tests/files/grayscale_alpha_8_should_be_grayscale_8.png");
-    let (output, opts) = get_opts(&input);
-
     test_it_converts(
-        &input,
-        &output,
-        &opts,
+        "tests/files/grayscale_alpha_8_should_be_grayscale_8.png",
+        None,
         ColorType::GrayscaleAlpha,
         BitDepth::Eight,
         ColorType::Grayscale,
@@ -857,13 +661,9 @@ fn grayscale_alpha_8_should_be_grayscale_8() {
 
 #[test]
 fn grayscale_16_should_be_grayscale_16() {
-    let input = PathBuf::from("tests/files/grayscale_16_should_be_grayscale_16.png");
-    let (output, opts) = get_opts(&input);
-
     test_it_converts(
-        &input,
-        &output,
-        &opts,
+        "tests/files/grayscale_16_should_be_grayscale_16.png",
+        None,
         ColorType::Grayscale,
         BitDepth::Sixteen,
         ColorType::Grayscale,
@@ -873,13 +673,9 @@ fn grayscale_16_should_be_grayscale_16() {
 
 #[test]
 fn grayscale_16_should_be_grayscale_8() {
-    let input = PathBuf::from("tests/files/grayscale_16_should_be_grayscale_8.png");
-    let (output, opts) = get_opts(&input);
-
     test_it_converts(
-        &input,
-        &output,
-        &opts,
+        "tests/files/grayscale_16_should_be_grayscale_8.png",
+        None,
         ColorType::Grayscale,
         BitDepth::Sixteen,
         ColorType::Grayscale,
@@ -889,13 +685,9 @@ fn grayscale_16_should_be_grayscale_8() {
 
 #[test]
 fn grayscale_8_should_be_grayscale_8() {
-    let input = PathBuf::from("tests/files/grayscale_8_should_be_grayscale_8.png");
-    let (output, opts) = get_opts(&input);
-
     test_it_converts(
-        &input,
-        &output,
-        &opts,
+        "tests/files/grayscale_8_should_be_grayscale_8.png",
+        None,
         ColorType::Grayscale,
         BitDepth::Eight,
         ColorType::Grayscale,
@@ -905,13 +697,9 @@ fn grayscale_8_should_be_grayscale_8() {
 
 #[test]
 fn small_files() {
-    let input = PathBuf::from("tests/files/small_files.png");
-    let (output, opts) = get_opts(&input);
-
     test_it_converts(
-        &input,
-        &output,
-        &opts,
+        "tests/files/small_files.png",
+        None,
         ColorType::Indexed,
         BitDepth::Eight,
         ColorType::Indexed,
@@ -1020,13 +808,9 @@ fn palette_should_be_reduced_with_both() {
 
 #[test]
 fn rgba_16_reduce_alpha_black() {
-    let input = PathBuf::from("tests/files/rgba_16_reduce_alpha_black.png");
-    let (output, opts) = get_opts(&input);
-
     test_it_converts(
-        &input,
-        &output,
-        &opts,
+        "tests/files/rgba_16_reduce_alpha_black.png",
+        None,
         ColorType::RGBA,
         BitDepth::Sixteen,
         ColorType::RGBA,
@@ -1036,13 +820,9 @@ fn rgba_16_reduce_alpha_black() {
 
 #[test]
 fn rgba_8_reduce_alpha_black() {
-    let input = PathBuf::from("tests/files/rgba_8_reduce_alpha_black.png");
-    let (output, opts) = get_opts(&input);
-
     test_it_converts(
-        &input,
-        &output,
-        &opts,
+        "tests/files/rgba_8_reduce_alpha_black.png",
+        None,
         ColorType::RGBA,
         BitDepth::Eight,
         ColorType::RGBA,
@@ -1052,13 +832,9 @@ fn rgba_8_reduce_alpha_black() {
 
 #[test]
 fn grayscale_alpha_16_reduce_alpha_black() {
-    let input = PathBuf::from("tests/files/grayscale_alpha_16_reduce_alpha_black.png");
-    let (output, opts) = get_opts(&input);
-
     test_it_converts(
-        &input,
-        &output,
-        &opts,
+        "tests/files/grayscale_alpha_16_reduce_alpha_black.png",
+        None,
         ColorType::GrayscaleAlpha,
         BitDepth::Sixteen,
         ColorType::GrayscaleAlpha,
@@ -1068,13 +844,9 @@ fn grayscale_alpha_16_reduce_alpha_black() {
 
 #[test]
 fn grayscale_alpha_8_reduce_alpha_black() {
-    let input = PathBuf::from("tests/files/grayscale_alpha_8_reduce_alpha_black.png");
-    let (output, opts) = get_opts(&input);
-
     test_it_converts(
-        &input,
-        &output,
-        &opts,
+        "tests/files/grayscale_alpha_8_reduce_alpha_black.png",
+        None,
         ColorType::GrayscaleAlpha,
         BitDepth::Eight,
         ColorType::GrayscaleAlpha,
@@ -1084,15 +856,9 @@ fn grayscale_alpha_8_reduce_alpha_black() {
 
 #[test]
 fn rgba_16_reduce_alpha_white() {
-    let input = PathBuf::from("tests/files/rgba_16_reduce_alpha_white.png");
-    let (output, mut opts) = get_opts(&input);
-    opts.alphas = HashSet::with_capacity(1);
-    opts.alphas.insert(AlphaOptim::White);
-
     test_it_converts(
-        &input,
-        &output,
-        &opts,
+        "tests/files/rgba_16_reduce_alpha_white.png",
+        Some(AlphaOptim::White),
         ColorType::RGBA,
         BitDepth::Sixteen,
         ColorType::RGBA,
@@ -1102,15 +868,9 @@ fn rgba_16_reduce_alpha_white() {
 
 #[test]
 fn rgba_8_reduce_alpha_white() {
-    let input = PathBuf::from("tests/files/rgba_8_reduce_alpha_white.png");
-    let (output, mut opts) = get_opts(&input);
-    opts.alphas = HashSet::with_capacity(1);
-    opts.alphas.insert(AlphaOptim::White);
-
     test_it_converts(
-        &input,
-        &output,
-        &opts,
+        "tests/files/rgba_8_reduce_alpha_white.png",
+        Some(AlphaOptim::White),
         ColorType::RGBA,
         BitDepth::Eight,
         ColorType::RGBA,
@@ -1120,15 +880,9 @@ fn rgba_8_reduce_alpha_white() {
 
 #[test]
 fn grayscale_alpha_16_reduce_alpha_white() {
-    let input = PathBuf::from("tests/files/grayscale_alpha_16_reduce_alpha_white.png");
-    let (output, mut opts) = get_opts(&input);
-    opts.alphas = HashSet::with_capacity(1);
-    opts.alphas.insert(AlphaOptim::White);
-
     test_it_converts(
-        &input,
-        &output,
-        &opts,
+        "tests/files/grayscale_alpha_16_reduce_alpha_white.png",
+        Some(AlphaOptim::White),
         ColorType::GrayscaleAlpha,
         BitDepth::Sixteen,
         ColorType::GrayscaleAlpha,
@@ -1138,15 +892,9 @@ fn grayscale_alpha_16_reduce_alpha_white() {
 
 #[test]
 fn grayscale_alpha_8_reduce_alpha_white() {
-    let input = PathBuf::from("tests/files/grayscale_alpha_8_reduce_alpha_white.png");
-    let (output, mut opts) = get_opts(&input);
-    opts.alphas = HashSet::with_capacity(1);
-    opts.alphas.insert(AlphaOptim::White);
-
     test_it_converts(
-        &input,
-        &output,
-        &opts,
+        "tests/files/grayscale_alpha_8_reduce_alpha_white.png",
+        Some(AlphaOptim::White),
         ColorType::GrayscaleAlpha,
         BitDepth::Eight,
         ColorType::GrayscaleAlpha,
@@ -1156,15 +904,9 @@ fn grayscale_alpha_8_reduce_alpha_white() {
 
 #[test]
 fn rgba_16_reduce_alpha_down() {
-    let input = PathBuf::from("tests/files/rgba_16_reduce_alpha_down.png");
-    let (output, mut opts) = get_opts(&input);
-    opts.alphas = HashSet::with_capacity(1);
-    opts.alphas.insert(AlphaOptim::Down);
-
     test_it_converts(
-        &input,
-        &output,
-        &opts,
+        "tests/files/rgba_16_reduce_alpha_down.png",
+        Some(AlphaOptim::Down),
         ColorType::RGBA,
         BitDepth::Sixteen,
         ColorType::RGBA,
@@ -1174,15 +916,9 @@ fn rgba_16_reduce_alpha_down() {
 
 #[test]
 fn rgba_8_reduce_alpha_down() {
-    let input = PathBuf::from("tests/files/rgba_8_reduce_alpha_down.png");
-    let (output, mut opts) = get_opts(&input);
-    opts.alphas = HashSet::with_capacity(1);
-    opts.alphas.insert(AlphaOptim::Down);
-
     test_it_converts(
-        &input,
-        &output,
-        &opts,
+        "tests/files/rgba_8_reduce_alpha_down.png",
+        Some(AlphaOptim::Down),
         ColorType::RGBA,
         BitDepth::Eight,
         ColorType::RGBA,
@@ -1192,15 +928,9 @@ fn rgba_8_reduce_alpha_down() {
 
 #[test]
 fn grayscale_alpha_16_reduce_alpha_down() {
-    let input = PathBuf::from("tests/files/grayscale_alpha_16_reduce_alpha_down.png");
-    let (output, mut opts) = get_opts(&input);
-    opts.alphas = HashSet::with_capacity(1);
-    opts.alphas.insert(AlphaOptim::Down);
-
     test_it_converts(
-        &input,
-        &output,
-        &opts,
+        "tests/files/grayscale_alpha_16_reduce_alpha_down.png",
+        Some(AlphaOptim::Down),
         ColorType::GrayscaleAlpha,
         BitDepth::Sixteen,
         ColorType::GrayscaleAlpha,
@@ -1210,15 +940,9 @@ fn grayscale_alpha_16_reduce_alpha_down() {
 
 #[test]
 fn grayscale_alpha_8_reduce_alpha_down() {
-    let input = PathBuf::from("tests/files/grayscale_alpha_8_reduce_alpha_down.png");
-    let (output, mut opts) = get_opts(&input);
-    opts.alphas = HashSet::with_capacity(1);
-    opts.alphas.insert(AlphaOptim::Down);
-
     test_it_converts(
-        &input,
-        &output,
-        &opts,
+        "tests/files/grayscale_alpha_8_reduce_alpha_down.png",
+        Some(AlphaOptim::Down),
         ColorType::GrayscaleAlpha,
         BitDepth::Eight,
         ColorType::GrayscaleAlpha,
@@ -1228,15 +952,9 @@ fn grayscale_alpha_8_reduce_alpha_down() {
 
 #[test]
 fn rgba_16_reduce_alpha_up() {
-    let input = PathBuf::from("tests/files/rgba_16_reduce_alpha_up.png");
-    let (output, mut opts) = get_opts(&input);
-    opts.alphas = HashSet::with_capacity(1);
-    opts.alphas.insert(AlphaOptim::Up);
-
     test_it_converts(
-        &input,
-        &output,
-        &opts,
+        "tests/files/rgba_16_reduce_alpha_up.png",
+        Some(AlphaOptim::Up),
         ColorType::RGBA,
         BitDepth::Sixteen,
         ColorType::RGBA,
@@ -1246,15 +964,9 @@ fn rgba_16_reduce_alpha_up() {
 
 #[test]
 fn rgba_8_reduce_alpha_up() {
-    let input = PathBuf::from("tests/files/rgba_8_reduce_alpha_up.png");
-    let (output, mut opts) = get_opts(&input);
-    opts.alphas = HashSet::with_capacity(1);
-    opts.alphas.insert(AlphaOptim::Up);
-
     test_it_converts(
-        &input,
-        &output,
-        &opts,
+        "tests/files/rgba_8_reduce_alpha_up.png",
+        Some(AlphaOptim::Up),
         ColorType::RGBA,
         BitDepth::Eight,
         ColorType::RGBA,
@@ -1264,15 +976,9 @@ fn rgba_8_reduce_alpha_up() {
 
 #[test]
 fn grayscale_alpha_16_reduce_alpha_up() {
-    let input = PathBuf::from("tests/files/grayscale_alpha_16_reduce_alpha_up.png");
-    let (output, mut opts) = get_opts(&input);
-    opts.alphas = HashSet::with_capacity(1);
-    opts.alphas.insert(AlphaOptim::Up);
-
     test_it_converts(
-        &input,
-        &output,
-        &opts,
+        "tests/files/grayscale_alpha_16_reduce_alpha_up.png",
+        Some(AlphaOptim::Up),
         ColorType::GrayscaleAlpha,
         BitDepth::Sixteen,
         ColorType::GrayscaleAlpha,
@@ -1282,15 +988,9 @@ fn grayscale_alpha_16_reduce_alpha_up() {
 
 #[test]
 fn grayscale_alpha_8_reduce_alpha_up() {
-    let input = PathBuf::from("tests/files/grayscale_alpha_8_reduce_alpha_up.png");
-    let (output, mut opts) = get_opts(&input);
-    opts.alphas = HashSet::with_capacity(1);
-    opts.alphas.insert(AlphaOptim::Up);
-
     test_it_converts(
-        &input,
-        &output,
-        &opts,
+        "tests/files/grayscale_alpha_8_reduce_alpha_up.png",
+        Some(AlphaOptim::Up),
         ColorType::GrayscaleAlpha,
         BitDepth::Eight,
         ColorType::GrayscaleAlpha,
@@ -1300,15 +1000,9 @@ fn grayscale_alpha_8_reduce_alpha_up() {
 
 #[test]
 fn rgba_16_reduce_alpha_left() {
-    let input = PathBuf::from("tests/files/rgba_16_reduce_alpha_left.png");
-    let (output, mut opts) = get_opts(&input);
-    opts.alphas = HashSet::with_capacity(1);
-    opts.alphas.insert(AlphaOptim::Left);
-
     test_it_converts(
-        &input,
-        &output,
-        &opts,
+        "tests/files/rgba_16_reduce_alpha_left.png",
+        Some(AlphaOptim::Left),
         ColorType::RGBA,
         BitDepth::Sixteen,
         ColorType::RGBA,
@@ -1318,15 +1012,9 @@ fn rgba_16_reduce_alpha_left() {
 
 #[test]
 fn rgba_8_reduce_alpha_left() {
-    let input = PathBuf::from("tests/files/rgba_8_reduce_alpha_left.png");
-    let (output, mut opts) = get_opts(&input);
-    opts.alphas = HashSet::with_capacity(1);
-    opts.alphas.insert(AlphaOptim::Left);
-
     test_it_converts(
-        &input,
-        &output,
-        &opts,
+        "tests/files/rgba_8_reduce_alpha_left.png",
+        Some(AlphaOptim::Left),
         ColorType::RGBA,
         BitDepth::Eight,
         ColorType::RGBA,
@@ -1336,15 +1024,9 @@ fn rgba_8_reduce_alpha_left() {
 
 #[test]
 fn grayscale_alpha_16_reduce_alpha_left() {
-    let input = PathBuf::from("tests/files/grayscale_alpha_16_reduce_alpha_left.png");
-    let (output, mut opts) = get_opts(&input);
-    opts.alphas = HashSet::with_capacity(1);
-    opts.alphas.insert(AlphaOptim::Left);
-
     test_it_converts(
-        &input,
-        &output,
-        &opts,
+        "tests/files/grayscale_alpha_16_reduce_alpha_left.png",
+        Some(AlphaOptim::Left),
         ColorType::GrayscaleAlpha,
         BitDepth::Sixteen,
         ColorType::GrayscaleAlpha,
@@ -1354,15 +1036,9 @@ fn grayscale_alpha_16_reduce_alpha_left() {
 
 #[test]
 fn grayscale_alpha_8_reduce_alpha_left() {
-    let input = PathBuf::from("tests/files/grayscale_alpha_8_reduce_alpha_left.png");
-    let (output, mut opts) = get_opts(&input);
-    opts.alphas = HashSet::with_capacity(1);
-    opts.alphas.insert(AlphaOptim::Left);
-
     test_it_converts(
-        &input,
-        &output,
-        &opts,
+        "tests/files/grayscale_alpha_8_reduce_alpha_left.png",
+        Some(AlphaOptim::Left),
         ColorType::GrayscaleAlpha,
         BitDepth::Eight,
         ColorType::GrayscaleAlpha,
@@ -1372,15 +1048,9 @@ fn grayscale_alpha_8_reduce_alpha_left() {
 
 #[test]
 fn rgba_16_reduce_alpha_right() {
-    let input = PathBuf::from("tests/files/rgba_16_reduce_alpha_right.png");
-    let (output, mut opts) = get_opts(&input);
-    opts.alphas = HashSet::with_capacity(1);
-    opts.alphas.insert(AlphaOptim::Right);
-
     test_it_converts(
-        &input,
-        &output,
-        &opts,
+        "tests/files/rgba_16_reduce_alpha_right.png",
+        Some(AlphaOptim::Right),
         ColorType::RGBA,
         BitDepth::Sixteen,
         ColorType::RGBA,
@@ -1390,15 +1060,9 @@ fn rgba_16_reduce_alpha_right() {
 
 #[test]
 fn rgba_8_reduce_alpha_right() {
-    let input = PathBuf::from("tests/files/rgba_8_reduce_alpha_right.png");
-    let (output, mut opts) = get_opts(&input);
-    opts.alphas = HashSet::with_capacity(1);
-    opts.alphas.insert(AlphaOptim::Right);
-
     test_it_converts(
-        &input,
-        &output,
-        &opts,
+        "tests/files/rgba_8_reduce_alpha_right.png",
+        Some(AlphaOptim::Right),
         ColorType::RGBA,
         BitDepth::Eight,
         ColorType::RGBA,
@@ -1408,15 +1072,9 @@ fn rgba_8_reduce_alpha_right() {
 
 #[test]
 fn grayscale_alpha_16_reduce_alpha_right() {
-    let input = PathBuf::from("tests/files/grayscale_alpha_16_reduce_alpha_right.png");
-    let (output, mut opts) = get_opts(&input);
-    opts.alphas = HashSet::with_capacity(1);
-    opts.alphas.insert(AlphaOptim::Right);
-
     test_it_converts(
-        &input,
-        &output,
-        &opts,
+        "tests/files/grayscale_alpha_16_reduce_alpha_right.png",
+        Some(AlphaOptim::Right),
         ColorType::GrayscaleAlpha,
         BitDepth::Sixteen,
         ColorType::GrayscaleAlpha,
@@ -1426,15 +1084,9 @@ fn grayscale_alpha_16_reduce_alpha_right() {
 
 #[test]
 fn grayscale_alpha_8_reduce_alpha_right() {
-    let input = PathBuf::from("tests/files/grayscale_alpha_8_reduce_alpha_right.png");
-    let (output, mut opts) = get_opts(&input);
-    opts.alphas = HashSet::with_capacity(1);
-    opts.alphas.insert(AlphaOptim::Right);
-
     test_it_converts(
-        &input,
-        &output,
-        &opts,
+        "tests/files/grayscale_alpha_8_reduce_alpha_right.png",
+        Some(AlphaOptim::Right),
         ColorType::GrayscaleAlpha,
         BitDepth::Eight,
         ColorType::GrayscaleAlpha,

--- a/tests/regression.rs
+++ b/tests/regression.rs
@@ -20,20 +20,21 @@ fn get_opts(input: &Path) -> (OutFile, oxipng::Options) {
 }
 
 fn test_it_converts(
-    input: &Path,
-    output: &OutFile,
-    opts: &oxipng::Options,
+    input: &str,
+    custom: Option<(OutFile, oxipng::Options)>,
     color_type_in: ColorType,
     bit_depth_in: BitDepth,
     color_type_out: ColorType,
     bit_depth_out: BitDepth,
 ) {
-    let png = png::PngData::new(input, opts.fix_errors).unwrap();
+    let input = PathBuf::from(input);
+    let (output, opts) = custom.unwrap_or_else(|| get_opts(&input));
+    let png = png::PngData::new(&input, opts.fix_errors).unwrap();
 
     assert_eq!(png.ihdr_data.color_type, color_type_in);
     assert_eq!(png.ihdr_data.bit_depth, bit_depth_in);
 
-    match oxipng::optimize(input, output, opts) {
+    match oxipng::optimize(&input, &output, &opts) {
         Ok(_) => (),
         Err(x) => panic!("{}", x),
     };
@@ -56,13 +57,9 @@ fn test_it_converts(
 
 #[test]
 fn issue_29() {
-    let input = PathBuf::from("tests/files/issue-29.png");
-    let (output, opts) = get_opts(&input);
-
     test_it_converts(
-        &input,
-        &output,
-        &opts,
+        "tests/files/issue-29.png",
+        None,
         ColorType::RGB,
         BitDepth::Eight,
         ColorType::RGB,
@@ -106,13 +103,9 @@ fn issue_42() {
 
 #[test]
 fn issue_52_01() {
-    let input = PathBuf::from("tests/files/issue-52-01.png");
-    let (output, opts) = get_opts(&input);
-
     test_it_converts(
-        &input,
-        &output,
-        &opts,
+        "tests/files/issue-52-01.png",
+        None,
         ColorType::RGBA,
         BitDepth::Eight,
         ColorType::Indexed,
@@ -122,13 +115,9 @@ fn issue_52_01() {
 
 #[test]
 fn issue_52_02() {
-    let input = PathBuf::from("tests/files/issue-52-02.png");
-    let (output, opts) = get_opts(&input);
-
     test_it_converts(
-        &input,
-        &output,
-        &opts,
+        "tests/files/issue-52-02.png",
+        None,
         ColorType::RGBA,
         BitDepth::Eight,
         ColorType::Indexed,
@@ -138,13 +127,9 @@ fn issue_52_02() {
 
 #[test]
 fn issue_52_03() {
-    let input = PathBuf::from("tests/files/issue-52-03.png");
-    let (output, opts) = get_opts(&input);
-
     test_it_converts(
-        &input,
-        &output,
-        &opts,
+        "tests/files/issue-52-03.png",
+        None,
         ColorType::RGBA,
         BitDepth::Eight,
         ColorType::Indexed,
@@ -154,13 +139,9 @@ fn issue_52_03() {
 
 #[test]
 fn issue_52_04() {
-    let input = PathBuf::from("tests/files/issue-52-04.png");
-    let (output, opts) = get_opts(&input);
-
     test_it_converts(
-        &input,
-        &output,
-        &opts,
+        "tests/files/issue-52-04.png",
+        None,
         ColorType::RGBA,
         BitDepth::Eight,
         ColorType::Indexed,
@@ -170,13 +151,9 @@ fn issue_52_04() {
 
 #[test]
 fn issue_52_05() {
-    let input = PathBuf::from("tests/files/issue-52-05.png");
-    let (output, opts) = get_opts(&input);
-
     test_it_converts(
-        &input,
-        &output,
-        &opts,
+        "tests/files/issue-52-05.png",
+        None,
         ColorType::RGBA,
         BitDepth::Eight,
         ColorType::Indexed,
@@ -186,13 +163,9 @@ fn issue_52_05() {
 
 #[test]
 fn issue_52_06() {
-    let input = PathBuf::from("tests/files/issue-52-06.png");
-    let (output, opts) = get_opts(&input);
-
     test_it_converts(
-        &input,
-        &output,
-        &opts,
+        "tests/files/issue-52-06.png",
+        None,
         ColorType::RGBA,
         BitDepth::Eight,
         ColorType::Indexed,
@@ -202,13 +175,9 @@ fn issue_52_06() {
 
 #[test]
 fn issue_56() {
-    let input = PathBuf::from("tests/files/issue-56.png");
-    let (output, opts) = get_opts(&input);
-
     test_it_converts(
-        &input,
-        &output,
-        &opts,
+        "tests/files/issue-56.png",
+        None,
         ColorType::Indexed,
         BitDepth::Four,
         ColorType::Indexed,
@@ -218,13 +187,9 @@ fn issue_56() {
 
 #[test]
 fn issue_58() {
-    let input = PathBuf::from("tests/files/issue-58.png");
-    let (output, opts) = get_opts(&input);
-
     test_it_converts(
-        &input,
-        &output,
-        &opts,
+        "tests/files/issue-58.png",
+        None,
         ColorType::Indexed,
         BitDepth::Four,
         ColorType::Indexed,
@@ -234,13 +199,9 @@ fn issue_58() {
 
 #[test]
 fn issue_59() {
-    let input = PathBuf::from("tests/files/issue-59.png");
-    let (output, opts) = get_opts(&input);
-
     test_it_converts(
-        &input,
-        &output,
-        &opts,
+        "tests/files/issue-59.png",
+        None,
         ColorType::RGBA,
         BitDepth::Eight,
         ColorType::RGBA,
@@ -250,13 +211,9 @@ fn issue_59() {
 
 #[test]
 fn issue_60() {
-    let input = PathBuf::from("tests/files/issue-60.png");
-    let (output, opts) = get_opts(&input);
-
     test_it_converts(
-        &input,
-        &output,
-        &opts,
+        "tests/files/issue-60.png",
+        None,
         ColorType::RGBA,
         BitDepth::Eight,
         ColorType::GrayscaleAlpha,
@@ -266,13 +223,9 @@ fn issue_60() {
 
 #[test]
 fn issue_80() {
-    let input = PathBuf::from("tests/files/issue-80.png");
-    let (output, opts) = get_opts(&input);
-
     test_it_converts(
-        &input,
-        &output,
-        &opts,
+        "tests/files/issue-80.png",
+        None,
         ColorType::Indexed,
         BitDepth::Two,
         ColorType::Indexed,
@@ -282,13 +235,9 @@ fn issue_80() {
 
 #[test]
 fn issue_82() {
-    let input = PathBuf::from("tests/files/issue-82.png");
-    let (output, opts) = get_opts(&input);
-
     test_it_converts(
-        &input,
-        &output,
-        &opts,
+        "tests/files/issue-82.png",
+        None,
         ColorType::Indexed,
         BitDepth::Four,
         ColorType::Indexed,
@@ -298,13 +247,9 @@ fn issue_82() {
 
 #[test]
 fn issue_89() {
-    let input = PathBuf::from("tests/files/issue-89.png");
-    let (output, opts) = get_opts(&input);
-
     test_it_converts(
-        &input,
-        &output,
-        &opts,
+        "tests/files/issue-89.png",
+        None,
         ColorType::RGBA,
         BitDepth::Eight,
         ColorType::Grayscale,
@@ -314,13 +259,9 @@ fn issue_89() {
 
 #[test]
 fn issue_92_filter_0() {
-    let input = PathBuf::from("tests/files/issue-92.png");
-    let (output, opts) = get_opts(&input);
-
     test_it_converts(
-        &input,
-        &output,
-        &opts,
+        "tests/files/issue-92.png",
+        None,
         ColorType::Grayscale,
         BitDepth::Eight,
         ColorType::Grayscale,
@@ -330,17 +271,14 @@ fn issue_92_filter_0() {
 
 #[test]
 fn issue_92_filter_5() {
-    let input = PathBuf::from("tests/files/issue-92.png");
-    let (_, mut opts) = get_opts(&input);
-    let mut filter = HashSet::new();
-    filter.insert(5);
-    opts.filter = filter;
-    let output = OutFile::Path(Some(input.with_extension("-f5-out.png").to_owned()));
+    let input = "tests/files/issue-92.png";
+    let (_, mut opts) = get_opts(Path::new(input));
+    opts.filter = [5].iter().cloned().collect();
+    let output = OutFile::Path(Some(Path::new(input).with_extension("-f5-out.png").to_owned()));
 
     test_it_converts(
         &input,
-        &output,
-        &opts,
+        Some((output, opts)),
         ColorType::Grayscale,
         BitDepth::Eight,
         ColorType::Grayscale,


### PR DESCRIPTION
Moved args to `test_it_converts` to minimize amount of code for each test.