### PR TITLE
Allow disabling all alpha optimizations when used as a library

### DIFF
--- a/src/reduction/alpha.rs
+++ b/src/reduction/alpha.rs
@@ -16,7 +16,10 @@ pub(crate) fn try_alpha_reductions(
     alphas: &HashSet<AlphaOptim>,
     eval: &Evaluator,
 ) {
-    assert!(!alphas.is_empty());
+    if alphas.is_empty() {
+        return;
+    }
+
     let alphas = alphas.iter().collect::<Vec<_>>();
     let alphas_iter = alphas.par_iter().with_max_len(1);
     alphas_iter


### PR DESCRIPTION
I was using oxipng as a library, and wanted to disable all alpha optimizations (to be fully lossless). I setting the `alphas` field of the `Option` struct to an empty hashset, but I hit an assert in the library.

I didn't see any reason why the assert should be there, so I removed the assert, and made the function apply no processing if the hashset was empty. I didn't encounter any problems converting some files (they came out as identical), and `cargo test` passed for me.

I've made this pull request just in case this assert is no longer needed. If it's actually there for good reason you can close this pull request.
