### PR TITLE
Chunk name as 4 bytes

### DIFF
--- a/src/headers.rs
+++ b/src/headers.rs
@@ -49,7 +49,7 @@ pub fn file_header_is_valid(bytes: &[u8]) -> bool {
 
 #[derive(Debug, Clone, Copy)]
 pub struct RawHeader<'a> {
-    pub name: &'a [u8],
+    pub name: [u8; 4],
     pub data: &'a [u8],
 }
 
@@ -98,10 +98,9 @@ pub fn parse_next_header<'a>(
         )));
     }
 
-    Ok(Some(RawHeader {
-        name: chunk_name,
-        data,
-    }))
+    let mut name = [0u8; 4];
+    name.copy_from_slice(chunk_name);
+    Ok(Some(RawHeader {name, data}))
 }
 
 pub fn parse_ihdr_header(byte_data: &[u8]) -> PngResult<IhdrData> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -820,21 +820,16 @@ fn perform_strip(png: &mut PngData, opts: &Options) {
         // Strip headers
         Headers::None => (),
         Headers::Keep(ref hdrs) => {
-            png.aux_headers.retain(|chunk, _| hdrs.contains(chunk));
+            png.aux_headers.retain(|chunk, _| std::str::from_utf8(chunk).ok().map_or(false, |name| hdrs.contains(name)));
         }
         Headers::Strip(ref hdrs) => for hdr in hdrs {
-            png.aux_headers.remove(hdr);
+            png.aux_headers.remove(hdr.as_bytes());
         },
         Headers::Safe => {
-            const PRESERVED_HEADERS: [&str; 9] = [
-                "cHRM", "gAMA", "iCCP", "sBIT", "sRGB", "bKGD", "hIST", "pHYs", "sPLT",
+            const PRESERVED_HEADERS: [[u8; 4]; 9] = [
+                *b"cHRM", *b"gAMA", *b"iCCP", *b"sBIT", *b"sRGB", *b"bKGD", *b"hIST", *b"pHYs", *b"sPLT",
             ];
-            let hdrs = png.aux_headers.keys().cloned().collect::<Vec<String>>();
-            for hdr in hdrs {
-                if !PRESERVED_HEADERS.contains(&hdr.as_ref()) {
-                    png.aux_headers.remove(&hdr);
-                }
-            }
+            png.aux_headers.retain(|hdr, _| PRESERVED_HEADERS.contains(hdr));
         }
         Headers::All => {
             png.aux_headers = HashMap::new();

--- a/src/main.rs
+++ b/src/main.rs
@@ -453,9 +453,9 @@ fn parse_opts_into_struct(
                 opts.strip = Headers::All;
             }
         } else {
-            const FORBIDDEN_CHUNKS: [&str; 5] = ["IHDR", "IDAT", "tRNS", "PLTE", "IEND"];
+            const FORBIDDEN_CHUNKS: [[u8; 4]; 5] = [*b"IHDR", *b"IDAT", *b"tRNS", *b"PLTE", *b"IEND"];
             for i in &hdrs {
-                if FORBIDDEN_CHUNKS.contains(&i.as_ref()) {
+                if FORBIDDEN_CHUNKS.iter().any(|chunk| chunk == i.as_bytes()) {
                     return Err(format!("{} chunk is not allowed to be stripped", i));
                 }
             }

--- a/src/reduction/alpha.rs
+++ b/src/reduction/alpha.rs
@@ -28,7 +28,7 @@ pub fn reduce_alpha_channel(png: &mut PngData, channels: u8) -> Option<Vec<u8>> 
 
     // sBIT contains information about alpha channel's original depth,
     // and alpha has just been removed
-    if let Some(sbit_header) = png.aux_headers.get_mut(&"sBIT".to_string()) {
+    if let Some(sbit_header) = png.aux_headers.get_mut(b"sBIT") {
         assert_eq!(sbit_header.len(), channels as usize);
         sbit_header.pop();
     }

--- a/src/reduction/color.rs
+++ b/src/reduction/color.rs
@@ -56,12 +56,12 @@ pub fn reduce_rgba_to_grayscale_alpha(png: &mut PngData) -> bool {
         }
     }
 
-    if let Some(sbit_header) = png.aux_headers.get_mut(&"sBIT".to_string()) {
+    if let Some(sbit_header) = png.aux_headers.get_mut(b"sBIT") {
         assert_eq!(sbit_header.len(), 4);
         sbit_header.remove(1);
         sbit_header.remove(1);
     }
-    if let Some(bkgd_header) = png.aux_headers.get_mut(&"bKGD".to_string()) {
+    if let Some(bkgd_header) = png.aux_headers.get_mut(b"bKGD") {
         assert_eq!(bkgd_header.len(), 6);
         bkgd_header.truncate(2);
     }
@@ -100,7 +100,7 @@ pub fn reduce_rgba_to_palette(png: &mut PngData) -> bool {
     }
 
     let mut color_palette = Vec::with_capacity(
-        palette.len() * 3 + if png.aux_headers.contains_key(&"bKGD".to_string()) {
+        palette.len() * 3 + if png.aux_headers.contains_key(b"bKGD") {
             6
         } else {
             0
@@ -123,7 +123,7 @@ pub fn reduce_rgba_to_palette(png: &mut PngData) -> bool {
         return false;
     }
 
-    if let Some(bkgd_header) = png.aux_headers.get_mut(&"bKGD".to_string()) {
+    if let Some(bkgd_header) = png.aux_headers.get_mut(b"bKGD") {
         assert_eq!(bkgd_header.len(), 6);
         let header_pixels = bkgd_header
             .iter()
@@ -144,7 +144,7 @@ pub fn reduce_rgba_to_palette(png: &mut PngData) -> bool {
             *bkgd_header = vec![entry as u8];
         }
     }
-    if let Some(sbit_header) = png.aux_headers.get_mut(&"sBIT".to_string()) {
+    if let Some(sbit_header) = png.aux_headers.get_mut(b"sBIT") {
         assert_eq!(sbit_header.len(), 4);
         sbit_header.pop();
     }
@@ -209,7 +209,7 @@ pub fn reduce_rgb_to_palette(png: &mut PngData) -> bool {
         return false;
     }
 
-    if let Some(bkgd_header) = png.aux_headers.get_mut(&"bKGD".to_string()) {
+    if let Some(bkgd_header) = png.aux_headers.get_mut(b"bKGD") {
         assert_eq!(bkgd_header.len(), 6);
         let header_pixels = bkgd_header
             .iter()
@@ -281,11 +281,11 @@ pub fn reduce_rgb_to_grayscale(png: &mut PngData) -> bool {
         }
         *trns = trns[0..2].to_owned();
     }
-    if let Some(sbit_header) = png.aux_headers.get_mut(&"sBIT".to_string()) {
+    if let Some(sbit_header) = png.aux_headers.get_mut(b"sBIT") {
         assert_eq!(sbit_header.len(), 3);
         sbit_header.truncate(1);
     }
-    if let Some(bkgd_header) = png.aux_headers.get_mut(&"bKGD".to_string()) {
+    if let Some(bkgd_header) = png.aux_headers.get_mut(b"bKGD") {
         assert_eq!(bkgd_header.len(), 6);
         bkgd_header.truncate(2);
     }

--- a/tests/flags.rs
+++ b/tests/flags.rs
@@ -81,9 +81,9 @@ fn strip_headers_list() {
 
     let png = PngData::new(&input, opts.fix_errors).unwrap();
 
-    assert!(png.aux_headers.contains_key("tEXt"));
-    assert!(png.aux_headers.contains_key("iTXt"));
-    assert!(png.aux_headers.contains_key("iCCP"));
+    assert!(png.aux_headers.contains_key(b"tEXt"));
+    assert!(png.aux_headers.contains_key(b"iTXt"));
+    assert!(png.aux_headers.contains_key(b"iCCP"));
 
     match oxipng::optimize(&InFile::Path(input), &output, &opts) {
         Ok(_) => (),
@@ -100,9 +100,9 @@ fn strip_headers_list() {
         }
     };
 
-    assert!(!png.aux_headers.contains_key("tEXt"));
-    assert!(png.aux_headers.contains_key("iTXt"));
-    assert!(!png.aux_headers.contains_key("iCCP"));
+    assert!(!png.aux_headers.contains_key(b"tEXt"));
+    assert!(png.aux_headers.contains_key(b"iTXt"));
+    assert!(!png.aux_headers.contains_key(b"iCCP"));
 
     remove_file(output).ok();
 }
@@ -115,9 +115,9 @@ fn strip_headers_safe() {
 
     let png = PngData::new(&input, opts.fix_errors).unwrap();
 
-    assert!(png.aux_headers.contains_key("tEXt"));
-    assert!(png.aux_headers.contains_key("iTXt"));
-    assert!(png.aux_headers.contains_key("iCCP"));
+    assert!(png.aux_headers.contains_key(b"tEXt"));
+    assert!(png.aux_headers.contains_key(b"iTXt"));
+    assert!(png.aux_headers.contains_key(b"iCCP"));
 
     match oxipng::optimize(&InFile::Path(input), &output, &opts) {
         Ok(_) => (),
@@ -134,9 +134,9 @@ fn strip_headers_safe() {
         }
     };
 
-    assert!(!png.aux_headers.contains_key("tEXt"));
-    assert!(!png.aux_headers.contains_key("iTXt"));
-    assert!(png.aux_headers.contains_key("iCCP"));
+    assert!(!png.aux_headers.contains_key(b"tEXt"));
+    assert!(!png.aux_headers.contains_key(b"iTXt"));
+    assert!(png.aux_headers.contains_key(b"iCCP"));
 
     remove_file(output).ok();
 }
@@ -149,9 +149,9 @@ fn strip_headers_all() {
 
     let png = PngData::new(&input, opts.fix_errors).unwrap();
 
-    assert!(png.aux_headers.contains_key("tEXt"));
-    assert!(png.aux_headers.contains_key("iTXt"));
-    assert!(png.aux_headers.contains_key("iCCP"));
+    assert!(png.aux_headers.contains_key(b"tEXt"));
+    assert!(png.aux_headers.contains_key(b"iTXt"));
+    assert!(png.aux_headers.contains_key(b"iCCP"));
 
     match oxipng::optimize(&InFile::Path(input), &output, &opts) {
         Ok(_) => (),
@@ -168,9 +168,9 @@ fn strip_headers_all() {
         }
     };
 
-    assert!(!png.aux_headers.contains_key("tEXt"));
-    assert!(!png.aux_headers.contains_key("iTXt"));
-    assert!(!png.aux_headers.contains_key("iCCP"));
+    assert!(!png.aux_headers.contains_key(b"tEXt"));
+    assert!(!png.aux_headers.contains_key(b"iTXt"));
+    assert!(!png.aux_headers.contains_key(b"iCCP"));
 
     remove_file(output).ok();
 }
@@ -183,9 +183,9 @@ fn strip_headers_none() {
 
     let png = PngData::new(&input, opts.fix_errors).unwrap();
 
-    assert!(png.aux_headers.contains_key("tEXt"));
-    assert!(png.aux_headers.contains_key("iTXt"));
-    assert!(png.aux_headers.contains_key("iCCP"));
+    assert!(png.aux_headers.contains_key(b"tEXt"));
+    assert!(png.aux_headers.contains_key(b"iTXt"));
+    assert!(png.aux_headers.contains_key(b"iCCP"));
 
     match oxipng::optimize(&InFile::Path(input), &output, &opts) {
         Ok(_) => (),
@@ -202,9 +202,9 @@ fn strip_headers_none() {
         }
     };
 
-    assert!(png.aux_headers.contains_key("tEXt"));
-    assert!(png.aux_headers.contains_key("iTXt"));
-    assert!(png.aux_headers.contains_key("iCCP"));
+    assert!(png.aux_headers.contains_key(b"tEXt"));
+    assert!(png.aux_headers.contains_key(b"iTXt"));
+    assert!(png.aux_headers.contains_key(b"iCCP"));
 
     remove_file(output).ok();
 }


### PR DESCRIPTION
Avoids unnecessary small temporary allocations and pointers larger than the value pointed to.