### PR TITLE
Avoid printing output bytes on decompress error

### DIFF
--- a/src/deflate/mod.rs
+++ b/src/deflate/mod.rs
@@ -27,8 +27,13 @@ pub mod cfzlib {
 
 /// Decompress a data stream using the DEFLATE algorithm
 pub fn inflate(data: &[u8]) -> PngResult<Vec<u8>> {
-    miniz_oxide::inflate::decompress_to_vec_zlib(data)
-        .map_err(|e| PngError::new(&format!("Error on decompress: {:?}", e)))
+    miniz_oxide::inflate::decompress_to_vec_zlib(data).map_err(|e| {
+        PngError::new(&format!(
+            "Error on decompress: {:?} (after {:?} decompressed bytes)",
+            e.status,
+            e.output.len()
+        ))
+    })
 }
 
 /// Compress a data stream using the DEFLATE algorithm


### PR DESCRIPTION
Hi, this is (one of many) ways to fix #452.

This seemed the least intrusive as we can't specifically override the Display/Debug implementations without creating our own type and mapping to it first.

Also, I chose to preserve part of the "decompressed so far" information, but just the byte count since it's mostly interesting in special cases (0, 1, some power of 2, etc).

Unfortunately, this means that one does lose information like a non-specific number of bytes all being 0 for example. I'm not sure how to reconcile that without making more intrusive changes (returning a struct rather than a formatted string, and handling the formatting somewhere with access to the current verbosity level perhaps).