### PR TITLE
Implement palette sorting

### DIFF
--- a/src/reduction/mod.rs
+++ b/src/reduction/mod.rs
@@ -226,6 +226,14 @@ pub fn reduce_color_type(png: &PngImage) -> Option<PngImage> {
         }
     }
 
+    //Make sure that palette gets sorted. Ideally, this should be done within reduced_color_to_palette.
+    if should_reduce_bit_depth && reduced.ihdr.color_type == ColorType::Indexed {
+        if let Some(r) = reduced_palette(&reduced) {
+            reduced = Cow::Owned(r);
+            should_reduce_bit_depth = true;
+        }
+    }
+
     if should_reduce_bit_depth {
         // Some conversions will allow us to perform bit depth reduction that
         // wasn't possible before


### PR DESCRIPTION
Sorting is based on ascending alpha channel value and descending luminosity. I only encountered very small gains when additionally using popularity based sorting alternatively, so I think this is a sensible default. It should be easy to implement additional approaches to sorting when desired.
I tried using the evaluation system to try both compression with and without palette sorting, but that resulted in smaller in compression gains (perhaps something wrong with the evaluation code), so enabling this by default is worth considering.