### PR TITLE
Fix info message and typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ to give any extra compression gains and is not recommended.
 PNG interlacing on any images that are processed. `-i 0` will remove interlacing from all
 processed images. Not specifying either will keep the same interlacing state as the
 input image. Note: Interlacing can add 25-50% to the size of an optimized image. Only use
-it if you believe the benefits outweight the costs for your use case.
+it if you believe the benefits outweigh the costs for your use case.
 * Strip: Used to remove metadata info from processed images. Used via `--strip [safe,all]`.
 Can save a few kilobytes if you don't need the metadata. "Safe" removes only metadata that
 will never affect rendering of the image. "All" removes all metadata that is not critical

--- a/README.template.md
+++ b/README.template.md
@@ -49,7 +49,7 @@ to give any extra compression gains and is not recommended.
 PNG interlacing on any images that are processed. `-i 0` will remove interlacing from all
 processed images. Not specifying either will keep the same interlacing state as the
 input image. Note: Interlacing can add 25-50% to the size of an optimized image. Only use
-it if you believe the benefits outweight the costs for your use case.
+it if you believe the benefits outweigh the costs for your use case.
 * Strip: Used to remove metadata info from processed images. Used via `--strip [safe,all]`.
 Can save a few kilobytes if you don't need the metadata. "Safe" removes only metadata that
 will never affect rendering of the image. "All" removes all metadata that is not critical

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -477,7 +477,7 @@ fn optimize_png(
             eprintln!(
                 "    {} bits/pixel, {} colors in palette",
                 png.raw.ihdr.bit_depth,
-                palette.len() / 3
+                palette.len()
             );
         } else {
             eprintln!(
@@ -824,7 +824,7 @@ fn report_reduction(png: &PngImage) {
         eprintln!(
             "Reducing image to {} bits/pixel, {} colors in palette",
             png.ihdr.bit_depth,
-            palette.len() / 3
+            palette.len()
         );
     } else {
         eprintln!(

--- a/tests/flags.rs
+++ b/tests/flags.rs
@@ -332,7 +332,7 @@ fn interlacing_1_to_0_small_files() {
 
     assert_eq!(png.raw.ihdr.interlaced, 0);
     assert_eq!(png.raw.ihdr.color_type, ColorType::Indexed);
-    // the depth can't be asserted reliably, because on such small file different zlib implementaitons pick diferent depth as the best
+    // the depth can't be asserted reliably, because on such small file different zlib implementations pick different depth as the best
 
     remove_file(output).ok();
 }


### PR DESCRIPTION
Fixes a few typos discovered by codespell and a verbose message that has a wrong number of colors since the palette object stores one entry per color.