### PR TITLE
Make cloudflare-zlib dependency optional

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -59,7 +59,8 @@ default-features = false
 features = ["png"]
 version = "0.23"
 
-[target.'cfg(any(target_arch = "x86_64", target_arch = "aarch64"))'.dependencies.cloudflare-zlib]
+[dependencies.cloudflare-zlib]
+optional = true
 features = ["arm-always"]
 version = "^0.2.2"
 

--- a/src/deflate/mod.rs
+++ b/src/deflate/mod.rs
@@ -18,7 +18,7 @@ pub mod cfzlib;
 #[cfg(not(feature = "cloudflare-zlib"))]
 pub mod cfzlib {
     pub fn is_supported() -> bool {
-        return false;
+        false
     }
 }
 

--- a/src/deflate/mod.rs
+++ b/src/deflate/mod.rs
@@ -12,10 +12,10 @@ mod deflater;
 #[cfg(feature = "libdeflater")]
 pub use deflater::deflate as libdeflater_deflate;
 
-#[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
+#[cfg(feature = "cloudflare-zlib")]
 pub mod cfzlib;
 
-#[cfg(not(any(target_arch = "x86_64", target_arch = "aarch64")))]
+#[cfg(not(feature = "cloudflare-zlib"))]
 pub mod cfzlib {
     pub fn is_supported() -> bool {
         return false;
@@ -38,7 +38,7 @@ pub fn deflate(
     max_size: &AtomicMin,
     deadline: &Deadline,
 ) -> PngResult<Vec<u8>> {
-    #[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
+    #[cfg(feature = "cloudflare-zlib")]
     {
         if cfzlib::is_supported() {
             return cfzlib::cfzlib_deflate(data, zc, zs, zw, max_size, deadline);


### PR DESCRIPTION
Although the Cloudflare fork of zlib may introduce performance improvements, there are issues building it with MinGW toolchains on Windows, as evidenced by this [StackOverflow question](https://stackoverflow.com/questions/61170244/gcc-exe-fail-when-building-cloudflare-zlib-sys-rs).

However, it is not always possible to switch to the MSVC toolchain on Windows, because that may break other native C libraries which have trouble with MSVC instead, and just compiling to a 32-bit target can get pretty messy too.

[I've opened an issue](https://gitlab.com/kornelski/cloudflare-zlib-sys/-/issues/1) to get this error fixed upstream, in the cloudflare-zlib-sys crate, but several months have passed with no answer.

Therefore, make the Cloudflare zlib dependency optional, so users will have to explicitly opt in for it.