### PR TITLE
Switch to crossbeam-channel + rayon::spawn

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -164,12 +164,22 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-channel"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b153fe7cbef478c567df0f972e02e6d736db11affe43dfc9c56a9374d1adfb87"
+dependencies = [
+ "crossbeam-utils 0.7.2",
+ "maybe-uninit",
+]
+
+[[package]]
+name = "crossbeam-channel"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dca26ee1f8d361640700bde38b2c37d8c22b3ce2d360e1fc1c74ea4b0aa7d775"
 dependencies = [
  "cfg-if 1.0.0",
- "crossbeam-utils",
+ "crossbeam-utils 0.8.0",
 ]
 
 [[package]]
@@ -180,7 +190,7 @@ checksum = "94af6efb46fef72616855b036a624cf27ba656ffc9be1b9a3c931cfc7749a9a9"
 dependencies = [
  "cfg-if 1.0.0",
  "crossbeam-epoch",
- "crossbeam-utils",
+ "crossbeam-utils 0.8.0",
 ]
 
 [[package]]
@@ -191,10 +201,21 @@ checksum = "ec0f606a85340376eef0d6d8fec399e6d4a544d648386c6645eb6d0653b27d9f"
 dependencies = [
  "cfg-if 1.0.0",
  "const_fn",
- "crossbeam-utils",
+ "crossbeam-utils 0.8.0",
  "lazy_static",
  "memoffset",
  "scopeguard",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3c7c73a2d1e9fc0886a08b93e98eb643461230d5f1925e4036204d5f2e261a8"
+dependencies = [
+ "autocfg",
+ "cfg-if 0.1.10",
+ "lazy_static",
 ]
 
 [[package]]
@@ -321,6 +342,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "maybe-uninit"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "60302e4db3a61da70c0cb7991976248362f30319e88850c487b9b95bbf059e00"
+
+[[package]]
 name = "memoffset"
 version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -408,6 +435,7 @@ dependencies = [
  "clap",
  "cloudflare-zlib",
  "crc",
+ "crossbeam-channel 0.4.4",
  "image",
  "indexmap",
  "itertools",
@@ -461,9 +489,9 @@ version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ab346ac5921dc62ffa9f89b7a773907511cdfa5490c572ae9be1be33e8afa4a"
 dependencies = [
- "crossbeam-channel",
+ "crossbeam-channel 0.5.0",
  "crossbeam-deque",
- "crossbeam-utils",
+ "crossbeam-utils 0.8.0",
  "lazy_static",
  "num_cpus",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,6 +40,7 @@ indexmap = "1.6.0"
 libdeflater = { version = "0.5.0", optional = true }
 log = "0.4.11"
 stderrlog = { version = "0.5.0", optional = true }
+crossbeam-channel = "0.4.4"
 
 [dependencies.rayon]
 optional = true

--- a/tests/flags.rs
+++ b/tests/flags.rs
@@ -118,6 +118,7 @@ fn verbose_mode() {
     #[cfg(feature = "rayon")]
     rayon::ThreadPoolBuilder::new()
         .start_handler(move |_| thread_init())
+        .num_threads(rayon::current_num_threads() + 1)
         .build()
         .unwrap()
         .install(move || rayon::spawn(thread_exec));

--- a/tests/flags.rs
+++ b/tests/flags.rs
@@ -55,9 +55,9 @@ fn test_it_converts(
 
 #[test]
 fn verbose_mode() {
+    use crossbeam_channel::{unbounded, Sender};
     use log::{set_logger, set_max_level, Level, LevelFilter, Log, Metadata, Record};
     use std::cell::RefCell;
-    use std::sync::mpsc::{sync_channel, SyncSender};
 
     // Rust runs tests in parallel by default.
     // We want to make sure that we verify only logs from our test.
@@ -66,7 +66,7 @@ fn verbose_mode() {
     // initialise it with Some(sender) only on threads spawned within
     // our test.
     thread_local! {
-        static VERBOSE_LOGS: RefCell<Option<SyncSender<String>>> = RefCell::new(None);
+        static VERBOSE_LOGS: RefCell<Option<Sender<String>>> = RefCell::new(None);
     }
 
     struct LogTester;
@@ -97,7 +97,7 @@ fn verbose_mode() {
     let input = PathBuf::from("tests/files/verbose_mode.png");
     let (output, opts) = get_opts(&input);
 
-    let (sender, receiver) = sync_channel(4);
+    let (sender, receiver) = unbounded();
 
     let thread_init = move || {
         // Initialise logs storage for all threads within our test.


### PR DESCRIPTION
So this PR might look a bit weird, but hopefully still acceptable. There are two things going on here:

1. A custom alternative to `std::thread::spawn` based on `rayon` + `crossbeam-channel`. See the comment on the function for motivation and more details, but TL;DR is that it makes possible to run OxiPNG with threads even on a Wasm target! (in engines that support Wasm threads). Working variant of Squoosh.app that makes use of this patch and runs OxiPNG+threads here: https://multithread--squoosh.netlify.app/editor
2. Since the part 1 requires `crossbeam-channel` anyway, I switched to it from `std::sync::mspc`, too, for the better performance as well as API improvements. For example, before this, evaluator had to use `sync_channel(4)` - a blocking synchronous channel with a magical constant maximum of 4 - because the async version of `std::sync::mpsc::Sender` can't be shared between threads (it doesn't implement `Sync` trait). However, with crossbeam it's not a problem, and it becomes possible to use asynchronous `unbounded` channel instead.