### PR TITLE
Remove doc-hidden `recursive` option

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -129,9 +129,6 @@ pub struct Options {
     ///
     /// Default: `false`
     pub pretend: bool,
-    /// Used only in CLI interface
-    #[doc(hidden)]
-    pub recursive: bool,
     /// Write to output even if there was no improvement in compression.
     ///
     /// Default: `false`
@@ -282,7 +279,6 @@ impl Default for Options {
         Options {
             backup: false,
             pretend: false,
-            recursive: false,
             fix_errors: false,
             force: false,
             preserve_attrs: false,

--- a/src/main.rs
+++ b/src/main.rs
@@ -255,7 +255,7 @@ fn main() {
             .collect(),
         &out_dir,
         &out_file,
-        opts.recursive,
+        matches.is_present("recursive"),
         true,
     );
 
@@ -379,10 +379,6 @@ fn parse_opts_into_struct(
 
     if matches.is_present("force") {
         opts.force = true;
-    }
-
-    if matches.is_present("recursive") {
-        opts.recursive = true;
     }
 
     if matches.is_present("fix") {


### PR DESCRIPTION

As the comment mentions, this is used only in CLI interface, so there's no reason for it not to live directly in CLI code.

Ref: #220.