### PR TITLE
Fix level 0

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -237,7 +237,7 @@ impl Options {
             compression.clear();
             compression.insert(3);
         }
-        self
+        self.apply_preset_1()
     }
 
     fn apply_preset_1(mut self) -> Self {


### PR DESCRIPTION
Preset level 0 was previously using the default (preset 2) filters and strategies, instead of what it says in the help. This PR fixes it by extending from preset 1.