### PR TITLE
Build more release binaries

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -7,20 +7,22 @@ on:
 
 jobs:
 
-  create-binaries-windows:
+  create-binaries:
 
     strategy:
       matrix:
-        conf:
-          - x86_64-pc-windows-msvc
-          - i686-pc-windows-msvc
+        os: [ubuntu-latest, macOS-latest, windows-latest]
         include:
-          - conf: x86_64-pc-windows-msvc
+          - os: ubuntu-latest
+            target: x86_64-unknown-linux-musl
+          - os: macOS-latest
+            target: x86_64-apple-darwin
+          - os: windows-latest
             target: x86_64-pc-windows-msvc
-          - conf: i686-pc-windows-msvc
+          - os: windows-latest
             target: i686-pc-windows-msvc
 
-    runs-on: windows-latest
+    runs-on: '${{ matrix.os }}'
 
     steps:
     - uses: actions/checkout@v2
@@ -33,9 +35,17 @@ jobs:
         target: ${{ matrix.target }}
         override: true
 
+    - name: Install musl
+      run: sudo apt-get install musl-tools
+      if: contains(matrix.target, 'linux-musl')
+
     - name: Build oxipng
       run: |
         cargo build --release --target ${{ matrix.target }}
+
+    - name: Strip binary
+      run: strip 'target/${{ matrix.target }}/release/oxipng'
+      if: "!contains(matrix.target, 'windows')"
 
     - name: Get the version
       shell: bash
@@ -44,22 +54,35 @@ jobs:
         VERSION=$(cargo pkgid | cut -d# -f2 | cut -d: -f2)
         echo "::set-output name=tag::$VERSION"
 
-    - name: Create zip
+    - name: Build package
+      id: package
+      shell: bash
       run: |
-        $OXIPNG_PATH="$Env:GITHUB_WORKSPACE\target\${{ matrix.target }}\release"
-        strip "$OXIPNG_PATH\oxipng.exe"
-        7z a oxipng-${{ steps.tagName.outputs.tag }}-${{ matrix.target }}.zip `
-             "$OXIPNG_PATH\oxipng.exe"
+        ARCHIVE_NAME="oxipng-${{ steps.tagName.outputs.tag }}-${{ matrix.target }}"
+        if [[ '${{ matrix.target }}' == *windows* ]]; then
+          ARCHIVE_FILE="${ARCHIVE_NAME}.zip"
+          mv LICENSE LICENSE.txt
+          7z a "${ARCHIVE_FILE}" "./target/${{ matrix.target }}/release/oxipng.exe" ./CHANGELOG.md ./LICENSE.txt ./README.md
+          echo ::set-output "name=file::${ARCHIVE_FILE}"
+          echo ::set-output "name=name::${ARCHIVE_NAME}.zip"
+        else
+          ARCHIVE_FILE="${ARCHIVE_NAME}.tar.gz"
+          mkdir "/tmp/${ARCHIVE_NAME}"
+          cp README.md CHANGELOG.md LICENSE "target/${{ matrix.target }}/release/oxipng" "/tmp/${ARCHIVE_NAME}"
+          tar -czf "${PWD}/${ARCHIVE_FILE}" -C /tmp/ "${ARCHIVE_NAME}"
+          echo ::set-output "name=file::${ARCHIVE_FILE}"
+          echo ::set-output "name=name::${ARCHIVE_NAME}.tar.gz"
+        fi
 
     - name: Upload artifacts
       uses: actions/upload-artifact@v2
       with:
-        name: oxipng-${{ steps.tagName.outputs.tag }}-${{ matrix.target }}
-        path: oxipng-${{ steps.tagName.outputs.tag }}-${{ matrix.target }}.zip
+        name: ${{ steps.package.outputs.name }}
+        path: ${{ steps.package.outputs.file }}
 
   deploy:
 
-    needs: create-binaries-windows
+    needs: create-binaries
 
     runs-on: ubuntu-latest
 
@@ -73,15 +96,10 @@ jobs:
           tail -n +2 CHANGELOG.md | sed -e '/^$/,$d' > CHANGELOG.txt
           echo "::set-output name=tag::$VERSION"
 
-      - name: Download x86_64 Windows artifact
+      - name: Download artifacts
         uses: actions/download-artifact@v2
         with:
-          name: oxipng-${{ steps.tagName.outputs.tag }}-x86_64-pc-windows-msvc
-
-      - name: Download i686 Windows artifact
-        uses: actions/download-artifact@v2
-        with:
-          name: oxipng-${{ steps.tagName.outputs.tag }}-i686-pc-windows-msvc
+          path: ./binaries
 
       - name: Create a release
         uses: softprops/action-gh-release@v1
@@ -89,7 +107,7 @@ jobs:
           name: v${{ steps.tagName.outputs.tag }}
           body_path: CHANGELOG.txt
           files: |
-            oxipng-${{ steps.tagName.outputs.tag }}-x86_64-pc-windows-msvc.zip
-            oxipng-${{ steps.tagName.outputs.tag }}-i686-pc-windows-msvc.zip
+            ./binaries/**/*.zip
+            ./binaries/**/*.tar.gz
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/oxipng.yml
+++ b/.github/workflows/oxipng.yml
@@ -34,17 +34,17 @@ jobs:
           os: macOS-latest
         exclude:
         - target: x86_64-pc-windows-msvc
-          rust: beta
+          toolchain: beta
         - target: x86_64-pc-windows-msvc
-          rust: nightly
+          toolchain: nightly
         - target: x86_64-apple-darwin
-          rust: beta
+          toolchain: beta
         - target: x86_64-apple-darwin
-          rust: nightly
+          toolchain: nightly
         - target: x86_64-unknown-linux-musl
-          rust: beta
+          toolchain: beta
         - target: x86_64-unknown-linux-musl
-          rust: nightly
+          toolchain: nightly
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/oxipng.yml
+++ b/.github/workflows/oxipng.yml
@@ -13,27 +13,44 @@ jobs:
     strategy:
       matrix:
         target:
-          - x86_64-unknown-linux-gnu
-          - x86_64-pc-windows-msvc
+        - x86_64-unknown-linux-gnu
+        - x86_64-unknown-linux-musl
+        - x86_64-pc-windows-msvc
+        - x86_64-apple-darwin
         toolchain:
-          # Minimum stable
-          - "1.41.0"
-          - stable
-          - beta
-          - nightly
+        # Minimum stable
+        - "1.41.0"
+        - stable
+        - beta
+        - nightly
         include:
-          - target: x86_64-unknown-linux-gnu
-            os: ubuntu-latest
-          - target: x86_64-pc-windows-msvc
-            os: windows-latest
+        - target: x86_64-unknown-linux-gnu
+          os: ubuntu-latest
+        - target: x86_64-unknown-linux-musl
+          os: ubuntu-latest
+        - target: x86_64-pc-windows-msvc
+          os: windows-latest
+        - target: x86_64-apple-darwin
+          os: macOS-latest
         exclude:
-          - target: x86_64-pc-windows-msvc
-            rust: beta
-          - target: x86_64-pc-windows-msvc
-            rust: nightly
+        - target: x86_64-pc-windows-msvc
+          rust: beta
+        - target: x86_64-pc-windows-msvc
+          rust: nightly
+        - target: x86_64-apple-darwin
+          rust: beta
+        - target: x86_64-apple-darwin
+          rust: nightly
+        - target: x86_64-unknown-linux-musl
+          rust: beta
+        - target: x86_64-unknown-linux-musl
+          rust: nightly
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v2
+    - name: Install musl tools
+      run: sudo apt-get install musl-tools
+      if: "contains(matrix.target, 'musl')"
     - name: Install ${{ matrix.toolchain }}
       uses: actions-rs/toolchain@v1
       with:

--- a/.github/workflows/oxipng.yml
+++ b/.github/workflows/oxipng.yml
@@ -9,24 +9,29 @@ on:
       - master
 
 jobs:
-  build-test-unix:
-    runs-on: ubuntu-latest
+  test:
     strategy:
       matrix:
-        conf:
-          - minimum-stable
-          - latest-stable
-          - latest-beta
-          - latest-nightly
+        target:
+          - x86_64-unknown-linux-gnu
+          - x86_64-pc-windows-msvc
+        toolchain:
+          # Minimum stable
+          - "1.41.0"
+          - stable
+          - beta
+          - nightly
         include:
-          - conf: minimum-stable
-            toolchain: 1.41.0
-          - conf: latest-stable
-            toolchain: stable
-          - conf: latest-beta
-            toolchain: beta
-          - conf: latest-nightly
-            toolchain: nightly
+          - target: x86_64-unknown-linux-gnu
+            os: ubuntu-latest
+          - target: x86_64-pc-windows-msvc
+            os: windows-latest
+        exclude:
+          - target: x86_64-pc-windows-msvc
+            rust: beta
+          - target: x86_64-pc-windows-msvc
+            rust: nightly
+    runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v2
     - name: Install ${{ matrix.toolchain }}
@@ -40,9 +45,9 @@ jobs:
       uses: actions/cache@v1
       with:
         path: ~/.cargo/registry/cache
-        key: ${{ runner.os }}-${{ matrix.conf }}-cargo-registry-${{ hashFiles('**/Cargo.lock') }}
+        key: ${{ matrix.target }}-${{ matrix.toolchain }}-cargo-registry-${{ hashFiles('**/Cargo.lock') }}
         restore-keys: |
-          ${{ runner.os }}-${{ matrix.conf }}-cargo-registry-
+          ${{ matrix.target }}-${{ matrix.toolchain }}-cargo-registry-
     - name: Run rustfmt
       if: matrix.toolchain == 'stable'
       uses: actions-rs/cargo@v1
@@ -60,57 +65,6 @@ jobs:
     - name: Build benchmarks
       if: matrix.toolchain == 'nightly'
       run: cargo bench --no-run
-    - name: Build docs
-      run: cargo doc --no-deps
-    - name: Check no default features
-      if: matrix.toolchain == 'stable'
-      uses: actions-rs/clippy-check@v1
-      with:
-        token: ${{ secrets.GITHUB_TOKEN }}
-        args: --no-default-features -- -D warnings
-
-  build-test-windows:
-    runs-on: windows-latest
-    strategy:
-      matrix:
-        conf:
-          - minimum-stable
-          - latest-stable
-        include:
-          - conf: minimum-stable
-            toolchain: 1.41.0
-          - conf: latest-stable
-            toolchain: stable
-    steps:
-    - uses: actions/checkout@v2
-    - name: Install ${{ matrix.toolchain }}
-      uses: actions-rs/toolchain@v1
-      with:
-        profile: minimal
-        toolchain: ${{ matrix.toolchain }}
-        override: true
-        components: clippy, rustfmt
-    - name: Cache cargo registry
-      uses: actions/cache@v1
-      with:
-        path: ~/.cargo/registry/cache
-        key: ${{ runner.os }}-${{ matrix.conf }}-cargo-registry-${{ hashFiles('**/Cargo.lock') }}
-        restore-keys: |
-          ${{ runner.os }}-${{ matrix.conf }}-cargo-registry-
-    - name: Run rustfmt
-      if: matrix.toolchain == 'stable'
-      uses: actions-rs/cargo@v1
-      with:
-        command: fmt
-        args: -- --check
-    - name: Run clippy
-      if: matrix.toolchain == 'stable'
-      uses: actions-rs/clippy-check@v1
-      with:
-        token: ${{ secrets.GITHUB_TOKEN }}
-        args: -- -D warnings
-    - name: Run tests
-      run: cargo test
     - name: Build docs
       run: cargo doc --no-deps
     - name: Check no default features


### PR DESCRIPTION
Include a static Linux binary with musl and a macOS build.  Also add readme, license and changelog to the release archives.  Closes GH-134.

I copied and adapted the workflow from one of my crates but I didn't test it; I just don't know how to do that with a forked repo.

I don't have access to macOS, but I'm sure it works, given that Windows also works.  I tested a musl build locally, but I didn't add it to the CI workflow.  Should I?
