### PR TITLE
Expose only one internal module specifically for tests

### DIFF
--- a/benches/deflate.rs
+++ b/benches/deflate.rs
@@ -3,28 +3,29 @@
 extern crate oxipng;
 extern crate test;
 
-use oxipng::png;
-use oxipng::deflate;
+use oxipng::internal_tests::*;
 use test::Bencher;
 use std::path::PathBuf;
 
 #[bench]
 fn deflate_16_bits_strategy_0(b: &mut Bencher) {
     let input = test::black_box(PathBuf::from("tests/files/rgb_16_should_be_rgb_16.png"));
-    let png = png::PngData::new(&input, false).unwrap();
+    let png = PngData::new(&input, false).unwrap();
 
     b.iter(|| {
-        deflate::deflate(png.raw_data.as_ref(), 9, 0, 15, None)
+        let min = AtomicMin::new(None);
+        deflate(png.raw_data.as_ref(), 9, 0, 15, &min)
     });
 }
 
 #[bench]
 fn deflate_8_bits_strategy_0(b: &mut Bencher) {
     let input = test::black_box(PathBuf::from("tests/files/rgb_8_should_be_rgb_8.png"));
-    let png = png::PngData::new(&input, false).unwrap();
+    let png = PngData::new(&input, false).unwrap();
 
     b.iter(|| {
-        deflate::deflate(png.raw_data.as_ref(), 9, 0, 15, None)
+        let min = AtomicMin::new(None);
+        deflate(png.raw_data.as_ref(), 9, 0, 15, &min)
     });
 }
 
@@ -33,10 +34,11 @@ fn deflate_4_bits_strategy_0(b: &mut Bencher) {
     let input = test::black_box(PathBuf::from(
         "tests/files/palette_4_should_be_palette_4.png",
     ));
-    let png = png::PngData::new(&input, false).unwrap();
+    let png = PngData::new(&input, false).unwrap();
 
     b.iter(|| {
-        deflate::deflate(png.raw_data.as_ref(), 9, 0, 15, None)
+        let min = AtomicMin::new(None);
+        deflate(png.raw_data.as_ref(), 9, 0, 15, &min)
     });
 }
 
@@ -45,10 +47,11 @@ fn deflate_2_bits_strategy_0(b: &mut Bencher) {
     let input = test::black_box(PathBuf::from(
         "tests/files/palette_2_should_be_palette_2.png",
     ));
-    let png = png::PngData::new(&input, false).unwrap();
+    let png = PngData::new(&input, false).unwrap();
 
     b.iter(|| {
-        deflate::deflate(png.raw_data.as_ref(), 9, 0, 15, None)
+        let min = AtomicMin::new(None);
+        deflate(png.raw_data.as_ref(), 9, 0, 15, &min)
     });
 }
 
@@ -57,30 +60,33 @@ fn deflate_1_bits_strategy_0(b: &mut Bencher) {
     let input = test::black_box(PathBuf::from(
         "tests/files/palette_1_should_be_palette_1.png",
     ));
-    let png = png::PngData::new(&input, false).unwrap();
+    let png = PngData::new(&input, false).unwrap();
 
     b.iter(|| {
-        deflate::deflate(png.raw_data.as_ref(), 9, 0, 15, None)
+        let min = AtomicMin::new(None);
+        deflate(png.raw_data.as_ref(), 9, 0, 15, &min)
     });
 }
 
 #[bench]
 fn deflate_16_bits_strategy_1(b: &mut Bencher) {
     let input = test::black_box(PathBuf::from("tests/files/rgb_16_should_be_rgb_16.png"));
-    let png = png::PngData::new(&input, false).unwrap();
+    let png = PngData::new(&input, false).unwrap();
 
     b.iter(|| {
-        deflate::deflate(png.raw_data.as_ref(), 9, 1, 15, None)
+        let min = AtomicMin::new(None);
+        deflate(png.raw_data.as_ref(), 9, 1, 15, &min)
     });
 }
 
 #[bench]
 fn deflate_8_bits_strategy_1(b: &mut Bencher) {
     let input = test::black_box(PathBuf::from("tests/files/rgb_8_should_be_rgb_8.png"));
-    let png = png::PngData::new(&input, false).unwrap();
+    let png = PngData::new(&input, false).unwrap();
 
     b.iter(|| {
-        deflate::deflate(png.raw_data.as_ref(), 9, 1, 15, None)
+        let min = AtomicMin::new(None);
+        deflate(png.raw_data.as_ref(), 9, 1, 15, &min)
     });
 }
 
@@ -89,10 +95,11 @@ fn deflate_4_bits_strategy_1(b: &mut Bencher) {
     let input = test::black_box(PathBuf::from(
         "tests/files/palette_4_should_be_palette_4.png",
     ));
-    let png = png::PngData::new(&input, false).unwrap();
+    let png = PngData::new(&input, false).unwrap();
 
     b.iter(|| {
-        deflate::deflate(png.raw_data.as_ref(), 9, 1, 15, None)
+        let min = AtomicMin::new(None);
+        deflate(png.raw_data.as_ref(), 9, 1, 15, &min)
     });
 }
 
@@ -101,10 +108,11 @@ fn deflate_2_bits_strategy_1(b: &mut Bencher) {
     let input = test::black_box(PathBuf::from(
         "tests/files/palette_2_should_be_palette_2.png",
     ));
-    let png = png::PngData::new(&input, false).unwrap();
+    let png = PngData::new(&input, false).unwrap();
 
     b.iter(|| {
-        deflate::deflate(png.raw_data.as_ref(), 9, 1, 15, None)
+        let min = AtomicMin::new(None);
+        deflate(png.raw_data.as_ref(), 9, 1, 15, &min)
     });
 }
 
@@ -113,30 +121,33 @@ fn deflate_1_bits_strategy_1(b: &mut Bencher) {
     let input = test::black_box(PathBuf::from(
         "tests/files/palette_1_should_be_palette_1.png",
     ));
-    let png = png::PngData::new(&input, false).unwrap();
+    let png = PngData::new(&input, false).unwrap();
 
     b.iter(|| {
-        deflate::deflate(png.raw_data.as_ref(), 9, 1, 15, None)
+        let min = AtomicMin::new(None);
+        deflate(png.raw_data.as_ref(), 9, 1, 15, &min)
     });
 }
 
 #[bench]
 fn deflate_16_bits_strategy_2(b: &mut Bencher) {
     let input = test::black_box(PathBuf::from("tests/files/rgb_16_should_be_rgb_16.png"));
-    let png = png::PngData::new(&input, false).unwrap();
+    let png = PngData::new(&input, false).unwrap();
 
     b.iter(|| {
-        deflate::deflate(png.raw_data.as_ref(), 9, 2, 15, None)
+        let min = AtomicMin::new(None);
+        deflate(png.raw_data.as_ref(), 9, 2, 15, &min)
     });
 }
 
 #[bench]
 fn deflate_8_bits_strategy_2(b: &mut Bencher) {
     let input = test::black_box(PathBuf::from("tests/files/rgb_8_should_be_rgb_8.png"));
-    let png = png::PngData::new(&input, false).unwrap();
+    let png = PngData::new(&input, false).unwrap();
 
     b.iter(|| {
-        deflate::deflate(png.raw_data.as_ref(), 9, 2, 15, None)
+        let min = AtomicMin::new(None);
+        deflate(png.raw_data.as_ref(), 9, 2, 15, &min)
     });
 }
 
@@ -145,10 +156,11 @@ fn deflate_4_bits_strategy_2(b: &mut Bencher) {
     let input = test::black_box(PathBuf::from(
         "tests/files/palette_4_should_be_palette_4.png",
     ));
-    let png = png::PngData::new(&input, false).unwrap();
+    let png = PngData::new(&input, false).unwrap();
 
     b.iter(|| {
-        deflate::deflate(png.raw_data.as_ref(), 9, 2, 15, None)
+        let min = AtomicMin::new(None);
+        deflate(png.raw_data.as_ref(), 9, 2, 15, &min)
     });
 }
 
@@ -157,10 +169,11 @@ fn deflate_2_bits_strategy_2(b: &mut Bencher) {
     let input = test::black_box(PathBuf::from(
         "tests/files/palette_2_should_be_palette_2.png",
     ));
-    let png = png::PngData::new(&input, false).unwrap();
+    let png = PngData::new(&input, false).unwrap();
 
     b.iter(|| {
-        deflate::deflate(png.raw_data.as_ref(), 9, 2, 15, None)
+        let min = AtomicMin::new(None);
+        deflate(png.raw_data.as_ref(), 9, 2, 15, &min)
     });
 }
 
@@ -169,30 +182,33 @@ fn deflate_1_bits_strategy_2(b: &mut Bencher) {
     let input = test::black_box(PathBuf::from(
         "tests/files/palette_1_should_be_palette_1.png",
     ));
-    let png = png::PngData::new(&input, false).unwrap();
+    let png = PngData::new(&input, false).unwrap();
 
     b.iter(|| {
-        deflate::deflate(png.raw_data.as_ref(), 9, 2, 15, None)
+        let min = AtomicMin::new(None);
+        deflate(png.raw_data.as_ref(), 9, 2, 15, &min)
     });
 }
 
 #[bench]
 fn deflate_16_bits_strategy_3(b: &mut Bencher) {
     let input = test::black_box(PathBuf::from("tests/files/rgb_16_should_be_rgb_16.png"));
-    let png = png::PngData::new(&input, false).unwrap();
+    let png = PngData::new(&input, false).unwrap();
 
     b.iter(|| {
-        deflate::deflate(png.raw_data.as_ref(), 9, 3, 15, None)
+        let min = AtomicMin::new(None);
+        deflate(png.raw_data.as_ref(), 9, 3, 15, &min)
     });
 }
 
 #[bench]
 fn deflate_8_bits_strategy_3(b: &mut Bencher) {
     let input = test::black_box(PathBuf::from("tests/files/rgb_8_should_be_rgb_8.png"));
-    let png = png::PngData::new(&input, false).unwrap();
+    let png = PngData::new(&input, false).unwrap();
 
     b.iter(|| {
-        deflate::deflate(png.raw_data.as_ref(), 9, 3, 15, None)
+        let min = AtomicMin::new(None);
+        deflate(png.raw_data.as_ref(), 9, 3, 15, &min)
     });
 }
 
@@ -201,10 +217,11 @@ fn deflate_4_bits_strategy_3(b: &mut Bencher) {
     let input = test::black_box(PathBuf::from(
         "tests/files/palette_4_should_be_palette_4.png",
     ));
-    let png = png::PngData::new(&input, false).unwrap();
+    let png = PngData::new(&input, false).unwrap();
 
     b.iter(|| {
-        deflate::deflate(png.raw_data.as_ref(), 9, 3, 15, None)
+        let min = AtomicMin::new(None);
+        deflate(png.raw_data.as_ref(), 9, 3, 15, &min)
     });
 }
 
@@ -213,10 +230,11 @@ fn deflate_2_bits_strategy_3(b: &mut Bencher) {
     let input = test::black_box(PathBuf::from(
         "tests/files/palette_2_should_be_palette_2.png",
     ));
-    let png = png::PngData::new(&input, false).unwrap();
+    let png = PngData::new(&input, false).unwrap();
 
     b.iter(|| {
-        deflate::deflate(png.raw_data.as_ref(), 9, 3, 15, None)
+        let min = AtomicMin::new(None);
+        deflate(png.raw_data.as_ref(), 9, 3, 15, &min)
     });
 }
 
@@ -225,19 +243,20 @@ fn deflate_1_bits_strategy_3(b: &mut Bencher) {
     let input = test::black_box(PathBuf::from(
         "tests/files/palette_1_should_be_palette_1.png",
     ));
-    let png = png::PngData::new(&input, false).unwrap();
+    let png = PngData::new(&input, false).unwrap();
 
     b.iter(|| {
-        deflate::deflate(png.raw_data.as_ref(), 9, 3, 15, None)
+        let min = AtomicMin::new(None);
+        deflate(png.raw_data.as_ref(), 9, 3, 15, &min)
     });
 }
 
 #[bench]
 fn inflate_generic(b: &mut Bencher) {
     let input = test::black_box(PathBuf::from("tests/files/rgb_16_should_be_rgb_16.png"));
-    let png = png::PngData::new(&input, false).unwrap();
+    let png = PngData::new(&input, false).unwrap();
 
     b.iter(|| {
-        deflate::inflate(png.idat_data.as_ref())
+        inflate(png.idat_data.as_ref())
     });
 }

--- a/benches/filters.rs
+++ b/benches/filters.rs
@@ -3,14 +3,14 @@
 extern crate oxipng;
 extern crate test;
 
-use oxipng::png;
+use oxipng::internal_tests::*;
 use test::Bencher;
 use std::path::PathBuf;
 
 #[bench]
 fn filters_16_bits_filter_0(b: &mut Bencher) {
     let input = test::black_box(PathBuf::from("tests/files/rgb_16_should_be_rgb_16.png"));
-    let png = png::PngData::new(&input, false).unwrap();
+    let png = PngData::new(&input, false).unwrap();
 
     b.iter(|| {
         png.filter_image(0);
@@ -20,7 +20,7 @@ fn filters_16_bits_filter_0(b: &mut Bencher) {
 #[bench]
 fn filters_8_bits_filter_0(b: &mut Bencher) {
     let input = test::black_box(PathBuf::from("tests/files/rgb_8_should_be_rgb_8.png"));
-    let png = png::PngData::new(&input, false).unwrap();
+    let png = PngData::new(&input, false).unwrap();
 
     b.iter(|| {
         png.filter_image(0);
@@ -32,7 +32,7 @@ fn filters_4_bits_filter_0(b: &mut Bencher) {
     let input = test::black_box(PathBuf::from(
         "tests/files/palette_4_should_be_palette_4.png",
     ));
-    let png = png::PngData::new(&input, false).unwrap();
+    let png = PngData::new(&input, false).unwrap();
 
     b.iter(|| {
         png.filter_image(0);
@@ -44,7 +44,7 @@ fn filters_2_bits_filter_0(b: &mut Bencher) {
     let input = test::black_box(PathBuf::from(
         "tests/files/palette_2_should_be_palette_2.png",
     ));
-    let png = png::PngData::new(&input, false).unwrap();
+    let png = PngData::new(&input, false).unwrap();
 
     b.iter(|| {
         png.filter_image(0);
@@ -56,7 +56,7 @@ fn filters_1_bits_filter_0(b: &mut Bencher) {
     let input = test::black_box(PathBuf::from(
         "tests/files/palette_1_should_be_palette_1.png",
     ));
-    let png = png::PngData::new(&input, false).unwrap();
+    let png = PngData::new(&input, false).unwrap();
 
     b.iter(|| {
         png.filter_image(0);
@@ -66,7 +66,7 @@ fn filters_1_bits_filter_0(b: &mut Bencher) {
 #[bench]
 fn filters_16_bits_filter_1(b: &mut Bencher) {
     let input = test::black_box(PathBuf::from("tests/files/rgb_16_should_be_rgb_16.png"));
-    let png = png::PngData::new(&input, false).unwrap();
+    let png = PngData::new(&input, false).unwrap();
 
     b.iter(|| {
         png.filter_image(1);
@@ -76,7 +76,7 @@ fn filters_16_bits_filter_1(b: &mut Bencher) {
 #[bench]
 fn filters_8_bits_filter_1(b: &mut Bencher) {
     let input = test::black_box(PathBuf::from("tests/files/rgb_8_should_be_rgb_8.png"));
-    let png = png::PngData::new(&input, false).unwrap();
+    let png = PngData::new(&input, false).unwrap();
 
     b.iter(|| {
         png.filter_image(1);
@@ -88,7 +88,7 @@ fn filters_4_bits_filter_1(b: &mut Bencher) {
     let input = test::black_box(PathBuf::from(
         "tests/files/palette_4_should_be_palette_4.png",
     ));
-    let png = png::PngData::new(&input, false).unwrap();
+    let png = PngData::new(&input, false).unwrap();
 
     b.iter(|| {
         png.filter_image(1);
@@ -100,7 +100,7 @@ fn filters_2_bits_filter_1(b: &mut Bencher) {
     let input = test::black_box(PathBuf::from(
         "tests/files/palette_2_should_be_palette_2.png",
     ));
-    let png = png::PngData::new(&input, false).unwrap();
+    let png = PngData::new(&input, false).unwrap();
 
     b.iter(|| {
         png.filter_image(1);
@@ -112,7 +112,7 @@ fn filters_1_bits_filter_1(b: &mut Bencher) {
     let input = test::black_box(PathBuf::from(
         "tests/files/palette_1_should_be_palette_1.png",
     ));
-    let png = png::PngData::new(&input, false).unwrap();
+    let png = PngData::new(&input, false).unwrap();
 
     b.iter(|| {
         png.filter_image(1);
@@ -122,7 +122,7 @@ fn filters_1_bits_filter_1(b: &mut Bencher) {
 #[bench]
 fn filters_16_bits_filter_2(b: &mut Bencher) {
     let input = test::black_box(PathBuf::from("tests/files/rgb_16_should_be_rgb_16.png"));
-    let png = png::PngData::new(&input, false).unwrap();
+    let png = PngData::new(&input, false).unwrap();
 
     b.iter(|| {
         png.filter_image(2);
@@ -132,7 +132,7 @@ fn filters_16_bits_filter_2(b: &mut Bencher) {
 #[bench]
 fn filters_8_bits_filter_2(b: &mut Bencher) {
     let input = test::black_box(PathBuf::from("tests/files/rgb_8_should_be_rgb_8.png"));
-    let png = png::PngData::new(&input, false).unwrap();
+    let png = PngData::new(&input, false).unwrap();
 
     b.iter(|| {
         png.filter_image(2);
@@ -144,7 +144,7 @@ fn filters_4_bits_filter_2(b: &mut Bencher) {
     let input = test::black_box(PathBuf::from(
         "tests/files/palette_4_should_be_palette_4.png",
     ));
-    let png = png::PngData::new(&input, false).unwrap();
+    let png = PngData::new(&input, false).unwrap();
 
     b.iter(|| {
         png.filter_image(2);
@@ -156,7 +156,7 @@ fn filters_2_bits_filter_2(b: &mut Bencher) {
     let input = test::black_box(PathBuf::from(
         "tests/files/palette_2_should_be_palette_2.png",
     ));
-    let png = png::PngData::new(&input, false).unwrap();
+    let png = PngData::new(&input, false).unwrap();
 
     b.iter(|| {
         png.filter_image(2);
@@ -168,7 +168,7 @@ fn filters_1_bits_filter_2(b: &mut Bencher) {
     let input = test::black_box(PathBuf::from(
         "tests/files/palette_1_should_be_palette_1.png",
     ));
-    let png = png::PngData::new(&input, false).unwrap();
+    let png = PngData::new(&input, false).unwrap();
 
     b.iter(|| {
         png.filter_image(2);
@@ -178,7 +178,7 @@ fn filters_1_bits_filter_2(b: &mut Bencher) {
 #[bench]
 fn filters_16_bits_filter_3(b: &mut Bencher) {
     let input = test::black_box(PathBuf::from("tests/files/rgb_16_should_be_rgb_16.png"));
-    let png = png::PngData::new(&input, false).unwrap();
+    let png = PngData::new(&input, false).unwrap();
 
     b.iter(|| {
         png.filter_image(3);
@@ -188,7 +188,7 @@ fn filters_16_bits_filter_3(b: &mut Bencher) {
 #[bench]
 fn filters_8_bits_filter_3(b: &mut Bencher) {
     let input = test::black_box(PathBuf::from("tests/files/rgb_8_should_be_rgb_8.png"));
-    let png = png::PngData::new(&input, false).unwrap();
+    let png = PngData::new(&input, false).unwrap();
 
     b.iter(|| {
         png.filter_image(3);
@@ -200,7 +200,7 @@ fn filters_4_bits_filter_3(b: &mut Bencher) {
     let input = test::black_box(PathBuf::from(
         "tests/files/palette_4_should_be_palette_4.png",
     ));
-    let png = png::PngData::new(&input, false).unwrap();
+    let png = PngData::new(&input, false).unwrap();
 
     b.iter(|| {
         png.filter_image(3);
@@ -212,7 +212,7 @@ fn filters_2_bits_filter_3(b: &mut Bencher) {
     let input = test::black_box(PathBuf::from(
         "tests/files/palette_2_should_be_palette_2.png",
     ));
-    let png = png::PngData::new(&input, false).unwrap();
+    let png = PngData::new(&input, false).unwrap();
 
     b.iter(|| {
         png.filter_image(3);
@@ -224,7 +224,7 @@ fn filters_1_bits_filter_3(b: &mut Bencher) {
     let input = test::black_box(PathBuf::from(
         "tests/files/palette_1_should_be_palette_1.png",
     ));
-    let png = png::PngData::new(&input, false).unwrap();
+    let png = PngData::new(&input, false).unwrap();
 
     b.iter(|| {
         png.filter_image(3);
@@ -234,7 +234,7 @@ fn filters_1_bits_filter_3(b: &mut Bencher) {
 #[bench]
 fn filters_16_bits_filter_4(b: &mut Bencher) {
     let input = test::black_box(PathBuf::from("tests/files/rgb_16_should_be_rgb_16.png"));
-    let png = png::PngData::new(&input, false).unwrap();
+    let png = PngData::new(&input, false).unwrap();
 
     b.iter(|| {
         png.filter_image(4);
@@ -244,7 +244,7 @@ fn filters_16_bits_filter_4(b: &mut Bencher) {
 #[bench]
 fn filters_8_bits_filter_4(b: &mut Bencher) {
     let input = test::black_box(PathBuf::from("tests/files/rgb_8_should_be_rgb_8.png"));
-    let png = png::PngData::new(&input, false).unwrap();
+    let png = PngData::new(&input, false).unwrap();
 
     b.iter(|| {
         png.filter_image(4);
@@ -256,7 +256,7 @@ fn filters_4_bits_filter_4(b: &mut Bencher) {
     let input = test::black_box(PathBuf::from(
         "tests/files/palette_4_should_be_palette_4.png",
     ));
-    let png = png::PngData::new(&input, false).unwrap();
+    let png = PngData::new(&input, false).unwrap();
 
     b.iter(|| {
         png.filter_image(4);
@@ -268,7 +268,7 @@ fn filters_2_bits_filter_4(b: &mut Bencher) {
     let input = test::black_box(PathBuf::from(
         "tests/files/palette_2_should_be_palette_2.png",
     ));
-    let png = png::PngData::new(&input, false).unwrap();
+    let png = PngData::new(&input, false).unwrap();
 
     b.iter(|| {
         png.filter_image(4);
@@ -280,7 +280,7 @@ fn filters_1_bits_filter_4(b: &mut Bencher) {
     let input = test::black_box(PathBuf::from(
         "tests/files/palette_1_should_be_palette_1.png",
     ));
-    let png = png::PngData::new(&input, false).unwrap();
+    let png = PngData::new(&input, false).unwrap();
 
     b.iter(|| {
         png.filter_image(4);
@@ -290,7 +290,7 @@ fn filters_1_bits_filter_4(b: &mut Bencher) {
 #[bench]
 fn filters_16_bits_filter_5(b: &mut Bencher) {
     let input = test::black_box(PathBuf::from("tests/files/rgb_16_should_be_rgb_16.png"));
-    let png = png::PngData::new(&input, false).unwrap();
+    let png = PngData::new(&input, false).unwrap();
 
     b.iter(|| {
         png.filter_image(5);
@@ -300,7 +300,7 @@ fn filters_16_bits_filter_5(b: &mut Bencher) {
 #[bench]
 fn filters_8_bits_filter_5(b: &mut Bencher) {
     let input = test::black_box(PathBuf::from("tests/files/rgb_8_should_be_rgb_8.png"));
-    let png = png::PngData::new(&input, false).unwrap();
+    let png = PngData::new(&input, false).unwrap();
 
     b.iter(|| {
         png.filter_image(5);
@@ -312,7 +312,7 @@ fn filters_4_bits_filter_5(b: &mut Bencher) {
     let input = test::black_box(PathBuf::from(
         "tests/files/palette_4_should_be_palette_4.png",
     ));
-    let png = png::PngData::new(&input, false).unwrap();
+    let png = PngData::new(&input, false).unwrap();
 
     b.iter(|| {
         png.filter_image(5);
@@ -324,7 +324,7 @@ fn filters_2_bits_filter_5(b: &mut Bencher) {
     let input = test::black_box(PathBuf::from(
         "tests/files/palette_2_should_be_palette_2.png",
     ));
-    let png = png::PngData::new(&input, false).unwrap();
+    let png = PngData::new(&input, false).unwrap();
 
     b.iter(|| {
         png.filter_image(5);
@@ -336,7 +336,7 @@ fn filters_1_bits_filter_5(b: &mut Bencher) {
     let input = test::black_box(PathBuf::from(
         "tests/files/palette_1_should_be_palette_1.png",
     ));
-    let png = png::PngData::new(&input, false).unwrap();
+    let png = PngData::new(&input, false).unwrap();
 
     b.iter(|| {
         png.filter_image(5);

--- a/benches/interlacing.rs
+++ b/benches/interlacing.rs
@@ -3,14 +3,14 @@
 extern crate oxipng;
 extern crate test;
 
-use oxipng::png;
+use oxipng::internal_tests::*;
 use test::Bencher;
 use std::path::PathBuf;
 
 #[bench]
 fn interlacing_16_bits(b: &mut Bencher) {
     let input = test::black_box(PathBuf::from("tests/files/rgb_16_should_be_rgb_16.png"));
-    let png = png::PngData::new(&input, false).unwrap();
+    let png = PngData::new(&input, false).unwrap();
 
     b.iter(|| {
         let mut safe_png = png.clone();
@@ -21,7 +21,7 @@ fn interlacing_16_bits(b: &mut Bencher) {
 #[bench]
 fn interlacing_8_bits(b: &mut Bencher) {
     let input = test::black_box(PathBuf::from("tests/files/rgb_8_should_be_rgb_8.png"));
-    let png = png::PngData::new(&input, false).unwrap();
+    let png = PngData::new(&input, false).unwrap();
 
     b.iter(|| {
         let mut safe_png = png.clone();
@@ -34,7 +34,7 @@ fn interlacing_4_bits(b: &mut Bencher) {
     let input = test::black_box(PathBuf::from(
         "tests/files/palette_4_should_be_palette_4.png",
     ));
-    let png = png::PngData::new(&input, false).unwrap();
+    let png = PngData::new(&input, false).unwrap();
 
     b.iter(|| {
         let mut safe_png = png.clone();
@@ -47,7 +47,7 @@ fn interlacing_2_bits(b: &mut Bencher) {
     let input = test::black_box(PathBuf::from(
         "tests/files/palette_2_should_be_palette_2.png",
     ));
-    let png = png::PngData::new(&input, false).unwrap();
+    let png = PngData::new(&input, false).unwrap();
 
     b.iter(|| {
         let mut safe_png = png.clone();
@@ -60,7 +60,7 @@ fn interlacing_1_bits(b: &mut Bencher) {
     let input = test::black_box(PathBuf::from(
         "tests/files/palette_1_should_be_palette_1.png",
     ));
-    let png = png::PngData::new(&input, false).unwrap();
+    let png = PngData::new(&input, false).unwrap();
 
     b.iter(|| {
         let mut safe_png = png.clone();
@@ -73,7 +73,7 @@ fn deinterlacing_16_bits(b: &mut Bencher) {
     let input = test::black_box(PathBuf::from(
         "tests/files/interlaced_rgb_16_should_be_rgb_16.png",
     ));
-    let png = png::PngData::new(&input, false).unwrap();
+    let png = PngData::new(&input, false).unwrap();
 
     b.iter(|| {
         let mut safe_png = png.clone();
@@ -86,7 +86,7 @@ fn deinterlacing_8_bits(b: &mut Bencher) {
     let input = test::black_box(PathBuf::from(
         "tests/files/interlaced_rgb_8_should_be_rgb_8.png",
     ));
-    let png = png::PngData::new(&input, false).unwrap();
+    let png = PngData::new(&input, false).unwrap();
 
     b.iter(|| {
         let mut safe_png = png.clone();
@@ -99,7 +99,7 @@ fn deinterlacing_4_bits(b: &mut Bencher) {
     let input = test::black_box(PathBuf::from(
         "tests/files/interlaced_palette_4_should_be_palette_4.png",
     ));
-    let png = png::PngData::new(&input, false).unwrap();
+    let png = PngData::new(&input, false).unwrap();
 
     b.iter(|| {
         let mut safe_png = png.clone();
@@ -112,7 +112,7 @@ fn deinterlacing_2_bits(b: &mut Bencher) {
     let input = test::black_box(PathBuf::from(
         "tests/files/interlaced_palette_2_should_be_palette_2.png",
     ));
-    let png = png::PngData::new(&input, false).unwrap();
+    let png = PngData::new(&input, false).unwrap();
 
     b.iter(|| {
         let mut safe_png = png.clone();
@@ -125,7 +125,7 @@ fn deinterlacing_1_bits(b: &mut Bencher) {
     let input = test::black_box(PathBuf::from(
         "tests/files/interlaced_palette_1_should_be_palette_1.png",
     ));
-    let png = png::PngData::new(&input, false).unwrap();
+    let png = PngData::new(&input, false).unwrap();
 
     b.iter(|| {
         let mut safe_png = png.clone();

--- a/benches/reductions.rs
+++ b/benches/reductions.rs
@@ -3,15 +3,14 @@
 extern crate oxipng;
 extern crate test;
 
-use oxipng::png;
-use oxipng::colors::AlphaOptim;
+use oxipng::internal_tests::*;
 use test::Bencher;
 use std::path::PathBuf;
 
 #[bench]
 fn reductions_16_to_8_bits(b: &mut Bencher) {
     let input = test::black_box(PathBuf::from("tests/files/rgb_16_should_be_rgb_8.png"));
-    let png = png::PngData::new(&input, false).unwrap();
+    let png = PngData::new(&input, false).unwrap();
 
     b.iter(|| {
         let mut safe_png = png.clone();
@@ -24,7 +23,7 @@ fn reductions_8_to_4_bits(b: &mut Bencher) {
     let input = test::black_box(PathBuf::from(
         "tests/files/palette_8_should_be_palette_4.png",
     ));
-    let png = png::PngData::new(&input, false).unwrap();
+    let png = PngData::new(&input, false).unwrap();
 
     b.iter(|| {
         let mut safe_png = png.clone();
@@ -37,7 +36,7 @@ fn reductions_8_to_2_bits(b: &mut Bencher) {
     let input = test::black_box(PathBuf::from(
         "tests/files/palette_8_should_be_palette_2.png",
     ));
-    let png = png::PngData::new(&input, false).unwrap();
+    let png = PngData::new(&input, false).unwrap();
 
     b.iter(|| {
         let mut safe_png = png.clone();
@@ -50,7 +49,7 @@ fn reductions_8_to_1_bits(b: &mut Bencher) {
     let input = test::black_box(PathBuf::from(
         "tests/files/palette_8_should_be_palette_1.png",
     ));
-    let png = png::PngData::new(&input, false).unwrap();
+    let png = PngData::new(&input, false).unwrap();
 
     b.iter(|| {
         let mut safe_png = png.clone();
@@ -63,7 +62,7 @@ fn reductions_4_to_2_bits(b: &mut Bencher) {
     let input = test::black_box(PathBuf::from(
         "tests/files/palette_4_should_be_palette_2.png",
     ));
-    let png = png::PngData::new(&input, false).unwrap();
+    let png = PngData::new(&input, false).unwrap();
 
     b.iter(|| {
         let mut safe_png = png.clone();
@@ -76,7 +75,7 @@ fn reductions_4_to_1_bits(b: &mut Bencher) {
     let input = test::black_box(PathBuf::from(
         "tests/files/palette_4_should_be_palette_1.png",
     ));
-    let png = png::PngData::new(&input, false).unwrap();
+    let png = PngData::new(&input, false).unwrap();
 
     b.iter(|| {
         let mut safe_png = png.clone();
@@ -89,7 +88,7 @@ fn reductions_2_to_1_bits(b: &mut Bencher) {
     let input = test::black_box(PathBuf::from(
         "tests/files/palette_2_should_be_palette_1.png",
     ));
-    let png = png::PngData::new(&input, false).unwrap();
+    let png = PngData::new(&input, false).unwrap();
 
     b.iter(|| {
         let mut safe_png = png.clone();
@@ -100,7 +99,7 @@ fn reductions_2_to_1_bits(b: &mut Bencher) {
 #[bench]
 fn reductions_rgba_to_rgb_16(b: &mut Bencher) {
     let input = test::black_box(PathBuf::from("tests/files/rgba_16_should_be_rgb_16.png"));
-    let png = png::PngData::new(&input, false).unwrap();
+    let png = PngData::new(&input, false).unwrap();
 
     b.iter(|| {
         let mut safe_png = png.clone();
@@ -111,7 +110,7 @@ fn reductions_rgba_to_rgb_16(b: &mut Bencher) {
 #[bench]
 fn reductions_rgba_to_rgb_8(b: &mut Bencher) {
     let input = test::black_box(PathBuf::from("tests/files/rgba_8_should_be_rgb_8.png"));
-    let png = png::PngData::new(&input, false).unwrap();
+    let png = PngData::new(&input, false).unwrap();
 
     b.iter(|| {
         let mut safe_png = png.clone();
@@ -124,7 +123,7 @@ fn reductions_rgba_to_grayscale_alpha_16(b: &mut Bencher) {
     let input = test::black_box(PathBuf::from(
         "tests/files/rgba_16_should_be_grayscale_alpha_16.png",
     ));
-    let png = png::PngData::new(&input, false).unwrap();
+    let png = PngData::new(&input, false).unwrap();
 
     b.iter(|| {
         let mut safe_png = png.clone();
@@ -137,7 +136,7 @@ fn reductions_rgba_to_grayscale_alpha_8(b: &mut Bencher) {
     let input = test::black_box(PathBuf::from(
         "tests/files/rgba_8_should_be_grayscale_alpha_8.png",
     ));
-    let png = png::PngData::new(&input, false).unwrap();
+    let png = PngData::new(&input, false).unwrap();
 
     b.iter(|| {
         let mut safe_png = png.clone();
@@ -150,7 +149,7 @@ fn reductions_rgba_to_grayscale_16(b: &mut Bencher) {
     let input = test::black_box(PathBuf::from(
         "tests/files/rgba_16_should_be_grayscale_16.png",
     ));
-    let png = png::PngData::new(&input, false).unwrap();
+    let png = PngData::new(&input, false).unwrap();
 
     b.iter(|| {
         let mut safe_png = png.clone();
@@ -163,7 +162,7 @@ fn reductions_rgba_to_grayscale_8(b: &mut Bencher) {
     let input = test::black_box(PathBuf::from(
         "tests/files/rgba_8_should_be_grayscale_8.png",
     ));
-    let png = png::PngData::new(&input, false).unwrap();
+    let png = PngData::new(&input, false).unwrap();
 
     b.iter(|| {
         let mut safe_png = png.clone();
@@ -176,7 +175,7 @@ fn reductions_rgb_to_grayscale_16(b: &mut Bencher) {
     let input = test::black_box(PathBuf::from(
         "tests/files/rgb_16_should_be_grayscale_16.png",
     ));
-    let png = png::PngData::new(&input, false).unwrap();
+    let png = PngData::new(&input, false).unwrap();
 
     b.iter(|| {
         let mut safe_png = png.clone();
@@ -187,7 +186,7 @@ fn reductions_rgb_to_grayscale_16(b: &mut Bencher) {
 #[bench]
 fn reductions_rgb_to_grayscale_8(b: &mut Bencher) {
     let input = test::black_box(PathBuf::from("tests/files/rgb_8_should_be_grayscale_8.png"));
-    let png = png::PngData::new(&input, false).unwrap();
+    let png = PngData::new(&input, false).unwrap();
 
     b.iter(|| {
         let mut safe_png = png.clone();
@@ -198,7 +197,7 @@ fn reductions_rgb_to_grayscale_8(b: &mut Bencher) {
 #[bench]
 fn reductions_rgba_to_palette_8(b: &mut Bencher) {
     let input = test::black_box(PathBuf::from("tests/files/rgba_8_should_be_palette_8.png"));
-    let png = png::PngData::new(&input, false).unwrap();
+    let png = PngData::new(&input, false).unwrap();
 
     b.iter(|| {
         let mut safe_png = png.clone();
@@ -209,7 +208,7 @@ fn reductions_rgba_to_palette_8(b: &mut Bencher) {
 #[bench]
 fn reductions_rgb_to_palette_8(b: &mut Bencher) {
     let input = test::black_box(PathBuf::from("tests/files/rgb_8_should_be_palette_8.png"));
-    let png = png::PngData::new(&input, false).unwrap();
+    let png = PngData::new(&input, false).unwrap();
 
     b.iter(|| {
         let mut safe_png = png.clone();
@@ -222,7 +221,7 @@ fn reductions_palette_duplicate_reduction(b: &mut Bencher) {
     let input = test::black_box(PathBuf::from(
         "tests/files/palette_should_be_reduced_with_dupes.png",
     ));
-    let png = png::PngData::new(&input, false).unwrap();
+    let png = PngData::new(&input, false).unwrap();
 
     b.iter(|| {
         let mut safe_png = png.clone();
@@ -235,7 +234,7 @@ fn reductions_palette_unused_reduction(b: &mut Bencher) {
     let input = test::black_box(PathBuf::from(
         "tests/files/palette_should_be_reduced_with_unused.png",
     ));
-    let png = png::PngData::new(&input, false).unwrap();
+    let png = PngData::new(&input, false).unwrap();
 
     b.iter(|| {
         let mut safe_png = png.clone();
@@ -248,7 +247,7 @@ fn reductions_palette_full_reduction(b: &mut Bencher) {
     let input = test::black_box(PathBuf::from(
         "tests/files/palette_should_be_reduced_with_both.png",
     ));
-    let png = png::PngData::new(&input, false).unwrap();
+    let png = PngData::new(&input, false).unwrap();
 
     b.iter(|| {
         let mut safe_png = png.clone();
@@ -259,7 +258,7 @@ fn reductions_palette_full_reduction(b: &mut Bencher) {
 #[bench]
 fn reductions_alpha_black(b: &mut Bencher) {
     let input = test::black_box(PathBuf::from("tests/files/rgba_8_reduce_alpha_black.png"));
-    let png = png::PngData::new(&input, false).unwrap();
+    let png = PngData::new(&input, false).unwrap();
 
     b.iter(|| {
         let mut safe_png = png.clone();
@@ -270,7 +269,7 @@ fn reductions_alpha_black(b: &mut Bencher) {
 #[bench]
 fn reductions_alpha_white(b: &mut Bencher) {
     let input = test::black_box(PathBuf::from("tests/files/rgba_8_reduce_alpha_white.png"));
-    let png = png::PngData::new(&input, false).unwrap();
+    let png = PngData::new(&input, false).unwrap();
 
     b.iter(|| {
         let mut safe_png = png.clone();
@@ -281,7 +280,7 @@ fn reductions_alpha_white(b: &mut Bencher) {
 #[bench]
 fn reductions_alpha_left(b: &mut Bencher) {
     let input = test::black_box(PathBuf::from("tests/files/rgba_8_reduce_alpha_left.png"));
-    let png = png::PngData::new(&input, false).unwrap();
+    let png = PngData::new(&input, false).unwrap();
 
     b.iter(|| {
         let mut safe_png = png.clone();
@@ -292,7 +291,7 @@ fn reductions_alpha_left(b: &mut Bencher) {
 #[bench]
 fn reductions_alpha_right(b: &mut Bencher) {
     let input = test::black_box(PathBuf::from("tests/files/rgba_8_reduce_alpha_right.png"));
-    let png = png::PngData::new(&input, false).unwrap();
+    let png = PngData::new(&input, false).unwrap();
 
     b.iter(|| {
         let mut safe_png = png.clone();
@@ -303,7 +302,7 @@ fn reductions_alpha_right(b: &mut Bencher) {
 #[bench]
 fn reductions_alpha_up(b: &mut Bencher) {
     let input = test::black_box(PathBuf::from("tests/files/rgba_8_reduce_alpha_up.png"));
-    let png = png::PngData::new(&input, false).unwrap();
+    let png = PngData::new(&input, false).unwrap();
 
     b.iter(|| {
         let mut safe_png = png.clone();
@@ -314,7 +313,7 @@ fn reductions_alpha_up(b: &mut Bencher) {
 #[bench]
 fn reductions_alpha_down(b: &mut Bencher) {
     let input = test::black_box(PathBuf::from("tests/files/rgba_8_reduce_alpha_down.png"));
-    let png = png::PngData::new(&input, false).unwrap();
+    let png = PngData::new(&input, false).unwrap();
 
     b.iter(|| {
         let mut safe_png = png.clone();

--- a/benches/zopfli.rs
+++ b/benches/zopfli.rs
@@ -3,28 +3,27 @@
 extern crate oxipng;
 extern crate test;
 
-use oxipng::png;
-use oxipng::deflate;
+use oxipng::internal_tests::*;
 use test::Bencher;
 use std::path::PathBuf;
 
 #[bench]
 fn zopfli_16_bits_strategy_0(b: &mut Bencher) {
     let input = test::black_box(PathBuf::from("tests/files/rgb_16_should_be_rgb_16.png"));
-    let png = png::PngData::new(&input, false).unwrap();
+    let png = PngData::new(&input, false).unwrap();
 
     b.iter(|| {
-        deflate::zopfli_deflate(png.raw_data.as_ref()).ok();
+        zopfli_deflate(png.raw_data.as_ref()).ok();
     });
 }
 
 #[bench]
 fn zopfli_8_bits_strategy_0(b: &mut Bencher) {
     let input = test::black_box(PathBuf::from("tests/files/rgb_8_should_be_rgb_8.png"));
-    let png = png::PngData::new(&input, false).unwrap();
+    let png = PngData::new(&input, false).unwrap();
 
     b.iter(|| {
-        deflate::zopfli_deflate(png.raw_data.as_ref()).ok();
+        zopfli_deflate(png.raw_data.as_ref()).ok();
     });
 }
 
@@ -33,10 +32,10 @@ fn zopfli_4_bits_strategy_0(b: &mut Bencher) {
     let input = test::black_box(PathBuf::from(
         "tests/files/palette_4_should_be_palette_4.png",
     ));
-    let png = png::PngData::new(&input, false).unwrap();
+    let png = PngData::new(&input, false).unwrap();
 
     b.iter(|| {
-        deflate::zopfli_deflate(png.raw_data.as_ref()).ok();
+        zopfli_deflate(png.raw_data.as_ref()).ok();
     });
 }
 
@@ -45,10 +44,10 @@ fn zopfli_2_bits_strategy_0(b: &mut Bencher) {
     let input = test::black_box(PathBuf::from(
         "tests/files/palette_2_should_be_palette_2.png",
     ));
-    let png = png::PngData::new(&input, false).unwrap();
+    let png = PngData::new(&input, false).unwrap();
 
     b.iter(|| {
-        deflate::zopfli_deflate(png.raw_data.as_ref()).ok();
+        zopfli_deflate(png.raw_data.as_ref()).ok();
     });
 }
 
@@ -57,9 +56,9 @@ fn zopfli_1_bits_strategy_0(b: &mut Bencher) {
     let input = test::black_box(PathBuf::from(
         "tests/files/palette_1_should_be_palette_1.png",
     ));
-    let png = png::PngData::new(&input, false).unwrap();
+    let png = PngData::new(&input, false).unwrap();
 
     b.iter(|| {
-        deflate::zopfli_deflate(png.raw_data.as_ref()).ok();
+        zopfli_deflate(png.raw_data.as_ref()).ok();
     });
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -32,20 +32,25 @@ pub use deflate::Deflaters;
 pub use error::PngError;
 pub use headers::Headers;
 
-#[doc(hidden)]
-pub mod colors;
-#[doc(hidden)]
-pub mod deflate;
-#[doc(hidden)]
-pub mod error;
+mod colors;
+mod deflate;
+mod error;
 mod filters;
-#[doc(hidden)]
-pub mod headers;
+mod headers;
 mod interlace;
-#[doc(hidden)]
-pub mod png;
+mod png;
 mod reduction;
 mod atomicmin;
+
+/// Private to oxipng; don't use outside tests and benches
+#[doc(hidden)]
+pub mod internal_tests {
+    pub use atomicmin::*;
+    pub use deflate::*;
+    pub use colors::*;
+    pub use headers::*;
+    pub use png::*;
+}
 
 #[derive(Clone, Debug)]
 pub enum OutFile {
@@ -693,7 +698,7 @@ fn optimize_png(
 
 /// Attempt all reduction operations requested by the given `Options` struct
 /// and apply them directly to the `PngData` passed in
-fn perform_reductions(png: &mut png::PngData, opts: &Options, deadline: &Deadline) -> bool {
+fn perform_reductions(png: &mut PngData, opts: &Options, deadline: &Deadline) -> bool {
     let mut reduction_occurred = false;
 
     if opts.palette_reduction && png.reduce_palette() {
@@ -781,7 +786,7 @@ impl Deadline {
 }
 
 /// Display the status of the image data after a reduction has taken place
-fn report_reduction(png: &png::PngData) {
+fn report_reduction(png: &PngData) {
     if let Some(ref palette) = png.palette {
         eprintln!(
             "Reducing image to {} bits/pixel, {} colors in palette",
@@ -799,7 +804,7 @@ fn report_reduction(png: &png::PngData) {
 }
 
 /// Strip headers from the `PngData` object, as requested by the passed `Options`
-fn perform_strip(png: &mut png::PngData, opts: &Options) {
+fn perform_strip(png: &mut PngData, opts: &Options) {
     match opts.strip {
         // Strip headers
         Headers::None => (),

--- a/tests/filters.rs
+++ b/tests/filters.rs
@@ -1,7 +1,6 @@
 extern crate oxipng;
 
-use oxipng::colors::{BitDepth, ColorType};
-use oxipng::png;
+use oxipng::internal_tests::*;
 use oxipng::{InFile, OutFile};
 use std::collections::HashSet;
 use std::fs::remove_file;
@@ -30,7 +29,7 @@ fn test_it_converts(
     let input = PathBuf::from(input);
 
     let (output, mut opts) = get_opts(&input);
-    let png = png::PngData::new(&input, opts.fix_errors).unwrap();
+    let png = PngData::new(&input, opts.fix_errors).unwrap();
     opts.filter = HashSet::new();
     opts.filter.insert(filter);
     assert_eq!(png.ihdr_data.color_type, color_type_in);
@@ -43,7 +42,7 @@ fn test_it_converts(
     let output = output.path().unwrap();
     assert!(output.exists());
 
-    let png = match png::PngData::new(output, opts.fix_errors) {
+    let png = match PngData::new(output, opts.fix_errors) {
         Ok(x) => x,
         Err(x) => {
             remove_file(output).ok();

--- a/tests/flags.rs
+++ b/tests/flags.rs
@@ -1,10 +1,7 @@
 extern crate oxipng;
 
 use oxipng::{InFile, OutFile};
-use oxipng::colors::{BitDepth, ColorType};
-use oxipng::deflate::Deflaters;
-use oxipng::headers::Headers;
-use oxipng::png;
+use oxipng::internal_tests::*;
 use std::collections::HashSet;
 use std::fs::remove_file;
 use std::path::Path;
@@ -30,7 +27,7 @@ fn test_it_converts(
     color_type_out: ColorType,
     bit_depth_out: BitDepth,
 ) {
-    let png = png::PngData::new(&input, opts.fix_errors).unwrap();
+    let png = PngData::new(&input, opts.fix_errors).unwrap();
 
     assert_eq!(png.ihdr_data.color_type, color_type_in);
     assert_eq!(png.ihdr_data.bit_depth, bit_depth_in);
@@ -42,7 +39,7 @@ fn test_it_converts(
     let output = output.path().unwrap();
     assert!(output.exists());
 
-    let png = match png::PngData::new(output, opts.fix_errors) {
+    let png = match PngData::new(output, opts.fix_errors) {
         Ok(x) => x,
         Err(x) => {
             remove_file(output).ok();
@@ -79,7 +76,7 @@ fn strip_headers_list() {
     let (output, mut opts) = get_opts(&input);
     opts.strip = Headers::Some(vec!["iCCP".to_owned(), "tEXt".to_owned()]);
 
-    let png = png::PngData::new(&input, opts.fix_errors).unwrap();
+    let png = PngData::new(&input, opts.fix_errors).unwrap();
 
     assert!(png.aux_headers.contains_key("tEXt"));
     assert!(png.aux_headers.contains_key("iTXt"));
@@ -92,7 +89,7 @@ fn strip_headers_list() {
     let output = output.path().unwrap();
     assert!(output.exists());
 
-    let png = match png::PngData::new(&output, opts.fix_errors) {
+    let png = match PngData::new(&output, opts.fix_errors) {
         Ok(x) => x,
         Err(x) => {
             remove_file(output).ok();
@@ -113,7 +110,7 @@ fn strip_headers_safe() {
     let (output, mut opts) = get_opts(&input);
     opts.strip = Headers::Safe;
 
-    let png = png::PngData::new(&input, opts.fix_errors).unwrap();
+    let png = PngData::new(&input, opts.fix_errors).unwrap();
 
     assert!(png.aux_headers.contains_key("tEXt"));
     assert!(png.aux_headers.contains_key("iTXt"));
@@ -126,7 +123,7 @@ fn strip_headers_safe() {
     let output = output.path().unwrap();
     assert!(output.exists());
 
-    let png = match png::PngData::new(&output, opts.fix_errors) {
+    let png = match PngData::new(&output, opts.fix_errors) {
         Ok(x) => x,
         Err(x) => {
             remove_file(output).ok();
@@ -147,7 +144,7 @@ fn strip_headers_all() {
     let (output, mut opts) = get_opts(&input);
     opts.strip = Headers::All;
 
-    let png = png::PngData::new(&input, opts.fix_errors).unwrap();
+    let png = PngData::new(&input, opts.fix_errors).unwrap();
 
     assert!(png.aux_headers.contains_key("tEXt"));
     assert!(png.aux_headers.contains_key("iTXt"));
@@ -160,7 +157,7 @@ fn strip_headers_all() {
     let output = output.path().unwrap();
     assert!(output.exists());
 
-    let png = match png::PngData::new(&output, opts.fix_errors) {
+    let png = match PngData::new(&output, opts.fix_errors) {
         Ok(x) => x,
         Err(x) => {
             remove_file(output).ok();
@@ -181,7 +178,7 @@ fn strip_headers_none() {
     let (output, mut opts) = get_opts(&input);
     opts.strip = Headers::None;
 
-    let png = png::PngData::new(&input, opts.fix_errors).unwrap();
+    let png = PngData::new(&input, opts.fix_errors).unwrap();
 
     assert!(png.aux_headers.contains_key("tEXt"));
     assert!(png.aux_headers.contains_key("iTXt"));
@@ -194,7 +191,7 @@ fn strip_headers_none() {
     let output = output.path().unwrap();
     assert!(output.exists());
 
-    let png = match png::PngData::new(&output, opts.fix_errors) {
+    let png = match PngData::new(&output, opts.fix_errors) {
         Ok(x) => x,
         Err(x) => {
             remove_file(output).ok();
@@ -215,7 +212,7 @@ fn interlacing_0_to_1() {
     let (output, mut opts) = get_opts(&input);
     opts.interlace = Some(1);
 
-    let png = png::PngData::new(&input, opts.fix_errors).unwrap();
+    let png = PngData::new(&input, opts.fix_errors).unwrap();
 
     assert_eq!(png.ihdr_data.interlaced, 0);
 
@@ -226,7 +223,7 @@ fn interlacing_0_to_1() {
     let output = output.path().unwrap();
     assert!(output.exists());
 
-    let png = match png::PngData::new(&output, opts.fix_errors) {
+    let png = match PngData::new(&output, opts.fix_errors) {
         Ok(x) => x,
         Err(x) => {
             remove_file(output).ok();
@@ -245,7 +242,7 @@ fn interlacing_1_to_0() {
     let (output, mut opts) = get_opts(&input);
     opts.interlace = Some(0);
 
-    let png = png::PngData::new(&input, opts.fix_errors).unwrap();
+    let png = PngData::new(&input, opts.fix_errors).unwrap();
 
     assert_eq!(png.ihdr_data.interlaced, 1);
 
@@ -256,7 +253,7 @@ fn interlacing_1_to_0() {
     let output = output.path().unwrap();
     assert!(output.exists());
 
-    let png = match png::PngData::new(&output, opts.fix_errors) {
+    let png = match PngData::new(&output, opts.fix_errors) {
         Ok(x) => x,
         Err(x) => {
             remove_file(output).ok();
@@ -275,7 +272,7 @@ fn interlacing_0_to_1_small_files() {
     let (output, mut opts) = get_opts(&input);
     opts.interlace = Some(1);
 
-    let png = png::PngData::new(&input, opts.fix_errors).unwrap();
+    let png = PngData::new(&input, opts.fix_errors).unwrap();
 
     assert_eq!(png.ihdr_data.interlaced, 0);
     assert_eq!(png.ihdr_data.color_type, ColorType::Indexed);
@@ -288,7 +285,7 @@ fn interlacing_0_to_1_small_files() {
     let output = output.path().unwrap();
     assert!(output.exists());
 
-    let png = match png::PngData::new(&output, opts.fix_errors) {
+    let png = match PngData::new(&output, opts.fix_errors) {
         Ok(x) => x,
         Err(x) => {
             remove_file(output).ok();
@@ -309,7 +306,7 @@ fn interlacing_1_to_0_small_files() {
     let (output, mut opts) = get_opts(&input);
     opts.interlace = Some(0);
 
-    let png = png::PngData::new(&input, opts.fix_errors).unwrap();
+    let png = PngData::new(&input, opts.fix_errors).unwrap();
 
     assert_eq!(png.ihdr_data.interlaced, 1);
     assert_eq!(png.ihdr_data.color_type, ColorType::Indexed);
@@ -322,7 +319,7 @@ fn interlacing_1_to_0_small_files() {
     let output = output.path().unwrap();
     assert!(output.exists());
 
-    let png = match png::PngData::new(&output, opts.fix_errors) {
+    let png = match PngData::new(&output, opts.fix_errors) {
         Ok(x) => x,
         Err(x) => {
             remove_file(output).ok();
@@ -346,7 +343,7 @@ fn interlaced_0_to_1_other_filter_mode() {
     filter.insert(4);
     opts.filter = filter;
 
-    let png = png::PngData::new(&input, opts.fix_errors).unwrap();
+    let png = PngData::new(&input, opts.fix_errors).unwrap();
 
     assert_eq!(png.ihdr_data.interlaced, 0);
 
@@ -357,7 +354,7 @@ fn interlaced_0_to_1_other_filter_mode() {
     let output = output.path().unwrap();
     assert!(output.exists());
 
-    let png = match png::PngData::new(&output, opts.fix_errors) {
+    let png = match PngData::new(&output, opts.fix_errors) {
         Ok(x) => x,
         Err(x) => {
             remove_file(output).ok();
@@ -395,7 +392,7 @@ fn fix_errors() {
     let (output, mut opts) = get_opts(&input);
     opts.fix_errors = true;
 
-    let png = png::PngData::new(&input, opts.fix_errors).unwrap();
+    let png = PngData::new(&input, opts.fix_errors).unwrap();
 
     assert_eq!(png.ihdr_data.color_type, ColorType::RGBA);
     assert_eq!(png.ihdr_data.bit_depth, BitDepth::Eight);
@@ -407,7 +404,7 @@ fn fix_errors() {
     let output = output.path().unwrap();
     assert!(output.exists());
 
-    let png = match png::PngData::new(&output, false) {
+    let png = match PngData::new(&output, false) {
         Ok(x) => x,
         Err(x) => {
             remove_file(output).ok();

--- a/tests/interlaced.rs
+++ b/tests/interlaced.rs
@@ -1,8 +1,7 @@
 extern crate oxipng;
 
 use oxipng::{InFile, OutFile};
-use oxipng::colors::{BitDepth, ColorType};
-use oxipng::png;
+use oxipng::internal_tests::*;
 use std::collections::HashSet;
 use std::fs::remove_file;
 use std::path::Path;
@@ -28,7 +27,7 @@ fn test_it_converts(
 ) {
     let input = PathBuf::from(input);
     let (output, opts) = get_opts(&input);
-    let png = png::PngData::new(&input, opts.fix_errors).unwrap();
+    let png = PngData::new(&input, opts.fix_errors).unwrap();
 
     assert_eq!(png.ihdr_data.color_type, color_type_in);
     assert_eq!(png.ihdr_data.bit_depth, bit_depth_in);
@@ -41,7 +40,7 @@ fn test_it_converts(
     let output = output.path().unwrap();
     assert!(output.exists());
 
-    let png = match png::PngData::new(output, opts.fix_errors) {
+    let png = match PngData::new(output, opts.fix_errors) {
         Ok(x) => x,
         Err(x) => {
             remove_file(output).ok();

--- a/tests/reduction.rs
+++ b/tests/reduction.rs
@@ -1,8 +1,7 @@
 extern crate oxipng;
 
 use oxipng::{InFile, OutFile};
-use oxipng::colors::{AlphaOptim, BitDepth, ColorType};
-use oxipng::png;
+use oxipng::internal_tests::*;
 use std::collections::HashSet;
 use std::fs::remove_file;
 use std::path::Path;
@@ -32,7 +31,7 @@ fn test_it_converts(
     if let Some(alpha) = alpha {
         opts.alphas = [alpha].iter().cloned().collect();
     }
-    let png = png::PngData::new(&input, opts.fix_errors).unwrap();
+    let png = PngData::new(&input, opts.fix_errors).unwrap();
 
     assert_eq!(png.ihdr_data.color_type, color_type_in);
     assert_eq!(png.ihdr_data.bit_depth, bit_depth_in);
@@ -45,7 +44,7 @@ fn test_it_converts(
     let output = output.path().unwrap();
     assert!(output.exists());
 
-    let png = match png::PngData::new(output, opts.fix_errors) {
+    let png = match PngData::new(output, opts.fix_errors) {
         Ok(x) => x,
         Err(x) => {
             remove_file(output).ok();
@@ -712,7 +711,7 @@ fn palette_should_be_reduced_with_dupes() {
     let input = PathBuf::from("tests/files/palette_should_be_reduced_with_dupes.png");
     let (output, opts) = get_opts(&input);
 
-    let png = png::PngData::new(&input, opts.fix_errors).unwrap();
+    let png = PngData::new(&input, opts.fix_errors).unwrap();
 
     assert_eq!(png.ihdr_data.color_type, ColorType::Indexed);
     assert_eq!(png.ihdr_data.bit_depth, BitDepth::Eight);
@@ -725,7 +724,7 @@ fn palette_should_be_reduced_with_dupes() {
     let output = output.path().unwrap();
     assert!(output.exists());
 
-    let png = match png::PngData::new(&output, opts.fix_errors) {
+    let png = match PngData::new(&output, opts.fix_errors) {
         Ok(x) => x,
         Err(x) => {
             remove_file(&output).ok();
@@ -745,7 +744,7 @@ fn palette_should_be_reduced_with_unused() {
     let input = PathBuf::from("tests/files/palette_should_be_reduced_with_unused.png");
     let (output, opts) = get_opts(&input);
 
-    let png = png::PngData::new(&input, opts.fix_errors).unwrap();
+    let png = PngData::new(&input, opts.fix_errors).unwrap();
 
     assert_eq!(png.ihdr_data.color_type, ColorType::Indexed);
     assert_eq!(png.ihdr_data.bit_depth, BitDepth::Eight);
@@ -758,7 +757,7 @@ fn palette_should_be_reduced_with_unused() {
     let output = output.path().unwrap();
     assert!(output.exists());
 
-    let png = match png::PngData::new(&output, opts.fix_errors) {
+    let png = match PngData::new(&output, opts.fix_errors) {
         Ok(x) => x,
         Err(x) => {
             remove_file(&output).ok();
@@ -778,7 +777,7 @@ fn palette_should_be_reduced_with_both() {
     let input = PathBuf::from("tests/files/palette_should_be_reduced_with_both.png");
     let (output, opts) = get_opts(&input);
 
-    let png = png::PngData::new(&input, opts.fix_errors).unwrap();
+    let png = PngData::new(&input, opts.fix_errors).unwrap();
 
     assert_eq!(png.ihdr_data.color_type, ColorType::Indexed);
     assert_eq!(png.ihdr_data.bit_depth, BitDepth::Eight);
@@ -791,7 +790,7 @@ fn palette_should_be_reduced_with_both() {
     let output = output.path().unwrap();
     assert!(output.exists());
 
-    let png = match png::PngData::new(&output, opts.fix_errors) {
+    let png = match PngData::new(&output, opts.fix_errors) {
         Ok(x) => x,
         Err(x) => {
             remove_file(&output).ok();

--- a/tests/regression.rs
+++ b/tests/regression.rs
@@ -1,7 +1,6 @@
 extern crate oxipng;
 
-use oxipng::colors::{BitDepth, ColorType};
-use oxipng::png;
+use oxipng::internal_tests::*;
 use oxipng::{InFile, OutFile};
 use std::collections::HashSet;
 use std::fs::remove_file;
@@ -29,7 +28,7 @@ fn test_it_converts(
 ) {
     let input = PathBuf::from(input);
     let (output, opts) = custom.unwrap_or_else(|| get_opts(&input));
-    let png = png::PngData::new(&input, opts.fix_errors).unwrap();
+    let png = PngData::new(&input, opts.fix_errors).unwrap();
 
     assert_eq!(png.ihdr_data.color_type, color_type_in);
     assert_eq!(png.ihdr_data.bit_depth, bit_depth_in);
@@ -41,7 +40,7 @@ fn test_it_converts(
     let output = output.path().unwrap();
     assert!(output.exists());
 
-    let png = match png::PngData::new(output, opts.fix_errors) {
+    let png = match PngData::new(output, opts.fix_errors) {
         Ok(x) => x,
         Err(x) => {
             remove_file(output).ok();
@@ -73,7 +72,7 @@ fn issue_42() {
     let (output, mut opts) = get_opts(&input);
     opts.interlace = Some(1);
 
-    let png = png::PngData::new(&input, opts.fix_errors).unwrap();
+    let png = PngData::new(&input, opts.fix_errors).unwrap();
 
     assert_eq!(png.ihdr_data.interlaced, 0);
     assert_eq!(png.ihdr_data.color_type, ColorType::GrayscaleAlpha);
@@ -86,7 +85,7 @@ fn issue_42() {
     let output = output.path().unwrap();
     assert!(output.exists());
 
-    let png = match png::PngData::new(&output, opts.fix_errors) {
+    let png = match PngData::new(&output, opts.fix_errors) {
         Ok(x) => x,
         Err(x) => {
             remove_file(output).ok();


### PR DESCRIPTION
Instead of having multiple public modules, re-export items in just one public module. Improves autocomplete.