### PR TITLE
Fix directional alpha reductions

### DIFF
--- a/src/reduction/alpha.rs
+++ b/src/reduction/alpha.rs
@@ -108,7 +108,7 @@ fn reduced_alpha_to_up(png: &PngImage, bpc: usize, bpp: usize) -> Vec<u8> {
                 current_line.extend_from_slice(pixel);
             }
         }
-        last_line = current_line.clone();
+        last_line = current_line[1..current_line.len()].to_vec();
         lines.push(current_line.clone());
         current_line.clear();
     }
@@ -118,6 +118,7 @@ fn reduced_alpha_to_up(png: &PngImage, bpc: usize, bpp: usize) -> Vec<u8> {
 fn reduced_alpha_to_down(png: &PngImage, bpc: usize, bpp: usize) -> Vec<u8> {
     let mut reduced = Vec::with_capacity(png.data.len());
     let mut last_line = Vec::new();
+    let mut pos = 0;
     for line in png.scan_lines() {
         if line.data.len() != last_line.len() {
             last_line = vec![0; line.data.len()];
@@ -131,7 +132,8 @@ fn reduced_alpha_to_down(png: &PngImage, bpc: usize, bpp: usize) -> Vec<u8> {
                 reduced.extend_from_slice(pixel);
             }
         }
-        last_line = reduced.clone();
+        last_line = reduced[(pos + 1)..reduced.len()].to_vec();
+        pos = reduced.len();
     }
     reduced
 }

--- a/src/reduction/alpha.rs
+++ b/src/reduction/alpha.rs
@@ -149,8 +149,8 @@ fn reduced_alpha_to_left(png: &PngImage, bpc: usize, bpp: usize) -> Vec<u8> {
                 line_bytes.resize(line_bytes.len() + bpc, 0);
             } else {
                 line_bytes.extend_from_slice(pixel);
+                last_pixel = pixel.to_owned();
             }
-            last_pixel = pixel.to_owned();
         }
         reduced.push(line.filter);
         reduced.extend(line_bytes.chunks(bpp).rev().flatten());
@@ -169,8 +169,8 @@ fn reduced_alpha_to_right(png: &PngImage, bpc: usize, bpp: usize) -> Vec<u8> {
                 reduced.resize(reduced.len() + bpc, 0);
             } else {
                 reduced.extend_from_slice(pixel);
+                last_pixel = pixel.to_owned();
             }
-            last_pixel = pixel.to_owned();
         }
     }
     reduced


### PR DESCRIPTION
The alpha up and down modes were not working correctly, producing the same output as alpha black. This was also causing a nasty performance issue with alpha down.
I've fixed both of these modes and tested on one of the included files:
`oxipng -o0 -a issue-133.png`
| branch | IDAT size | Time |
|-|-|-|
| master | 1076430 | 56.1s |
| alphafixes | 1030377 | 3.6s |

The left and right alphas were also not giving the expected result, only extending pixels once due to incorrect tracking of the `last_pixel`.

It would probably be good to add tests for these, though I'm not sure how you would do that.

Thoughts for further improvements: A typical method for alpha optimisation is to "smear" in all directions at once, which can give a more compressible result. An example of this can be seen if you remove the alpha from the bear picture in the rgba test files:
![rgba_8_reduce_alpha_black](https://user-images.githubusercontent.com/4584038/198746883-bb262e5b-1689-4ac7-941e-258fa096a518.png)
