### PR TITLE
Allow usage on wasm32-unknown-unknown target

### DIFF
--- a/src/evaluate.rs
+++ b/src/evaluate.rs
@@ -11,12 +11,9 @@ use crate::png::STD_STRATEGY;
 use crate::png::STD_WINDOW;
 #[cfg(not(feature = "parallel"))]
 use crate::rayon;
-#[cfg(not(feature = "parallel"))]
-use crate::rayon::prelude::*;
 use crate::Deadline;
 #[cfg(feature = "parallel")]
 use rayon;
-#[cfg(feature = "parallel")]
 use rayon::prelude::*;
 use std::sync::atomic::AtomicUsize;
 use std::sync::atomic::Ordering::SeqCst;


### PR DESCRIPTION
This PR allows to compile and use OxiPNG on `wasm32-unknown-unknown` target, thus fixes #157.

The changes are described in commit messages, but, as a short summary, two primary fixes are:
 - Avoiding call to `Instant::now()` in `Deadline::new` when no `Timeout` is set. This is required because `Instant::now()` panics on `wasm32-unknown-unknown` (as it tries to retrieve time, for which there is no generic Wasm syscall implementation), and so allows to initialise OxiPNG with default options (no timeout) while still allowing to use timeout on other platforms.
 - Trying all the combinations on the main thread when `feature = "parallel"` is unset. Threads proposal for Wasm is not finalised and will take time to be ready in mainstream implementation, so this is also important for OxiPNG to work on Wasm target.