### PR TITLE
Non-self-mutable reductions

### DIFF
--- a/benches/interlacing.rs
+++ b/benches/interlacing.rs
@@ -14,7 +14,7 @@ fn interlacing_16_bits(b: &mut Bencher) {
 
     b.iter(|| {
         let mut safe_png = png.clone();
-        safe_png.change_interlacing(1);
+        safe_png.change_interlacing(1)
     });
 }
 
@@ -25,7 +25,7 @@ fn interlacing_8_bits(b: &mut Bencher) {
 
     b.iter(|| {
         let mut safe_png = png.clone();
-        safe_png.change_interlacing(1);
+        safe_png.change_interlacing(1)
     });
 }
 
@@ -38,7 +38,7 @@ fn interlacing_4_bits(b: &mut Bencher) {
 
     b.iter(|| {
         let mut safe_png = png.clone();
-        safe_png.change_interlacing(1);
+        safe_png.change_interlacing(1)
     });
 }
 
@@ -51,7 +51,7 @@ fn interlacing_2_bits(b: &mut Bencher) {
 
     b.iter(|| {
         let mut safe_png = png.clone();
-        safe_png.change_interlacing(1);
+        safe_png.change_interlacing(1)
     });
 }
 
@@ -64,7 +64,7 @@ fn interlacing_1_bits(b: &mut Bencher) {
 
     b.iter(|| {
         let mut safe_png = png.clone();
-        safe_png.change_interlacing(1);
+        safe_png.change_interlacing(1)
     });
 }
 
@@ -77,7 +77,7 @@ fn deinterlacing_16_bits(b: &mut Bencher) {
 
     b.iter(|| {
         let mut safe_png = png.clone();
-        safe_png.change_interlacing(0);
+        safe_png.change_interlacing(0)
     });
 }
 
@@ -90,7 +90,7 @@ fn deinterlacing_8_bits(b: &mut Bencher) {
 
     b.iter(|| {
         let mut safe_png = png.clone();
-        safe_png.change_interlacing(0);
+        safe_png.change_interlacing(0)
     });
 }
 
@@ -103,7 +103,7 @@ fn deinterlacing_4_bits(b: &mut Bencher) {
 
     b.iter(|| {
         let mut safe_png = png.clone();
-        safe_png.change_interlacing(0);
+        safe_png.change_interlacing(0)
     });
 }
 
@@ -116,7 +116,7 @@ fn deinterlacing_2_bits(b: &mut Bencher) {
 
     b.iter(|| {
         let mut safe_png = png.clone();
-        safe_png.change_interlacing(0);
+        safe_png.change_interlacing(0)
     });
 }
 
@@ -129,6 +129,6 @@ fn deinterlacing_1_bits(b: &mut Bencher) {
 
     b.iter(|| {
         let mut safe_png = png.clone();
-        safe_png.change_interlacing(0);
+        safe_png.change_interlacing(0)
     });
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -740,10 +740,13 @@ fn perform_reductions(png: &mut PngData, opts: &Options, deadline: &Deadline) ->
         return reduction_occurred;
     }
 
-    if opts.bit_depth_reduction && png.reduce_bit_depth() {
-        reduction_occurred = true;
-        if opts.verbosity == Some(1) {
-            report_reduction(png);
+    if opts.bit_depth_reduction {
+        if let Some(reduced) = png.reduce_bit_depth() {
+            png.apply_reduction(reduced);
+            reduction_occurred = true;
+            if opts.verbosity == Some(1) {
+                report_reduction(png);
+            }
         }
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -766,8 +766,8 @@ fn perform_reductions(png: &mut PngData, opts: &Options, deadline: &Deadline) ->
     }
 
     if let Some(interlacing) = opts.interlace {
-        if png.change_interlacing(interlacing) {
-            png.ihdr_data.interlaced = interlacing;
+        if let Some(reduced) = png.change_interlacing(interlacing) {
+            png.apply_reduction(reduced);
             reduction_occurred = true;
         }
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,6 +12,7 @@ extern crate rayon;
 extern crate rgb;
 extern crate zopfli;
 
+use reduction::*;
 use atomicmin::AtomicMin;
 use crc::crc32;
 use deflate::inflate;
@@ -725,10 +726,13 @@ fn optimize_png(png: &mut PngData, original_data: &[u8], opts: &Options) -> PngR
 fn perform_reductions(png: &mut PngData, opts: &Options, deadline: &Deadline) -> bool {
     let mut reduction_occurred = false;
 
-    if opts.palette_reduction && png.reduce_palette() {
-        reduction_occurred = true;
-        if opts.verbosity == Some(1) {
-            report_reduction(png);
+    if opts.palette_reduction {
+        if let Some(reduced) = reduced_palette(png) {
+            png.apply_reduction(reduced);
+            reduction_occurred = true;
+            if opts.verbosity == Some(1) {
+                report_reduction(png);
+            }
         }
     }
 

--- a/src/reduction/alpha.rs
+++ b/src/reduction/alpha.rs
@@ -3,6 +3,7 @@ use png::PngData;
 use colors::ColorType;
 use std::collections::HashMap;
 
+#[must_use]
 pub fn reduced_alpha_channel(png: &PngData) -> Option<ReducedPng> {
     let target_color_type = match png.ihdr_data.color_type {
         ColorType::GrayscaleAlpha => ColorType::Grayscale,
@@ -45,6 +46,7 @@ pub fn reduced_alpha_channel(png: &PngData) -> Option<ReducedPng> {
 
     Some(ReducedPng {
         raw_data,
+        bit_depth: png.ihdr_data.bit_depth,
         color_type: target_color_type,
         aux_headers,
         transparency_pixel: None,

--- a/src/reduction/alpha.rs
+++ b/src/reduction/alpha.rs
@@ -47,6 +47,7 @@ pub fn reduced_alpha_channel(png: &PngData) -> Option<ReducedPng> {
     Some(ReducedPng {
         raw_data,
         bit_depth: png.ihdr_data.bit_depth,
+        interlaced: png.ihdr_data.interlaced,
         color_type: target_color_type,
         aux_headers,
         transparency_pixel: None,

--- a/src/reduction/alpha.rs
+++ b/src/reduction/alpha.rs
@@ -1,7 +1,16 @@
+use reduction::ReducedPng;
 use png::PngData;
+use colors::ColorType;
+use std::collections::HashMap;
 
-pub fn reduce_alpha_channel(png: &mut PngData, channels: u8) -> Option<Vec<u8>> {
+pub fn reduced_alpha_channel(png: &PngData) -> Option<ReducedPng> {
+    let target_color_type = match png.ihdr_data.color_type {
+        ColorType::GrayscaleAlpha => ColorType::Grayscale,
+        ColorType::RGBA => ColorType::RGB,
+        _ => return None,
+    };
     let byte_depth = png.ihdr_data.bit_depth.as_u8() >> 3;
+    let channels = png.channels_per_pixel();
     let bpp = channels * byte_depth;
     let bpp_mask = bpp - 1;
     assert_eq!(0, bpp & bpp_mask);
@@ -14,27 +23,31 @@ pub fn reduce_alpha_channel(png: &mut PngData, channels: u8) -> Option<Vec<u8>> 
         }
     }
 
-    let mut reduced = Vec::with_capacity(png.raw_data.len());
+    let mut raw_data = Vec::with_capacity(png.raw_data.len());
     for line in png.scan_lines() {
-        reduced.push(line.filter);
+        raw_data.push(line.filter);
         for (i, &byte) in line.data.iter().enumerate() {
             if i as u8 & bpp_mask >= colored_bytes {
                 continue;
             } else {
-                reduced.push(byte);
+                raw_data.push(byte);
             }
         }
     }
 
+    let mut aux_headers = HashMap::new();
     // sBIT contains information about alpha channel's original depth,
     // and alpha has just been removed
-    if let Some(sbit_header) = png.aux_headers.get_mut(b"sBIT") {
+    if let Some(sbit_header) = png.aux_headers.get(b"sBIT") {
         // Some programs save the sBIT header as RGB even if the image is RGBA.
-        // Only remove the alpha channel if it's actually there.
-        if sbit_header.len() == 4 {
-            sbit_header.pop();
-        }
+        aux_headers.insert(*b"sBIT", Some(sbit_header.iter().cloned().take(3).collect()));
     }
 
-    Some(reduced)
+    Some(ReducedPng {
+        raw_data,
+        color_type: target_color_type,
+        aux_headers,
+        transparency_pixel: None,
+        palette: None,
+    })
 }

--- a/src/reduction/bit_depth.rs
+++ b/src/reduction/bit_depth.rs
@@ -82,6 +82,7 @@ pub fn reduce_bit_depth_8_or_less(png: &PngData) -> Option<ReducedPng> {
 
     Some(ReducedPng {
         color_type: png.ihdr_data.color_type,
+        interlaced: png.ihdr_data.interlaced,
         raw_data: reduced.to_bytes(),
         bit_depth: BitDepth::from_u8(allowed_bits as u8),
         aux_headers: Default::default(),

--- a/src/reduction/color.rs
+++ b/src/reduction/color.rs
@@ -6,18 +6,6 @@ use rgb::{FromSlice, RGB8, RGBA8};
 use std::collections::HashMap;
 use std::hash::Hash;
 
-use super::alpha::reduce_alpha_channel;
-
-pub fn reduce_rgba_to_rgb(png: &mut PngData) -> bool {
-    if let Some(reduced) = reduce_alpha_channel(png, 4) {
-        png.raw_data = reduced;
-        png.ihdr_data.color_type = ColorType::RGB;
-        true
-    } else {
-        false
-    }
-}
-
 pub fn reduce_rgba_to_grayscale_alpha(png: &mut PngData) -> bool {
     let mut reduced = Vec::with_capacity(png.raw_data.len());
     let byte_depth = png.ihdr_data.bit_depth.as_u8() >> 3;
@@ -185,6 +173,7 @@ pub fn reduced_color_to_palette(png: &mut PngData) -> Option<ReducedPng> {
         color_type: ColorType::Indexed,
         aux_headers,
         raw_data,
+        transparency_pixel: None,
         palette: Some(palette_vec),
     })
 }
@@ -241,14 +230,4 @@ pub fn reduce_rgb_to_grayscale(png: &mut PngData) -> bool {
     png.raw_data = reduced;
     png.ihdr_data.color_type = ColorType::Grayscale;
     true
-}
-
-pub fn reduce_grayscale_alpha_to_grayscale(png: &mut PngData) -> bool {
-    if let Some(reduced) = reduce_alpha_channel(png, 2) {
-        png.raw_data = reduced;
-        png.ihdr_data.color_type = ColorType::Grayscale;
-        true
-    } else {
-        false
-    }
 }

--- a/src/reduction/color.rs
+++ b/src/reduction/color.rs
@@ -61,6 +61,7 @@ pub fn reduce_rgba_to_grayscale_alpha(png: &PngData) -> Option<ReducedPng> {
     Some(ReducedPng {
         raw_data: reduced,
         bit_depth: png.ihdr_data.bit_depth,
+        interlaced: png.ihdr_data.interlaced,
         color_type: ColorType::GrayscaleAlpha,
         palette: None,
         transparency_pixel: None,
@@ -178,6 +179,7 @@ pub fn reduced_color_to_palette(png: &PngData) -> Option<ReducedPng> {
     Some(ReducedPng {
         color_type: ColorType::Indexed,
         bit_depth: png.ihdr_data.bit_depth,
+        interlaced: png.ihdr_data.interlaced,
         aux_headers,
         raw_data,
         transparency_pixel: None,
@@ -242,6 +244,7 @@ pub fn reduce_rgb_to_grayscale(png: &PngData) -> Option<ReducedPng> {
         raw_data: reduced,
         color_type: ColorType::Grayscale,
         bit_depth: png.ihdr_data.bit_depth,
+        interlaced: png.ihdr_data.interlaced,
         palette: None,
         transparency_pixel,
         aux_headers,

--- a/src/reduction/mod.rs
+++ b/src/reduction/mod.rs
@@ -19,6 +19,7 @@ pub struct ReducedPng {
     pub transparency_pixel: Option<Vec<u8>>,
     /// replace if Some, delete if None
     pub aux_headers: HashMap<[u8; 4], Option<Vec<u8>>>,
+    pub interlaced: u8,
 }
 
 /// Attempt to reduce the number of colors in the palette
@@ -109,6 +110,7 @@ fn do_palette_reduction(png: &PngData, palette_map: &[Option<u8>; 256]) -> Optio
     Some(ReducedPng {
         color_type: ColorType::Indexed,
         bit_depth: png.ihdr_data.bit_depth,
+        interlaced: png.ihdr_data.interlaced,
         raw_data,
         transparency_pixel: None,
         palette: Some(reordered_palette(png.palette.as_ref()?, palette_map)),

--- a/src/reduction/mod.rs
+++ b/src/reduction/mod.rs
@@ -1,3 +1,157 @@
+use std::collections::HashMap;
+use colors::{BitDepth, ColorType};
+use std::collections::hash_map::Entry::*;
+use png::PngData;
+use rgb::RGBA8;
+
 mod alpha;
 pub mod bit_depth;
 pub mod color;
+
+pub struct ReducedPng {
+    pub raw_data: Vec<u8>,
+    pub palette: Option<Vec<RGBA8>>,
+    pub aux_headers: HashMap<[u8; 4], Option<Vec<u8>>>,
+    pub color_type: ColorType,
+}
+
+/// Attempt to reduce the number of colors in the palette
+/// Returns true if the palette was reduced, false otherwise
+pub fn reduced_palette(png: &PngData) -> Option<ReducedPng> {
+    if png.ihdr_data.color_type != ColorType::Indexed {
+        // Can't reduce if there is no palette
+        return None;
+    }
+    if png.ihdr_data.bit_depth == BitDepth::One {
+        // Gains from 1-bit images will be at most 1 byte
+        // Not worth the CPU time
+        return None;
+    }
+
+    let mut palette_map = [None; 256];
+    let mut used = [false; 256];
+    {
+        let palette = png.palette.as_ref()?;
+
+        // Find palette entries that are never used
+        for line in png.scan_lines() {
+            match png.ihdr_data.bit_depth {
+                BitDepth::Eight => for &byte in line.data {
+                    used[byte as usize] = true;
+                },
+                BitDepth::Four => for &byte in line.data {
+                    used[(byte & 0x0F) as usize] = true;
+                    used[(byte >> 4) as usize] = true;
+                },
+                BitDepth::Two => for &byte in line.data {
+                    used[(byte & 0x03) as usize] = true;
+                    used[((byte >> 2) & 0x03) as usize] = true;
+                    used[((byte >> 4) & 0x03) as usize] = true;
+                    used[(byte >> 6) as usize] = true;
+                },
+                _ => unreachable!(),
+            }
+        }
+
+        let mut next_index = 0u16;
+        let mut seen = HashMap::with_capacity(palette.len());
+        for (i, (used, palette_map)) in
+            used.iter().cloned().zip(palette_map.iter_mut()).enumerate()
+        {
+            if !used {
+                continue;
+            }
+            // There are invalid files that use pixel indices beyond palette size
+            let color = palette.get(i).cloned().unwrap_or(RGBA8::new(0, 0, 0, 255));
+            match seen.entry(color) {
+                Vacant(new) => {
+                    *palette_map = Some(next_index as u8);
+                    new.insert(next_index as u8);
+                    next_index += 1;
+                }
+                Occupied(remap_to) => {
+                    *palette_map = Some(*remap_to.get());
+                }
+            }
+        }
+    }
+
+    do_palette_reduction(png, &palette_map)
+}
+
+fn do_palette_reduction(png: &PngData, palette_map: &[Option<u8>; 256]) -> Option<ReducedPng> {
+    let byte_map = palette_map_to_byte_map(png, palette_map)?;
+    let mut raw_data = Vec::with_capacity(png.raw_data.len());
+
+    // Reassign data bytes to new indices
+    for line in png.scan_lines() {
+        raw_data.push(line.filter);
+        for byte in line.data {
+            raw_data.push(byte_map[*byte as usize]);
+        }
+    }
+
+    let mut aux_headers = HashMap::new();
+    if let Some(bkgd_header) = png.aux_headers.get(b"bKGD") {
+        if let Some(Some(map_to)) = bkgd_header.get(0).and_then(|&idx| palette_map.get(idx as usize)) {
+            aux_headers.insert(*b"bKGD", Some(vec![*map_to]));
+        }
+    }
+
+    Some(ReducedPng {
+        color_type: ColorType::Indexed,
+        raw_data,
+        palette: Some(reordered_palette(png.palette.as_ref()?, palette_map)),
+        aux_headers,
+    })
+}
+
+fn palette_map_to_byte_map(png: &PngData, palette_map: &[Option<u8>; 256]) -> Option<[u8; 256]> {
+    let len = png.palette.as_ref().map(|p| p.len()).unwrap_or(0);
+    if (0..len).all(|i| palette_map[i].map_or(true, |to| to == i as u8)) {
+        // No reduction necessary
+        return None;
+    }
+
+    let mut byte_map = [0u8; 256];
+
+    // low bit-depths can be pre-computed for every byte value
+    match png.ihdr_data.bit_depth {
+        BitDepth::Eight => {
+            for byte in 0..=255 {
+                byte_map[byte as usize] = palette_map[byte as usize].unwrap_or(0)
+            }
+        }
+        BitDepth::Four => {
+            for byte in 0..=255 {
+                byte_map[byte as usize] = palette_map[(byte & 0x0F) as usize].unwrap_or(0)
+                    | (palette_map[(byte >> 4) as usize].unwrap_or(0) << 4);
+            }
+        }
+        BitDepth::Two => {
+            for byte in 0..=255 {
+                byte_map[byte as usize] = palette_map[(byte & 0x03) as usize].unwrap_or(0)
+                    | (palette_map[((byte >> 2) & 0x03) as usize].unwrap_or(0) << 2)
+                    | (palette_map[((byte >> 4) & 0x03) as usize].unwrap_or(0) << 4)
+                    | (palette_map[(byte >> 6) as usize].unwrap_or(0) << 6);
+            }
+        }
+        _ => {}
+    }
+
+    return Some(byte_map)
+}
+
+fn reordered_palette(palette: &[RGBA8], palette_map: &[Option<u8>; 256]) -> Vec<RGBA8> {
+    let max_index = palette_map.iter().cloned()
+        .filter_map(|x| x)
+        .max()
+        .unwrap_or(0) as usize;
+    let mut new_palette = vec![RGBA8::new(0, 0, 0, 255); max_index + 1];
+    for (&color, &map_to) in palette.iter().zip(palette_map.iter()) {
+        if let Some(map_to) = map_to {
+            new_palette[map_to as usize] = color;
+        }
+    }
+    new_palette
+}

--- a/src/reduction/mod.rs
+++ b/src/reduction/mod.rs
@@ -4,19 +4,24 @@ use std::collections::hash_map::Entry::*;
 use png::PngData;
 use rgb::RGBA8;
 
-mod alpha;
+pub mod alpha;
 pub mod bit_depth;
 pub mod color;
 
+/// Fields to replace in PngData to apply the reduction
 pub struct ReducedPng {
-    pub raw_data: Vec<u8>,
-    pub palette: Option<Vec<RGBA8>>,
-    pub aux_headers: HashMap<[u8; 4], Option<Vec<u8>>>,
     pub color_type: ColorType,
+    pub raw_data: Vec<u8>,
+    /// replace if Some
+    pub palette: Option<Vec<RGBA8>>,
+    /// replace if Some
+    pub transparency_pixel: Option<Vec<u8>>,
+    /// replace if Some, delete if None
+    pub aux_headers: HashMap<[u8; 4], Option<Vec<u8>>>,
 }
 
 /// Attempt to reduce the number of colors in the palette
-/// Returns true if the palette was reduced, false otherwise
+/// Returns `None` if palette hasn't changed
 pub fn reduced_palette(png: &PngData) -> Option<ReducedPng> {
     if png.ihdr_data.color_type != ColorType::Indexed {
         // Can't reduce if there is no palette
@@ -101,6 +106,7 @@ fn do_palette_reduction(png: &PngData, palette_map: &[Option<u8>; 256]) -> Optio
     Some(ReducedPng {
         color_type: ColorType::Indexed,
         raw_data,
+        transparency_pixel: None,
         palette: Some(reordered_palette(png.palette.as_ref()?, palette_map)),
         aux_headers,
     })

--- a/src/reduction/mod.rs
+++ b/src/reduction/mod.rs
@@ -12,6 +12,7 @@ pub mod color;
 pub struct ReducedPng {
     pub color_type: ColorType,
     pub raw_data: Vec<u8>,
+    pub bit_depth: BitDepth,
     /// replace if Some
     pub palette: Option<Vec<RGBA8>>,
     /// replace if Some
@@ -22,6 +23,7 @@ pub struct ReducedPng {
 
 /// Attempt to reduce the number of colors in the palette
 /// Returns `None` if palette hasn't changed
+#[must_use]
 pub fn reduced_palette(png: &PngData) -> Option<ReducedPng> {
     if png.ihdr_data.color_type != ColorType::Indexed {
         // Can't reduce if there is no palette
@@ -84,6 +86,7 @@ pub fn reduced_palette(png: &PngData) -> Option<ReducedPng> {
     do_palette_reduction(png, &palette_map)
 }
 
+#[must_use]
 fn do_palette_reduction(png: &PngData, palette_map: &[Option<u8>; 256]) -> Option<ReducedPng> {
     let byte_map = palette_map_to_byte_map(png, palette_map)?;
     let mut raw_data = Vec::with_capacity(png.raw_data.len());
@@ -105,6 +108,7 @@ fn do_palette_reduction(png: &PngData, palette_map: &[Option<u8>; 256]) -> Optio
 
     Some(ReducedPng {
         color_type: ColorType::Indexed,
+        bit_depth: png.ihdr_data.bit_depth,
         raw_data,
         transparency_pixel: None,
         palette: Some(reordered_palette(png.palette.as_ref()?, palette_map)),


### PR DESCRIPTION
Instead of immediately, mutably modifying `self`, reductions return a struct with the changed fields.

For now, this is just work in progress, but in the future it'll allow two things:

* Run some reductions in parallel
* Apply reductions only after verifying they're beneficial — #152 