### PR TITLE
Alpha heuristic improvements

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -768,7 +768,9 @@ fn perform_reductions(png: &mut PngData, opts: &Options, deadline: &Deadline) ->
         return reduction_occurred;
     }
 
-    png.try_alpha_reduction(&opts.alphas);
+    if png.try_alpha_reduction(&opts.alphas) {
+        reduction_occurred = true;
+    }
 
     reduction_occurred
 }

--- a/src/png/mod.rs
+++ b/src/png/mod.rs
@@ -20,7 +20,8 @@ use std::iter::Iterator;
 use std::path::Path;
 
 const STD_COMPRESSION: u8 = 8;
-const STD_STRATEGY: u8 = 2; // Huffman only
+/// Must use normal compression, as faster ones (Huffman/RLE-only) are not representative
+const STD_STRATEGY: u8 = 0;
 const STD_WINDOW: u8 = 15;
 const STD_FILTERS: [u8; 2] = [0, 5];
 

--- a/src/png/mod.rs
+++ b/src/png/mod.rs
@@ -587,7 +587,7 @@ impl PngData {
         changed
     }
 
-    pub fn try_alpha_reduction(&mut self, alphas: &HashSet<AlphaOptim>) {
+    pub fn try_alpha_reduction(&mut self, alphas: &HashSet<AlphaOptim>) -> bool {
         assert!(!alphas.is_empty());
         let alphas = alphas.iter().collect::<Vec<_>>();
         let best_size = AtomicMin::new(None);
@@ -623,7 +623,9 @@ impl PngData {
 
         if let Some(best) = best {
             self.raw_data = best.1.raw_data;
+            return true;
         }
+        false
     }
 
     pub fn reduce_alpha_channel(&mut self, optim: AlphaOptim) -> bool {


### PR DESCRIPTION
1. I've found an image that with alpha reductions is compressed worse than without alpha reductions (I can't share the image, as it's private). That's because zlib strategy = 2 ignores repetitions, and picks alpha that compresses badly with a better strategy.

2. Cloning of image makes copy of both idat and raw data, but in alpha reductions both are getting replaced immediately, which is wasteful. I've made alpha reductions return only copy of relevant data.