### PR TITLE
Add "max" level alias; various level-related warnings

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -206,8 +206,16 @@ impl Options {
                 opts.apply_preset_4()
             }
             5 => opts.apply_preset_5(),
-            _ => opts.apply_preset_6(),
+            6 => opts.apply_preset_6(),
+            _ => {
+                warn!("Level 7 and above don't exist yet and are identical to level 6");
+                opts.apply_preset_6()
+            }
         }
+    }
+
+    pub fn max_compression() -> Options {
+        Options::from_preset(6)
     }
 
     // The following methods make assumptions that they are operating

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -201,7 +201,10 @@ impl Options {
             1 => opts.apply_preset_1(),
             2 => opts.apply_preset_2(),
             3 => opts.apply_preset_3(),
-            4 => opts.apply_preset_4(),
+            4 => {
+                warn!("Level 4 is deprecated and is identical to level 3");
+                opts.apply_preset_4()
+            }
             5 => opts.apply_preset_5(),
             _ => opts.apply_preset_6(),
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -233,8 +233,8 @@ fn main() {
     -o 2   =>  --zc 9 --zs 0-3 -f 0,5       (8 trials with zlib or 2 trials with other compressors)
     -o 3   =>  --zc 9 --zs 0-3 -f 0-5       (24 trials with zlib or 6 trials with other compressors)
     -o 4   =>                               (deprecated; same as `-o 3`)
-    -o 5   =>  --zc 3-9 --zs 0-3 -f 0-5     (96 trials with zlib; same as `-o 3` for other compressors)
-    -o 6   =>  --zc 1-9 --zs 0-3 -f 0-5     (180 trials with zlib; same as -o 3` for other compressors)
+    -o 5   =>  --zc 3-9 --zs 0-3 -f 0-5     (168 trials with zlib; same as `-o 3` for other compressors)
+    -o 6   =>  --zc 1-9 --zs 0-3 -f 0-5     (216 trials with zlib; same as `-o 3` for other compressors)
     -o max =>                               (stable alias for the max compression)
 
     Manually specifying a compression option (zc, zs, etc.) will override the optimization preset,

--- a/src/main.rs
+++ b/src/main.rs
@@ -313,6 +313,14 @@ fn collect_files(
 fn parse_opts_into_struct(
     matches: &ArgMatches,
 ) -> Result<(OutFile, Option<PathBuf>, Options), String> {
+    stderrlog::new()
+        .module(module_path!())
+        .quiet(matches.is_present("quiet"))
+        .verbosity(if matches.is_present("verbose") { 3 } else { 2 })
+        .show_level(false)
+        .init()
+        .unwrap();
+
     let mut opts = if let Some(x) = matches.value_of("optimization") {
         if let Ok(opt) = x.parse::<u8>() {
             Options::from_preset(opt)
@@ -396,14 +404,6 @@ fn parse_opts_into_struct(
     if matches.is_present("preserve") {
         opts.preserve_attrs = true;
     }
-
-    stderrlog::new()
-        .module(module_path!())
-        .quiet(matches.is_present("quiet"))
-        .verbosity(if matches.is_present("verbose") { 3 } else { 2 })
-        .show_level(false)
-        .init()
-        .unwrap();
 
     if matches.is_present("no-bit-reduction") {
         opts.bit_depth_reduction = false;

--- a/src/main.rs
+++ b/src/main.rs
@@ -231,9 +231,9 @@ fn main() {
     -o 1  =>  --zc 9                       (1 trial, determined heuristically)
     -o 2  =>  --zc 9 --zs 0-3 -f 0,5       (8 trials)
     -o 3  =>  --zc 9 --zs 0-3 -f 0-5       (24 trials)
-    -o 4  =>  --zc 9 --zs 0-3 -f 0-5 -a    (24 trials + 6 alpha trials)
-    -o 5  =>  --zc 3-9 --zs 0-3 -f 0-5 -a  (96 trials + 6 alpha trials)
-    -o 6  =>  --zc 1-9 --zs 0-3 -f 0-5 -a  (180 trials + 6 alpha trials)
+    -o 4  =>                               (deprecated; same as `-o 3`)
+    -o 5  =>  --zc 3-9 --zs 0-3 -f 0-5     (96 trials)
+    -o 6  =>  --zc 1-9 --zs 0-3 -f 0-5     (180 trials)
 
     Manually specifying a compression option (zc, zs, etc.) will override the optimization preset,
     regardless of the order you write the arguments.")

--- a/src/main.rs
+++ b/src/main.rs
@@ -230,12 +230,12 @@ fn main() {
         .after_help("Optimization levels:
     -o 0   =>  --zc 3 --nz                  (0 or 1 trials)
     -o 1   =>  --zc 9                       (1 trial, determined heuristically)
-    -o 2   =>  --zc 9 --zs 0-3 -f 0,5       (8 trials)
-    -o 3   =>  --zc 9 --zs 0-3 -f 0-5       (24 trials)
+    -o 2   =>  --zc 9 --zs 0-3 -f 0,5       (8 trials with zlib or 2 trials with other compressors)
+    -o 3   =>  --zc 9 --zs 0-3 -f 0-5       (24 trials with zlib or 6 trials with other compressors)
     -o 4   =>                               (deprecated; same as `-o 3`)
-    -o 5   =>  --zc 3-9 --zs 0-3 -f 0-5     (96 trials)
-    -o 6   =>  --zc 1-9 --zs 0-3 -f 0-5     (180 trials)
-    -o max =>                               (alias for the max compression, currently same as -o 6)
+    -o 5   =>  --zc 3-9 --zs 0-3 -f 0-5     (96 trials with zlib; same as `-o 3` for other compressors)
+    -o 6   =>  --zc 1-9 --zs 0-3 -f 0-5     (180 trials with zlib; same as -o 3` for other compressors)
+    -o max =>                               (stable alias for the max compression)
 
     Manually specifying a compression option (zc, zs, etc.) will override the optimization preset,
     regardless of the order you write the arguments.")

--- a/src/main.rs
+++ b/src/main.rs
@@ -321,15 +321,12 @@ fn parse_opts_into_struct(
         .init()
         .unwrap();
 
-    let mut opts = if let Some(x) = matches.value_of("optimization") {
-        if let Ok(opt) = x.parse::<u8>() {
-            Options::from_preset(opt)
-        } else {
-            unreachable!()
-        }
-    } else {
-        Options::default()
+    let level = match matches.value_of("optimization") {
+        Some(x) => x.parse::<u8>().unwrap(),
+        None => 2,
     };
+
+    let mut opts = Options::from_preset(level);
 
     if let Some(x) = matches.value_of("interlace") {
         opts.interlace = x.parse::<u8>().ok();
@@ -491,6 +488,17 @@ fn parse_opts_into_struct(
             Some("16k") => *window = 14,
             // 32k is default
             _ => (),
+        }
+    }
+
+    if level > 3 {
+        match opts.deflate {
+            Deflaters::Zlib { .. } => {}
+            _ => {
+                warn!(
+                    "Level 4 and above are equivalent to level 3 for compressors other than zlib"
+                );
+            }
         }
     }
 


### PR DESCRIPTION
 - Show a deprecation warning for `Options::from_preset(4)` / `-o 4` as per #221. Can be still removed later, but for now at least avoids confusion.
 - Show warning for usage of levels 4 and above for Zopfli and Libdeflate. This is not immediately obvious to users, but such levels end up iterating over same parameters as level 3 for these compressors, since there are no fine-tuned compressor options.
 - Adds `Options::max_compression` and `-o max` to always refer to best compression as discussed in #221.
 - Warns about usage of levels that don't exist yet. Previously these would silently downgrade to `-o 6`, but I think it's worth showing a warning now that we have explicit `max_compression` method / option.