### PR TITLE
Allow setting libdeflate compression level

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -281,18 +281,18 @@ checksum = "8371e4e5341c3a96db127eb2465ac681ced4c433e01dd0e938adbef26ba93ba5"
 
 [[package]]
 name = "libdeflate-sys"
-version = "0.10.0"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43afa5b192ff058426ba20a4f35c290ef402478d6045ac934ac15aa947a3898d"
+checksum = "cb6784b6b84b67d71b4307963d456a9c7c29f9b47c658f533e598de369e34277"
 dependencies = [
  "cc",
 ]
 
 [[package]]
 name = "libdeflater"
-version = "0.10.0"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e656b7960ec49e864badc7ad1b810427a7ac8b78511a699ce5cdc3ead0b32e5b"
+checksum = "d8e285aa6a046fd338b2592c16bee148b2b00789138ed6b7bb56bb13d585050d"
 dependencies = [
  "libdeflate-sys",
 ]
@@ -387,7 +387,7 @@ checksum = "9ff7415e9ae3fff1225851df9e0d9e4e5479f947619774677a63572e55e80eff"
 
 [[package]]
 name = "oxipng"
-version = "6.0.0"
+version = "6.0.1"
 dependencies = [
  "bit-vec",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,7 @@ zopfli = { version = "0.7.1", optional = true }
 miniz_oxide = "0.6.2"
 rgb = "0.8.33"
 indexmap = "1.9.1"
-libdeflater = { version = "0.10.0", optional = true }
+libdeflater = { version = "0.11.0", optional = true }
 log = "0.4.17"
 stderrlog = { version = "0.5.3", optional = true, default-features = false }
 crossbeam-channel = "0.5.6"

--- a/benches/libdeflater.rs
+++ b/benches/libdeflater.rs
@@ -13,7 +13,7 @@ fn libdeflater_16_bits_strategy_0(b: &mut Bencher) {
     let png = PngData::new(&input, false).unwrap();
 
     b.iter(|| {
-        libdeflater_deflate(png.raw.data.as_ref(), &AtomicMin::new(None)).ok();
+        libdeflater_deflate(png.raw.data.as_ref(), 12, &AtomicMin::new(None)).ok();
     });
 }
 
@@ -23,7 +23,7 @@ fn libdeflater_8_bits_strategy_0(b: &mut Bencher) {
     let png = PngData::new(&input, false).unwrap();
 
     b.iter(|| {
-        libdeflater_deflate(png.raw.data.as_ref(), &AtomicMin::new(None)).ok();
+        libdeflater_deflate(png.raw.data.as_ref(), 12, &AtomicMin::new(None)).ok();
     });
 }
 
@@ -35,7 +35,7 @@ fn libdeflater_4_bits_strategy_0(b: &mut Bencher) {
     let png = PngData::new(&input, false).unwrap();
 
     b.iter(|| {
-        libdeflater_deflate(png.raw.data.as_ref(), &AtomicMin::new(None)).ok();
+        libdeflater_deflate(png.raw.data.as_ref(), 12, &AtomicMin::new(None)).ok();
     });
 }
 
@@ -47,7 +47,7 @@ fn libdeflater_2_bits_strategy_0(b: &mut Bencher) {
     let png = PngData::new(&input, false).unwrap();
 
     b.iter(|| {
-        libdeflater_deflate(png.raw.data.as_ref(), &AtomicMin::new(None)).ok();
+        libdeflater_deflate(png.raw.data.as_ref(), 12, &AtomicMin::new(None)).ok();
     });
 }
 
@@ -59,6 +59,6 @@ fn libdeflater_1_bits_strategy_0(b: &mut Bencher) {
     let png = PngData::new(&input, false).unwrap();
 
     b.iter(|| {
-        libdeflater_deflate(png.raw.data.as_ref(), &AtomicMin::new(None)).ok();
+        libdeflater_deflate(png.raw.data.as_ref(), 12, &AtomicMin::new(None)).ok();
     });
 }

--- a/src/deflate/deflater.rs
+++ b/src/deflate/deflater.rs
@@ -2,8 +2,8 @@ use crate::atomicmin::AtomicMin;
 use crate::{PngError, PngResult};
 use libdeflater::{CompressionError, CompressionLvl, Compressor};
 
-pub fn deflate(data: &[u8], max_size: &AtomicMin) -> PngResult<Vec<u8>> {
-    let mut compressor = Compressor::new(CompressionLvl::best());
+pub fn deflate(data: &[u8], level: u8, max_size: &AtomicMin) -> PngResult<Vec<u8>> {
+    let mut compressor = Compressor::new(CompressionLvl::new(level.into()).unwrap());
     let capacity = max_size.get().unwrap_or(data.len() / 2);
     let mut dest = vec![0; capacity];
     let len = compressor

--- a/src/deflate/mod.rs
+++ b/src/deflate/mod.rs
@@ -104,5 +104,8 @@ pub enum Deflaters {
     },
     #[cfg(feature = "libdeflater")]
     /// Use libdeflater.
-    Libdeflater,
+    Libdeflater {
+        /// Which compression levels to try on the file (1-12)
+        compression: IndexSet<u8>,
+    },
 }

--- a/tests/flags.rs
+++ b/tests/flags.rs
@@ -603,7 +603,9 @@ fn zopfli_mode() {
 fn libdeflater_mode() {
     let input = PathBuf::from("tests/files/zopfli_mode.png");
     let (output, mut opts) = get_opts(&input);
-    opts.deflate = Deflaters::Libdeflater;
+    let mut compression = IndexSet::new();
+    compression.insert(0);
+    opts.deflate = Deflaters::Libdeflater { compression };
 
     test_it_converts(
         input,


### PR DESCRIPTION
This PR enables the `--zc` option with range 1-12 when using libdeflater (`-D`). When `-D` is specified without `--zc`, the level will default to 12 (the same level it was fixed to previously).
Libdeflater is also updated to v0.11.0.

Additionally this fixes a minor issue where a non-optimal result may be achieved with libdeflate due to lack of slack space (see [libdeflate.h#L92](https://github.com/ebiggers/libdeflate/blob/7eb94ca1fa8c72663938d0fa05427e8f68c0cc87/libdeflate.h#L92)).

Thoughts on implementation:
It may be better to make the level an optional value for the `-D` argument rather than reusing `--zc`, since they have different ranges and the levels in the presets currently only apply to zlib.

Thoughts for future:
Libdeflater can outclass zlib in both speed and ratio. It might be nice to just remove zlib and make libdeflater the default.

Closes #454.
