### PR TITLE
Reduce allocations

### DIFF
--- a/src/png/scan_lines.rs
+++ b/src/png/scan_lines.rs
@@ -12,7 +12,7 @@ pub struct ScanLines<'a> {
 }
 
 impl<'a> Iterator for ScanLines<'a> {
-    type Item = ScanLine;
+    type Item = ScanLine<'a>;
     fn next(&mut self) -> Option<Self::Item> {
         if self.end == self.png.raw_data.len() {
             None
@@ -109,7 +109,7 @@ impl<'a> Iterator for ScanLines<'a> {
             }
             Some(ScanLine {
                 filter: self.png.raw_data[self.start],
-                data: self.png.raw_data[(self.start + 1)..self.end].to_owned(),
+                data: &self.png.raw_data[(self.start + 1)..self.end],
                 pass: current_pass,
             })
         } else {
@@ -122,7 +122,7 @@ impl<'a> Iterator for ScanLines<'a> {
             self.end = self.start + bytes_per_line + 1;
             Some(ScanLine {
                 filter: self.png.raw_data[self.start],
-                data: self.png.raw_data[(self.start + 1)..self.end].to_owned(),
+                data: &self.png.raw_data[(self.start + 1)..self.end],
                 pass: None,
             })
         }
@@ -131,11 +131,11 @@ impl<'a> Iterator for ScanLines<'a> {
 
 #[derive(Debug, Clone)]
 /// A scan line in a PNG image
-pub struct ScanLine {
+pub struct ScanLine<'a> {
     /// The filter type used to encode the current scan line (0-4)
     pub filter: u8,
     /// The byte data for the current scan line, encoded with the filter specified in the `filter` field
-    pub data: Vec<u8>,
+    pub data: &'a[u8],
     /// The current pass if the image is interlaced
     pub pass: Option<u8>,
 }

--- a/src/reduction/alpha.rs
+++ b/src/reduction/alpha.rs
@@ -1,12 +1,14 @@
 use png::PngData;
 
-pub fn reduce_alpha_channel(png: &mut PngData, channels: usize) -> Option<Vec<u8>> {
-    let byte_depth: u8 = png.ihdr_data.bit_depth.as_u8() >> 3;
-    let bpp: usize = channels * byte_depth as usize;
-    let colored_bytes = bpp - byte_depth as usize;
+pub fn reduce_alpha_channel(png: &mut PngData, channels: u8) -> Option<Vec<u8>> {
+    let byte_depth = png.ihdr_data.bit_depth.as_u8() >> 3;
+    let bpp = channels * byte_depth;
+    let bpp_mask = bpp - 1;
+    assert_eq!(0, bpp & bpp_mask);
+    let colored_bytes = bpp - byte_depth;
     for line in png.scan_lines() {
         for (i, &byte) in line.data.iter().enumerate() {
-            if i % bpp >= colored_bytes {
+            if i as u8 & bpp_mask >= colored_bytes {
                 if byte != 255 {
                     return None;
                 }
@@ -18,7 +20,7 @@ pub fn reduce_alpha_channel(png: &mut PngData, channels: usize) -> Option<Vec<u8
     for line in png.scan_lines() {
         reduced.push(line.filter);
         for (i, &byte) in line.data.iter().enumerate() {
-            if i % bpp >= colored_bytes {
+            if i as u8 & bpp_mask >= colored_bytes {
                 continue;
             } else {
                 reduced.push(byte);
@@ -29,7 +31,7 @@ pub fn reduce_alpha_channel(png: &mut PngData, channels: usize) -> Option<Vec<u8
     // sBIT contains information about alpha channel's original depth,
     // and alpha has just been removed
     if let Some(sbit_header) = png.aux_headers.get_mut(&"sBIT".to_string()) {
-        assert_eq!(sbit_header.len(), channels);
+        assert_eq!(sbit_header.len(), channels as usize);
         sbit_header.pop();
     }
 

--- a/src/reduction/alpha.rs
+++ b/src/reduction/alpha.rs
@@ -1,24 +1,35 @@
 use png::PngData;
 
-pub fn reduce_alpha_channel(png: &mut PngData, bpp_factor: usize) -> Option<Vec<u8>> {
-    let mut reduced = Vec::with_capacity(png.raw_data.len());
+pub fn reduce_alpha_channel(png: &mut PngData, channels: usize) -> Option<Vec<u8>> {
     let byte_depth: u8 = png.ihdr_data.bit_depth.as_u8() >> 3;
-    let bpp: usize = bpp_factor * byte_depth as usize;
+    let bpp: usize = channels * byte_depth as usize;
     let colored_bytes = bpp - byte_depth as usize;
     for line in png.scan_lines() {
-        reduced.push(line.filter);
-        for (i, byte) in line.data.iter().enumerate() {
+        for (i, &byte) in line.data.iter().enumerate() {
             if i % bpp >= colored_bytes {
-                if *byte != 255 {
+                if byte != 255 {
                     return None;
                 }
-            } else {
-                reduced.push(*byte);
             }
         }
     }
+
+    let mut reduced = Vec::with_capacity(png.raw_data.len());
+    for line in png.scan_lines() {
+        reduced.push(line.filter);
+        for (i, &byte) in line.data.iter().enumerate() {
+            if i % bpp >= colored_bytes {
+                continue;
+            } else {
+                reduced.push(byte);
+            }
+        }
+    }
+
+    // sBIT contains information about alpha channel's original depth,
+    // and alpha has just been removed
     if let Some(sbit_header) = png.aux_headers.get_mut(&"sBIT".to_string()) {
-        assert_eq!(sbit_header.len(), bpp_factor);
+        assert_eq!(sbit_header.len(), channels);
         sbit_header.pop();
     }
 


### PR DESCRIPTION
ScanLine iterator can borrow lines instead of copying them