### PR TITLE
Timeout

### DIFF
--- a/src/deflate/mod.rs
+++ b/src/deflate/mod.rs
@@ -1,3 +1,4 @@
+use Deadline;
 use atomicmin::AtomicMin;
 use error::PngError;
 use miniz_oxide;
@@ -25,11 +26,11 @@ pub fn inflate(data: &[u8]) -> PngResult<Vec<u8>> {
 }
 
 /// Compress a data stream using the DEFLATE algorithm
-pub fn deflate(data: &[u8], zc: u8, zs: u8, zw: u8, max_size: &AtomicMin) -> PngResult<Vec<u8>> {
+pub(crate) fn deflate(data: &[u8], zc: u8, zs: u8, zw: u8, max_size: &AtomicMin, deadline: &Deadline) -> PngResult<Vec<u8>> {
     #[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
     {
         if cfzlib::is_supported() {
-            return cfzlib::cfzlib_deflate(data, zc, zs, zw, max_size);
+            return cfzlib::cfzlib_deflate(data, zc, zs, zw, max_size, deadline);
         }
     }
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -6,6 +6,7 @@ use std::fmt;
 #[derive(Debug, Clone)]
 pub enum PngError {
     DeflatedDataTooLong(usize),
+    TimedOut,
     NotPNG,
     APNGNotSupported,
     InvalidData,
@@ -28,6 +29,7 @@ impl fmt::Display for PngError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match *self {
             PngError::DeflatedDataTooLong(_) => f.write_str("deflated data too long"),
+            PngError::TimedOut => f.write_str("timed out"),
             PngError::NotPNG => f.write_str("Invalid header detected; Not a PNG file"),
             PngError::InvalidData => f.write_str("Invalid data found; unable to read PNG file"),
             PngError::TruncatedData => {

--- a/src/reduction/alpha.rs
+++ b/src/reduction/alpha.rs
@@ -9,7 +9,7 @@ use png::PngImage;
 use colors::ColorType;
 use rayon::prelude::*;
 
-pub fn try_alpha_reductions(png: Arc<PngImage>, alphas: &HashSet<AlphaOptim>, eval: &Evaluator) {
+pub(crate) fn try_alpha_reductions(png: Arc<PngImage>, alphas: &HashSet<AlphaOptim>, eval: &Evaluator) {
     assert!(!alphas.is_empty());
     let alphas = alphas.iter().collect::<Vec<_>>();
     let alphas_iter = alphas.par_iter().with_max_len(1);

--- a/src/reduction/mod.rs
+++ b/src/reduction/mod.rs
@@ -13,8 +13,8 @@ use bit_depth::*;
 pub mod color;
 use color::*;
 
-pub use bit_depth::reduce_bit_depth;
-pub use alpha::try_alpha_reductions;
+pub(crate) use bit_depth::reduce_bit_depth;
+pub(crate) use alpha::try_alpha_reductions;
 
 /// Attempt to reduce the number of colors in the palette
 /// Returns `None` if palette hasn't changed


### PR DESCRIPTION
(requires #158)

Short timeouts didn't work well with large images, because the timeout was checked rarely.

This adds more checks of `deadline.passed()`