### PR TITLE
Use fast heuristic for reduction evaluation

### DIFF
--- a/src/evaluate.rs
+++ b/src/evaluate.rs
@@ -86,7 +86,8 @@ impl Evaluator {
         // but results will be collected via the message queue
         let eval_send = self.eval_send.clone();
         rayon::spawn(move || {
-            let filters_iter = STD_FILTERS.par_iter().with_max_len(1);
+            let FILTERS: [u8; 1] = [0];
+            let filters_iter = FILTERS.par_iter().with_max_len(1);
 
             // Updating of best result inside the parallel loop would require locks,
             // which are dangerous to do in side Rayon's loop.
@@ -98,7 +99,7 @@ impl Evaluator {
                 }
                 if let Ok(idat_data) = deflate::deflate(
                     &image.filter_image(filter),
-                    STD_COMPRESSION,
+                    1,
                     STD_STRATEGY,
                     STD_WINDOW,
                     &best_candidate_size,


### PR DESCRIPTION
This improves runtime by 8% on my benchmark. Surprisingly, it only causes output files to be a fraction of a percent larger. I feel like this compression loss definitely _should_ be larger. It might just be an issue with the images I use for testing, but it seems to me that something is going wrong in the evaluation code. I also think that evaluation is not that impactful on many images since several reductions are rarely not worth doing.

Note that I have not refactored this code to fix warnings since it is a significant change and I want to hear your opinion first.