### PR TITLE
Avoid asserts panicking on broken files

### DIFF
--- a/src/filters.rs
+++ b/src/filters.rs
@@ -63,7 +63,7 @@ pub fn filter_line(filter: u8, bpp: usize, data: &[u8], last_line: &[u8], buf: &
 }
 
 pub fn unfilter_line(filter: u8, bpp: usize, data: &[u8], last_line: &[u8], buf: &mut Vec<u8>) {
-    assert_eq!(buf.len(), 0);
+    buf.clear();
     buf.reserve(data.len());
     match filter {
         0 => {

--- a/src/interlace.rs
+++ b/src/interlace.rs
@@ -5,7 +5,7 @@ use bit_vec::BitVec;
 #[must_use]
 pub fn interlace_image(png: &PngImage) -> PngImage {
     let mut passes: Vec<BitVec> = vec![BitVec::new(); 7];
-    let bits_per_pixel = png.ihdr.bit_depth.as_u8() * png.channels_per_pixel();
+    let bits_per_pixel = png.ihdr.bpp();
     for (index, line) in png.scan_lines().enumerate() {
         match index % 8 {
             // Add filter bytes to passes that will be in the output image
@@ -95,7 +95,7 @@ pub fn interlace_image(png: &PngImage) -> PngImage {
 }
 
 pub fn deinterlace_image(png: &PngImage) -> PngImage {
-    let bits_per_pixel = png.ihdr.bit_depth.as_u8() * png.channels_per_pixel();
+    let bits_per_pixel = png.ihdr.bpp();
     let bits_per_line = 8 + bits_per_pixel as usize * png.ihdr.width as usize;
     // Initialize each output line with a starting filter byte of 0
     // as well as some blank data

--- a/src/png/mod.rs
+++ b/src/png/mod.rs
@@ -118,6 +118,11 @@ impl PngData {
         let ihdr_header = parse_ihdr_header(&ihdr)?;
         let raw_data = deflate::inflate(idat_headers.as_ref())?;
 
+        // Reject files with incorrect width/height or truncated data
+        if raw_data.len() != ihdr_header.raw_data_size() {
+            return Err(PngError::TruncatedData);
+        }
+
         let (palette, transparency_pixel) = Self::palette_to_rgba(
             ihdr_header.color_type,
             aux_headers.remove(b"PLTE"),

--- a/src/png/mod.rs
+++ b/src/png/mod.rs
@@ -100,7 +100,7 @@ impl PngData {
         let mut idat_headers: Vec<u8> = Vec::new();
         while let Some(header) = parse_next_header(byte_data, &mut byte_offset, fix_errors)? {
             match &header.name {
-                b"IDAT" => idat_headers.extend(header.data),
+                b"IDAT" => idat_headers.extend_from_slice(header.data),
                 b"acTL" => return Err(PngError::APNGNotSupported),
                 _ => {
                     aux_headers.insert(header.name, header.data.to_owned());

--- a/src/png/scan_lines.rs
+++ b/src/png/scan_lines.rs
@@ -167,8 +167,7 @@ impl Iterator for ScanLineRanges {
         let bits_per_line = pixels_per_line * u32::from(self.bits_per_pixel);
         let bytes_per_line = ((bits_per_line + 7) / 8) as usize;
         let len = bytes_per_line + 1;
-        assert!(self.left >= len);
-        self.left -= len;
+        self.left = self.left.checked_sub(len)?;
         Some((len, current_pass))
     }
 }

--- a/src/reduction/alpha.rs
+++ b/src/reduction/alpha.rs
@@ -185,7 +185,9 @@ pub fn reduced_alpha_channel(png: &PngImage) -> Option<PngImage> {
     let channels = png.channels_per_pixel();
     let bpp = channels * byte_depth;
     let bpp_mask = bpp - 1;
-    assert_eq!(0, bpp & bpp_mask);
+    if 0 != bpp & bpp_mask {
+        return None;
+    }
     let colored_bytes = bpp - byte_depth;
     for line in png.scan_lines() {
         for (i, &byte) in line.data.iter().enumerate() {

--- a/src/reduction/color.rs
+++ b/src/reduction/color.rs
@@ -111,6 +111,7 @@ pub fn reduced_color_to_palette(png: &PngImage) -> Option<PngImage> {
     let transparency_pixel = png
         .transparency_pixel
         .as_ref()
+        .filter(|t| png.ihdr.color_type == ColorType::RGB && t.len() >= 6)
         .map(|t| RGB8::new(t[1], t[3], t[5]));
     for line in png.scan_lines() {
         raw_data.push(line.filter);

--- a/src/reduction/color.rs
+++ b/src/reduction/color.rs
@@ -12,7 +12,9 @@ pub fn reduce_rgba_to_grayscale_alpha(png: &PngImage) -> Option<PngImage> {
     let byte_depth = png.ihdr.bit_depth.as_u8() >> 3;
     let bpp = 4 * byte_depth;
     let bpp_mask = bpp - 1;
-    assert_eq!(0, bpp & bpp_mask);
+    if 0 != bpp & bpp_mask {
+        return None;
+    }
     let colored_bytes = bpp - byte_depth;
     for line in png.scan_lines() {
         reduced.push(line.filter);
@@ -157,7 +159,10 @@ pub fn reduced_color_to_palette(png: &PngImage) -> Option<PngImage> {
 
     let mut aux_headers = png.aux_headers.clone();
     if let Some(bkgd_header) = png.aux_headers.get(b"bKGD") {
-        assert_eq!(bkgd_header.len(), 6);
+        if bkgd_header.len() != 6 {
+            // malformed chunk?
+            return None;
+        }
         // In bKGD 16-bit values are used even for 8-bit images
         let bg = RGBA8::new(bkgd_header[1], bkgd_header[3], bkgd_header[5], 255);
         let entry = if let Some(&entry) = palette.get(&bg) {


### PR DESCRIPTION
This rejects malformed files gracefully instead of panicking in random places.