### PR TITLE
Fix #449 by bumping dependencies. Update changelog and prepare for 6.0.1 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-### Next
+### Version 6.0.1
 
 - [Bugfix] Fix an issue where Zopfli mode could generate corrupt images
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+### Next
+
+- [Bugfix] Fix an issue where Zopfli mode could generate corrupt images
+
 ### Version 6.0.0
 
 - [Breaking] Bump minimum Rust version to 1.57.0

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -185,15 +185,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "deflate"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c86f7e25f518f4b81808a2cf1c50996a61f5c2eb394b2393bd87f2a4780a432f"
-dependencies = [
- "adler32",
-]
-
-[[package]]
 name = "either"
 version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -209,6 +200,16 @@ dependencies = [
  "libc",
  "redox_syscall",
  "windows-sys",
+]
+
+[[package]]
+name = "flate2"
+version = "1.0.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f82b0f4c27ad9f8bfd1f3208d882da2b09c301bc1c828fd3a00d0216d2fbbff6"
+dependencies = [
+ "crc32fast",
+ "miniz_oxide 0.5.4",
 ]
 
 [[package]]
@@ -410,13 +411,13 @@ dependencies = [
 
 [[package]]
 name = "png"
-version = "0.17.5"
+version = "0.17.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc38c0ad57efb786dd57b9864e5b18bae478c00c824dc55a38bbc9da95dde3ba"
+checksum = "8f0e7f4c94ec26ff209cee506314212639d6c91b80afb82984819fafce9df01c"
 dependencies = [
  "bitflags",
  "crc32fast",
- "deflate",
+ "flate2",
  "miniz_oxide 0.5.4",
 ]
 
@@ -616,9 +617,9 @@ checksum = "c811ca4a8c853ef420abd8592ba53ddbbac90410fab6903b3e79972a631f7680"
 
 [[package]]
 name = "zopfli"
-version = "0.7.0"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4f3cae89ab7952cf7f091fffda70f373ba3ee110ac6221b3b6c3c285b04f82e"
+checksum = "f1e0d16c30236860686a8f03d36b384dc2fc0675a8916367d2f9a1ecd795eab6"
 dependencies = [
  "adler32",
  "byteorder",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ required-features = ["binary"]
 bit-vec = "0.6.3"
 crc = "3.0.0"
 itertools = "0.10.3"
-zopfli = { version = "0.7.0", optional = true }
+zopfli = { version = "0.7.1", optional = true }
 miniz_oxide = "0.6.2"
 rgb = "0.8.33"
 indexmap = "1.9.1"
@@ -45,7 +45,7 @@ version = "1.5.3"
 
 [dependencies.clap]
 optional = true
-version = "3.2.17"
+version = "3.2.20"
 
 [dependencies.wild]
 optional = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ homepage = "https://github.com/shssoichiro/oxipng"
 license = "MIT"
 name = "oxipng"
 repository = "https://github.com/shssoichiro/oxipng"
-version = "6.0.0"
+version = "6.0.1"
 rust-version = "1.57.0"
 
 [badges]


### PR DESCRIPTION
The 0.7.0 version of the `zopfli` crate has a regression that could cause invalid DEFLATE streams to be generated. The cause of that regression has been identified and corrected, and the fix was tested. A new patch version of that crate was published with the fix.

OxiPNG needs that fix to generate proper PNGs when the Zopfli mode is enabled, so let's update dependencies again. I've modified the changelog and bumped the OxiPNG version to 6.0.1 to make it as easy to deploy as possible :tada:

Fixes #449.