### PR TITLE
4× faster RGB/A to palette conversion

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -264,6 +264,7 @@ dependencies = [
  "miniz_oxide 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "num_cpus 1.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rayon 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rgb 0.8.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "wild 2.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "zopfli 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -312,6 +313,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "redox_syscall 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
+
+[[package]]
+name = "rgb"
+version = "0.8.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "scopeguard"
@@ -435,6 +441,7 @@ dependencies = [
 "checksum rayon-core 1.4.1 (registry+https://github.com/rust-lang/crates.io-index)" = "b055d1e92aba6877574d8fe604a63c8b5df60f60e5982bf7ccbb1338ea527356"
 "checksum redox_syscall 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)" = "cf8fb82a4d1c9b28f1c26c574a5b541f5ffb4315f6c9a791fa47b6a04438fe93"
 "checksum redox_termios 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "7e891cfe48e9100a70a3b6eb652fef28920c117d366339687bd5576160db0f76"
+"checksum rgb 0.8.11 (registry+https://github.com/rust-lang/crates.io-index)" = "002bebda58b24482d6911a59512e8a17fa1defecf5a2162521113b7cc5422dd1"
 "checksum scopeguard 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "94258f53601af11e6a49f722422f6e3425c52b06245a5cf9bc09908b174f5e27"
 "checksum strsim 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "bb4f380125926a99e52bc279241539c018323fab05ad6368b56f93d9369ff550"
 "checksum termion 1.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "689a3bdfaab439fd92bc87df5c4c78417d3cbe537487274e9b0b2dce76e92096"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,6 +34,7 @@ itertools = "^0.7.7"
 num_cpus = "^1.0.0"
 zopfli = "^0.3.4"
 miniz_oxide = "0.2.0"
+rgb = "0.8.11"
 
 [dependencies.rayon]
 optional = true

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,6 +4,7 @@ extern crate byteorder;
 extern crate cloudflare_zlib_sys;
 extern crate crc;
 extern crate image;
+extern crate rgb;
 extern crate itertools;
 extern crate miniz_oxide;
 extern crate num_cpus;

--- a/tests/reduction.rs
+++ b/tests/reduction.rs
@@ -718,7 +718,7 @@ fn palette_should_be_reduced_with_dupes() {
 
     assert_eq!(png.ihdr_data.color_type, ColorType::Indexed);
     assert_eq!(png.ihdr_data.bit_depth, BitDepth::Eight);
-    assert_eq!(png.palette.unwrap().len(), 43 * 3);
+    assert_eq!(png.palette.unwrap().len(), 43);
 
     match oxipng::optimize(&InFile::Path(input), &output, &opts) {
         Ok(_) => (),
@@ -737,7 +737,7 @@ fn palette_should_be_reduced_with_dupes() {
 
     assert_eq!(png.ihdr_data.color_type, ColorType::Indexed);
     assert_eq!(png.ihdr_data.bit_depth, BitDepth::Eight);
-    assert_eq!(png.palette.unwrap().len(), 35 * 3);
+    assert_eq!(png.palette.unwrap().len(), 35);
 
     remove_file(output).ok();
 }
@@ -751,7 +751,7 @@ fn palette_should_be_reduced_with_unused() {
 
     assert_eq!(png.ihdr_data.color_type, ColorType::Indexed);
     assert_eq!(png.ihdr_data.bit_depth, BitDepth::Eight);
-    assert_eq!(png.palette.unwrap().len(), 35 * 3);
+    assert_eq!(png.palette.unwrap().len(), 35);
 
     match oxipng::optimize(&InFile::Path(input), &output, &opts) {
         Ok(_) => (),
@@ -770,7 +770,7 @@ fn palette_should_be_reduced_with_unused() {
 
     assert_eq!(png.ihdr_data.color_type, ColorType::Indexed);
     assert_eq!(png.ihdr_data.bit_depth, BitDepth::Eight);
-    assert_eq!(png.palette.unwrap().len(), 33 * 3);
+    assert_eq!(png.palette.unwrap().len(), 33);
 
     remove_file(output).ok();
 }
@@ -784,7 +784,7 @@ fn palette_should_be_reduced_with_both() {
 
     assert_eq!(png.ihdr_data.color_type, ColorType::Indexed);
     assert_eq!(png.ihdr_data.bit_depth, BitDepth::Eight);
-    assert_eq!(png.palette.unwrap().len(), 43 * 3);
+    assert_eq!(png.palette.unwrap().len(), 43);
 
     match oxipng::optimize(&InFile::Path(input), &output, &opts) {
         Ok(_) => (),
@@ -803,7 +803,7 @@ fn palette_should_be_reduced_with_both() {
 
     assert_eq!(png.ihdr_data.color_type, ColorType::Indexed);
     assert_eq!(png.ihdr_data.bit_depth, BitDepth::Eight);
-    assert_eq!(png.palette.unwrap().len(), 33 * 3);
+    assert_eq!(png.palette.unwrap().len(), 33);
 
     remove_file(output).ok();
 }


### PR DESCRIPTION
Manipulation of palette as separate vec of RGB bytes and tRNS to match was cumbersome. I've changed the internal representation of palette to a vec RGBA colors. Actual chunks are auto-generated on file write.

Fixed-size 4-byte RGBA pixels are much cheaper to use than 128-bit fat pointers of variable-length slices.

With colors being structs I was able to replace duplicate RGB and RGBA reduction functions with one function using generics. 

The end result is that RGBA to palette reduction is 4-4.5 times faster.