### PR TITLE
Update stderrlog dependency to v0.5.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -506,9 +506,9 @@ checksum = "a4a3381e03edd24287172047536f20cabde766e2cd3e65e6b00fb3af51c4f38d"
 
 [[package]]
 name = "stderrlog"
-version = "0.5.1"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "45a53e2eff3e94a019afa6265e8ee04cb05b9d33fe9f5078b14e4e391d155a38"
+checksum = "5b81364c25bf70a0f9beae4ae704d466bf37e704e887ebac89eb9a28d01d491f"
 dependencies = [
  "atty",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,7 @@ rgb = "0.8.25"
 indexmap = "1.6.1"
 libdeflater = { version = "0.8.0", optional = true }
 log = "0.4.14"
-stderrlog = { version = "0.5.1", optional = true }
+stderrlog = { version = "0.5.2", optional = true }
 crossbeam-channel = "0.5.0"
 
 [dependencies.filetime]


### PR DESCRIPTION
Oxipng has an optional dependency on [stderrlog](https://github.com/cardoe/stderrlog-rs), which itself has a dependency on [thread_local](https://github.com/Amanieu/thread_local-rs/issues/33). Versions of thread_local < 1.1.4 have a [vulnerability caused by a data race in `Iter` and `IterMut`](https://rustsec.org/advisories/RUSTSEC-2022-0006.html). Updating to stderrlog v0.5.1 means that Oxipng will use a patched version of thread_local.
