### PR TITLE
Preallocate memory in reduced_alpha_to_up

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,6 +37,7 @@ zopfli = "^0.4.0"
 miniz_oxide = "0.2.0"
 rgb = "0.8.11"
 
+
 [dependencies.rayon]
 optional = true
 version = "^1.0.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,7 +37,6 @@ zopfli = "^0.4.0"
 miniz_oxide = "0.2.0"
 rgb = "0.8.11"
 
-
 [dependencies.rayon]
 optional = true
 version = "^1.0.0"

--- a/src/reduction/alpha.rs
+++ b/src/reduction/alpha.rs
@@ -97,7 +97,7 @@ fn reduced_alpha_to_up(png: &PngImage, bpc: usize, bpp: usize) -> Vec<u8> {
     scan_lines.reverse();
     let mut lines = Vec::with_capacity(scan_lines.len());
     let mut last_line = Vec::new();
-    let mut current_line = Vec::with_capacity(scan_lines[0].data.len());
+    let mut current_line = Vec::with_capacity(scan_lines[0].data.len() + 1); // filter size + pixels
     for line in scan_lines {
         if line.data.len() != last_line.len() {
             last_line = vec![0; line.data.len()];

--- a/src/reduction/alpha.rs
+++ b/src/reduction/alpha.rs
@@ -93,11 +93,11 @@ fn reduced_alpha_to_white(png: &PngImage, bpc: usize, bpp: usize) -> Vec<u8> {
 }
 
 fn reduced_alpha_to_up(png: &PngImage, bpc: usize, bpp: usize) -> Vec<u8> {
-    let mut lines = Vec::new();
     let mut scan_lines = png.scan_lines().collect::<Vec<ScanLine<'_>>>();
     scan_lines.reverse();
+    let mut lines = Vec::with_capacity(scan_lines.len());
     let mut last_line = Vec::new();
-    let mut current_line = Vec::with_capacity(last_line.len());
+    let mut current_line = Vec::with_capacity(scan_lines[0].data.len());
     for line in scan_lines {
         if line.data.len() != last_line.len() {
             last_line = vec![0; line.data.len()];


### PR DESCRIPTION
For this [image](https://proxy.duckduckgo.com/iu/?u=https%3A%2F%2Fwww.pngarts.com%2Ffiles%2F4%2FSpace-Rocket-PNG-Image-Transparent-Background.png&f=1) when using oxipng -a, valgrind reports 20 less allocs/frees

Original: 
>==8410==   total heap usage: 5,305,656 allocs, 5,305,577 frees, 9,187,337,048 bytes allocated

With this patch:
>==8977==   total heap usage: 5,305,636 allocs, 5,305,557 frees, 9,186,624,996 bytes allocated

It's a pretty low-hanging fruit optimization, which is maybe why I picked it up :P. Ideally though oxipng should use some kind of memory pool data structure to allocate memory and allow stages of the optimizer to reuse it instead of allocating. There are tons of new vecs created from function to function. This patch could also be optimized a bit more maybe, by also accounting for pixel size when allocating.

Also I wasn't quite able to run benchmark tests on this. Seemingly the benchmark tests fail to compile due to missing functions? Is this problem reproducible for other people?

