### PR TITLE
Strengthen alpha reductions

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -421,9 +421,7 @@ fn parse_opts_into_struct(
         opts.alphas.insert(AlphaOptim::Black);
         opts.alphas.insert(AlphaOptim::White);
         opts.alphas.insert(AlphaOptim::Up);
-        opts.alphas.insert(AlphaOptim::Down);
         opts.alphas.insert(AlphaOptim::Left);
-        opts.alphas.insert(AlphaOptim::Right);
     }
 
     if matches.is_present("backup") {

--- a/src/reduction/alpha.rs
+++ b/src/reduction/alpha.rs
@@ -117,8 +117,8 @@ fn reduced_alpha_to_up(png: &PngImage, bpc: usize, bpp: usize) -> Vec<u8> {
                         reduced[offset..(offset + bpp - bpc)]
                             .copy_from_slice(&pixel[..(bpp - bpc)]);
                     }
-                    transparent[col] = 0;
                 }
+                transparent[col] = i32::MIN; // Prevent copying upwards again
                 reduced.extend_from_slice(pixel);
                 line_transparent = false;
             }


### PR DESCRIPTION
In an attempt to combine the best alpha reductions together I've made improved replacements for the 'up' and 'left' methods. These will now also fill in the opposite direction to complete the line/column. The 'up' method additionally blanks out empty rows.
Overall it's a fairly minor improvement (0.5% for some images), but as these are almost always stronger than the down/right methods as well, we can turn those ones off by default for a small but helpful speed boost (4 reductions x2 filters is more likely to fit within your thread count).

Normal image:
![dots](https://user-images.githubusercontent.com/4584038/198912066-fc0fe8fe-70ae-4f53-8f9f-944356ccd340.png)
'Up' method with transparency removed:
![dots-up](https://user-images.githubusercontent.com/4584038/198912068-0104e0c8-5c70-4f55-9d1a-df2e94e9de84.png)
'Left' method with transparency removed:
![dots-left](https://user-images.githubusercontent.com/4584038/198912073-e8299c9d-ee37-4a1e-aa99-84e0caf4a517.png)
