### PR TITLE
Avoid mixing Rayon with Mutex

### DIFF
--- a/src/rayon.rs
+++ b/src/rayon.rs
@@ -51,3 +51,7 @@ impl<I: Iterator> ParallelIterator for I {
 pub fn join<A, B>(a: impl FnOnce() -> A, b: impl FnOnce() -> B) -> (A, B) {
     (a(), b())
 }
+
+pub fn spawn(a: impl FnOnce() -> A) -> A {
+    a()
+}


### PR DESCRIPTION
Previous loop had Mutex inside rayon's for_each, and [this was dangerous](https://github.com/rayon-rs/rayon/issues/592).

This reorganizes the loop to be single threaded, fed by multiple async tasks. This makes evaluation even more async than before.