### PR TITLE
Cargo.toml: set arm-always for cloudflare-zlib

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,8 +58,9 @@ default-features = false
 features = ["png"]
 version = "0.23"
 
-[target.'cfg(any(target_arch = "x86_64", target_arch = "aarch64"))'.dependencies]
-cloudflare-zlib = "^0.2.2"
+[target.'cfg(any(target_arch = "x86_64", target_arch = "aarch64"))'.dependencies.cloudflare-zlib]
+features = ["arm-always"]
+version = "^0.2.2"
 
 [build-dependencies]
 rustc_version = "0.2"


### PR DESCRIPTION
Without this, cloudflare-zlib currently bails out early on all `aarch64` CPUs. This is one of the two solutions I proposed in #276, and it's the option I prefer out of the two.

Fixes #276.