### PR TITLE
apply_preset_5 and apply_preset_6 to set correct compression levels.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -263,7 +263,7 @@ impl Options {
     fn apply_preset_5(mut self) -> Self {
         if let Deflaters::Zlib { compression, .. } = &mut self.deflate {
             compression.clear();
-            for i in 3..9 {
+            for i in 3..10 {
                 compression.insert(i);
             }
         }
@@ -273,11 +273,11 @@ impl Options {
     fn apply_preset_6(mut self) -> Self {
         if let Deflaters::Zlib { compression, .. } = &mut self.deflate {
             compression.clear();
-            for i in 1..3 {
+            for i in 1..10 {
                 compression.insert(i);
             }
         }
-        self.apply_preset_5()
+        self.apply_preset_4()
     }
 }
 


### PR DESCRIPTION
The for loop in apply_preset_5 was not including 9.
apply_preset_6 now builds now calls apply_preset_4 instead of
apply_preset_5, and adds all compression levels from 1 to 9.

I have not written unit tests for this, yet.

fix #424 