### PR TITLE
Add check option

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -131,6 +131,10 @@ pub struct Options {
     ///
     /// Default: `false`
     pub fix_errors: bool,
+    /// Don't actually run any optimizations, just parse the PNG file.
+    ///
+    /// Default: `false`
+    pub check: bool,
     /// Don't actually write any output, just calculate the best results.
     ///
     /// Default: `false`
@@ -299,6 +303,7 @@ impl Default for Options {
 
         Options {
             backup: false,
+            check: false,
             pretend: false,
             fix_errors: false,
             force: false,
@@ -362,6 +367,11 @@ pub fn optimize(input: &InFile, output: &OutFile, opts: &Options) -> PngResult<(
     };
 
     let mut png = PngData::from_slice(&in_data, opts.fix_errors)?;
+
+    if opts.check {
+        info!("Running in check mode, not optimizing");
+        return Ok(());
+    }
 
     // Run the optimizer on the decoded PNG.
     let mut optimized_output = optimize_png(&mut png, &in_data, opts, deadline)?;

--- a/src/main.rs
+++ b/src/main.rs
@@ -83,6 +83,10 @@ fn main() {
             .help("Preserve file attributes if possible")
             .short('p')
             .long("preserve"))
+        .arg(Arg::new("check")
+            .help("Do not run any optimization passes")
+            .short('c')
+            .long("check"))
         .arg(Arg::new("pretend")
             .help("Do not write any files, only calculate compression gains")
             .short('P')
@@ -413,6 +417,10 @@ fn parse_opts_into_struct(
 
     if matches.is_present("fix") {
         opts.fix_errors = true;
+    }
+
+    if matches.is_present("check") {
+        opts.check = true;
     }
 
     if matches.is_present("pretend") {


### PR DESCRIPTION
This allows users to make sure Oxipng can parse a PNG file before commiting to an optimization.