### PR TITLE
New filter strategies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -32,12 +32,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
-name = "bit-vec"
-version = "0.6.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "349f9b6a179ed607305526ca489b34ad0a41aed5f7980fa90eb03160b69598fb"
-
-[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -380,7 +374,6 @@ checksum = "9ff7415e9ae3fff1225851df9e0d9e4e5479f947619774677a63572e55e80eff"
 name = "oxipng"
 version = "6.0.1"
 dependencies = [
- "bit-vec",
  "bitvec",
  "clap",
  "crossbeam-channel",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -44,6 +44,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
+name = "bitvec"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bc2832c24239b0141d5674bb9174f9d68a8b5b3f2753311927c172ca46f7e9c"
+dependencies = [
+ "funty",
+ "radium",
+ "tap",
+ "wyz",
+]
+
+[[package]]
 name = "bytemuck"
 version = "1.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -193,6 +205,12 @@ dependencies = [
  "crc32fast",
  "miniz_oxide",
 ]
+
+[[package]]
+name = "funty"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
 
 [[package]]
 name = "glob"
@@ -363,6 +381,7 @@ name = "oxipng"
 version = "6.0.1"
 dependencies = [
  "bit-vec",
+ "bitvec",
  "clap",
  "crossbeam-channel",
  "filetime",
@@ -390,6 +409,12 @@ dependencies = [
  "flate2",
  "miniz_oxide",
 ]
+
+[[package]]
+name = "radium"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09"
 
 [[package]]
 name = "rayon"
@@ -471,6 +496,12 @@ name = "strsim"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
+
+[[package]]
+name = "tap"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
 name = "termcolor"
@@ -584,6 +615,15 @@ name = "windows_x86_64_msvc"
 version = "0.36.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c811ca4a8c853ef420abd8592ba53ddbbac90410fab6903b3e79972a631f7680"
+
+[[package]]
+name = "wyz"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30b31594f29d27036c383b53b59ed3476874d518f0efb151b27a4c275141390e"
+dependencies = [
+ "tap",
+]
 
 [[package]]
 name = "zopfli"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -392,6 +392,7 @@ dependencies = [
  "log",
  "rayon",
  "rgb",
+ "rustc-hash",
  "rustc_version",
  "stderrlog",
  "wild",
@@ -457,6 +458,12 @@ checksum = "c3b221de559e4a29df3b957eec92bc0de6bc8eaf6ca9cfed43e5e1d67ff65a34"
 dependencies = [
  "bytemuck",
 ]
+
+[[package]]
+name = "rustc-hash"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 
 [[package]]
 name = "rustc_version"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,6 +33,7 @@ log = "0.4.17"
 stderrlog = { version = "0.5.3", optional = true, default-features = false }
 crossbeam-channel = "0.5.6"
 bitvec = "1.0.1"
+rustc-hash = "1.1.0"
 
 [dependencies.filetime]
 optional = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,6 @@ path = "src/main.rs"
 required-features = ["binary"]
 
 [dependencies]
-bit-vec = "0.6.3"
 itertools = "0.10.3"
 zopfli = { version = "0.7.1", optional = true }
 rgb = "0.8.33"
@@ -75,5 +74,5 @@ opt-level = 2
 [profile.release]
 lto = "thin"
 
-[profile.dev.package.bit-vec]
+[profile.dev.package.bitvec]
 opt-level = 3

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,6 +32,7 @@ libdeflater = "0.11.0"
 log = "0.4.17"
 stderrlog = { version = "0.5.3", optional = true, default-features = false }
 crossbeam-channel = "0.5.6"
+bitvec = "1.0.1"
 
 [dependencies.filetime]
 optional = true

--- a/benches/filters.rs
+++ b/benches/filters.rs
@@ -3,7 +3,7 @@
 extern crate oxipng;
 extern crate test;
 
-use oxipng::internal_tests::*;
+use oxipng::{internal_tests::*, RowFilter};
 use std::path::PathBuf;
 use test::Bencher;
 
@@ -13,7 +13,7 @@ fn filters_16_bits_filter_0(b: &mut Bencher) {
     let png = PngData::new(&input, false).unwrap();
 
     b.iter(|| {
-        png.raw.filter_image(0);
+        png.raw.filter_image(RowFilter::None);
     });
 }
 
@@ -23,7 +23,7 @@ fn filters_8_bits_filter_0(b: &mut Bencher) {
     let png = PngData::new(&input, false).unwrap();
 
     b.iter(|| {
-        png.raw.filter_image(0);
+        png.raw.filter_image(RowFilter::None);
     });
 }
 
@@ -35,7 +35,7 @@ fn filters_4_bits_filter_0(b: &mut Bencher) {
     let png = PngData::new(&input, false).unwrap();
 
     b.iter(|| {
-        png.raw.filter_image(0);
+        png.raw.filter_image(RowFilter::None);
     });
 }
 
@@ -47,7 +47,7 @@ fn filters_2_bits_filter_0(b: &mut Bencher) {
     let png = PngData::new(&input, false).unwrap();
 
     b.iter(|| {
-        png.raw.filter_image(0);
+        png.raw.filter_image(RowFilter::None);
     });
 }
 
@@ -59,7 +59,7 @@ fn filters_1_bits_filter_0(b: &mut Bencher) {
     let png = PngData::new(&input, false).unwrap();
 
     b.iter(|| {
-        png.raw.filter_image(0);
+        png.raw.filter_image(RowFilter::None);
     });
 }
 
@@ -69,7 +69,7 @@ fn filters_16_bits_filter_1(b: &mut Bencher) {
     let png = PngData::new(&input, false).unwrap();
 
     b.iter(|| {
-        png.raw.filter_image(1);
+        png.raw.filter_image(RowFilter::Sub);
     });
 }
 
@@ -79,7 +79,7 @@ fn filters_8_bits_filter_1(b: &mut Bencher) {
     let png = PngData::new(&input, false).unwrap();
 
     b.iter(|| {
-        png.raw.filter_image(1);
+        png.raw.filter_image(RowFilter::Sub);
     });
 }
 
@@ -91,7 +91,7 @@ fn filters_4_bits_filter_1(b: &mut Bencher) {
     let png = PngData::new(&input, false).unwrap();
 
     b.iter(|| {
-        png.raw.filter_image(1);
+        png.raw.filter_image(RowFilter::Sub);
     });
 }
 
@@ -103,7 +103,7 @@ fn filters_2_bits_filter_1(b: &mut Bencher) {
     let png = PngData::new(&input, false).unwrap();
 
     b.iter(|| {
-        png.raw.filter_image(1);
+        png.raw.filter_image(RowFilter::Sub);
     });
 }
 
@@ -115,7 +115,7 @@ fn filters_1_bits_filter_1(b: &mut Bencher) {
     let png = PngData::new(&input, false).unwrap();
 
     b.iter(|| {
-        png.raw.filter_image(1);
+        png.raw.filter_image(RowFilter::Sub);
     });
 }
 
@@ -125,7 +125,7 @@ fn filters_16_bits_filter_2(b: &mut Bencher) {
     let png = PngData::new(&input, false).unwrap();
 
     b.iter(|| {
-        png.raw.filter_image(2);
+        png.raw.filter_image(RowFilter::Up);
     });
 }
 
@@ -135,7 +135,7 @@ fn filters_8_bits_filter_2(b: &mut Bencher) {
     let png = PngData::new(&input, false).unwrap();
 
     b.iter(|| {
-        png.raw.filter_image(2);
+        png.raw.filter_image(RowFilter::Up);
     });
 }
 
@@ -147,7 +147,7 @@ fn filters_4_bits_filter_2(b: &mut Bencher) {
     let png = PngData::new(&input, false).unwrap();
 
     b.iter(|| {
-        png.raw.filter_image(2);
+        png.raw.filter_image(RowFilter::Up);
     });
 }
 
@@ -159,7 +159,7 @@ fn filters_2_bits_filter_2(b: &mut Bencher) {
     let png = PngData::new(&input, false).unwrap();
 
     b.iter(|| {
-        png.raw.filter_image(2);
+        png.raw.filter_image(RowFilter::Up);
     });
 }
 
@@ -171,7 +171,7 @@ fn filters_1_bits_filter_2(b: &mut Bencher) {
     let png = PngData::new(&input, false).unwrap();
 
     b.iter(|| {
-        png.raw.filter_image(2);
+        png.raw.filter_image(RowFilter::Up);
     });
 }
 
@@ -181,7 +181,7 @@ fn filters_16_bits_filter_3(b: &mut Bencher) {
     let png = PngData::new(&input, false).unwrap();
 
     b.iter(|| {
-        png.raw.filter_image(3);
+        png.raw.filter_image(RowFilter::Average);
     });
 }
 
@@ -191,7 +191,7 @@ fn filters_8_bits_filter_3(b: &mut Bencher) {
     let png = PngData::new(&input, false).unwrap();
 
     b.iter(|| {
-        png.raw.filter_image(3);
+        png.raw.filter_image(RowFilter::Average);
     });
 }
 
@@ -203,7 +203,7 @@ fn filters_4_bits_filter_3(b: &mut Bencher) {
     let png = PngData::new(&input, false).unwrap();
 
     b.iter(|| {
-        png.raw.filter_image(3);
+        png.raw.filter_image(RowFilter::Average);
     });
 }
 
@@ -215,7 +215,7 @@ fn filters_2_bits_filter_3(b: &mut Bencher) {
     let png = PngData::new(&input, false).unwrap();
 
     b.iter(|| {
-        png.raw.filter_image(3);
+        png.raw.filter_image(RowFilter::Average);
     });
 }
 
@@ -227,7 +227,7 @@ fn filters_1_bits_filter_3(b: &mut Bencher) {
     let png = PngData::new(&input, false).unwrap();
 
     b.iter(|| {
-        png.raw.filter_image(3);
+        png.raw.filter_image(RowFilter::Average);
     });
 }
 
@@ -237,7 +237,7 @@ fn filters_16_bits_filter_4(b: &mut Bencher) {
     let png = PngData::new(&input, false).unwrap();
 
     b.iter(|| {
-        png.raw.filter_image(4);
+        png.raw.filter_image(RowFilter::Paeth);
     });
 }
 
@@ -247,7 +247,7 @@ fn filters_8_bits_filter_4(b: &mut Bencher) {
     let png = PngData::new(&input, false).unwrap();
 
     b.iter(|| {
-        png.raw.filter_image(4);
+        png.raw.filter_image(RowFilter::Paeth);
     });
 }
 
@@ -259,7 +259,7 @@ fn filters_4_bits_filter_4(b: &mut Bencher) {
     let png = PngData::new(&input, false).unwrap();
 
     b.iter(|| {
-        png.raw.filter_image(4);
+        png.raw.filter_image(RowFilter::Paeth);
     });
 }
 
@@ -271,7 +271,7 @@ fn filters_2_bits_filter_4(b: &mut Bencher) {
     let png = PngData::new(&input, false).unwrap();
 
     b.iter(|| {
-        png.raw.filter_image(4);
+        png.raw.filter_image(RowFilter::Paeth);
     });
 }
 
@@ -283,7 +283,7 @@ fn filters_1_bits_filter_4(b: &mut Bencher) {
     let png = PngData::new(&input, false).unwrap();
 
     b.iter(|| {
-        png.raw.filter_image(4);
+        png.raw.filter_image(RowFilter::Paeth);
     });
 }
 
@@ -293,7 +293,7 @@ fn filters_16_bits_filter_5(b: &mut Bencher) {
     let png = PngData::new(&input, false).unwrap();
 
     b.iter(|| {
-        png.raw.filter_image(5);
+        png.raw.filter_image(RowFilter::MinSum);
     });
 }
 
@@ -303,7 +303,7 @@ fn filters_8_bits_filter_5(b: &mut Bencher) {
     let png = PngData::new(&input, false).unwrap();
 
     b.iter(|| {
-        png.raw.filter_image(5);
+        png.raw.filter_image(RowFilter::MinSum);
     });
 }
 
@@ -315,7 +315,7 @@ fn filters_4_bits_filter_5(b: &mut Bencher) {
     let png = PngData::new(&input, false).unwrap();
 
     b.iter(|| {
-        png.raw.filter_image(5);
+        png.raw.filter_image(RowFilter::MinSum);
     });
 }
 
@@ -327,7 +327,7 @@ fn filters_2_bits_filter_5(b: &mut Bencher) {
     let png = PngData::new(&input, false).unwrap();
 
     b.iter(|| {
-        png.raw.filter_image(5);
+        png.raw.filter_image(RowFilter::MinSum);
     });
 }
 
@@ -339,6 +339,6 @@ fn filters_1_bits_filter_5(b: &mut Bencher) {
     let png = PngData::new(&input, false).unwrap();
 
     b.iter(|| {
-        png.raw.filter_image(5);
+        png.raw.filter_image(RowFilter::MinSum);
     });
 }

--- a/benches/strategies.rs
+++ b/benches/strategies.rs
@@ -1,0 +1,58 @@
+#![feature(test)]
+
+extern crate oxipng;
+extern crate test;
+
+use oxipng::{internal_tests::*, RowFilter};
+use std::path::PathBuf;
+use test::Bencher;
+
+#[bench]
+fn filters_minsum(b: &mut Bencher) {
+    let input = test::black_box(PathBuf::from("tests/files/rgb_8_should_be_rgb_8.png"));
+    let png = PngData::new(&input, false).unwrap();
+
+    b.iter(|| {
+        png.raw.filter_image(RowFilter::MinSum);
+    });
+}
+
+#[bench]
+fn filters_entropy(b: &mut Bencher) {
+    let input = test::black_box(PathBuf::from("tests/files/rgb_8_should_be_rgb_8.png"));
+    let png = PngData::new(&input, false).unwrap();
+
+    b.iter(|| {
+        png.raw.filter_image(RowFilter::Entropy);
+    });
+}
+
+#[bench]
+fn filters_bigrams(b: &mut Bencher) {
+    let input = test::black_box(PathBuf::from("tests/files/rgb_8_should_be_rgb_8.png"));
+    let png = PngData::new(&input, false).unwrap();
+
+    b.iter(|| {
+        png.raw.filter_image(RowFilter::Bigrams);
+    });
+}
+
+#[bench]
+fn filters_bigent(b: &mut Bencher) {
+    let input = test::black_box(PathBuf::from("tests/files/rgb_8_should_be_rgb_8.png"));
+    let png = PngData::new(&input, false).unwrap();
+
+    b.iter(|| {
+        png.raw.filter_image(RowFilter::BigEnt);
+    });
+}
+
+#[bench]
+fn filters_brute(b: &mut Bencher) {
+    let input = test::black_box(PathBuf::from("tests/files/rgb_8_should_be_rgb_8.png"));
+    let png = PngData::new(&input, false).unwrap();
+
+    b.iter(|| {
+        png.raw.filter_image(RowFilter::Brute);
+    });
+}

--- a/src/evaluate.rs
+++ b/src/evaluate.rs
@@ -3,10 +3,9 @@
 
 use crate::atomicmin::AtomicMin;
 use crate::deflate;
+use crate::filters::RowFilter;
 use crate::png::PngData;
 use crate::png::PngImage;
-use crate::png::STD_COMPRESSION;
-use crate::png::STD_FILTERS;
 #[cfg(not(feature = "parallel"))]
 use crate::rayon;
 use crate::Deadline;
@@ -19,9 +18,13 @@ use std::sync::atomic::AtomicUsize;
 use std::sync::atomic::Ordering::SeqCst;
 use std::sync::Arc;
 
+/// Must use normal (lazy) compression, as faster ones (greedy) are not representative
+const STD_COMPRESSION: u8 = 5;
+const STD_FILTERS: [RowFilter; 2] = [RowFilter::None, RowFilter::MinSum];
+
 struct Candidate {
     image: PngData,
-    filter: u8,
+    filter: RowFilter,
     // first wins tie-breaker
     nth: usize,
 }

--- a/src/filters.rs
+++ b/src/filters.rs
@@ -1,130 +1,180 @@
+use std::{fmt::Display, mem::transmute};
+
 use crate::error::PngError;
 
-pub fn filter_line(filter: u8, bpp: usize, data: &[u8], last_line: &[u8], buf: &mut Vec<u8>) {
-    assert!(data.len() >= bpp);
-    assert!(last_line.is_empty() || data.len() == last_line.len());
-    buf.reserve(data.len());
-    match filter {
-        0 => {
-            buf.extend_from_slice(data);
+#[repr(u8)]
+#[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Clone, Copy, Hash)]
+pub enum RowFilter {
+    // Standard filter types
+    None,
+    Sub,
+    Up,
+    Average,
+    Paeth,
+    // Heuristic strategies
+    MinSum,
+}
+
+impl TryFrom<u8> for RowFilter {
+    type Error = ();
+
+    fn try_from(value: u8) -> Result<Self, Self::Error> {
+        if value > Self::LAST {
+            return Err(());
         }
-        1 => {
-            buf.extend_from_slice(&data[0..bpp]);
-            buf.extend(
-                data.iter()
-                    .skip(bpp)
-                    .zip(data.iter())
-                    .map(|(cur, last)| cur.wrapping_sub(*last)),
-            );
-        }
-        2 => {
-            if last_line.is_empty() {
-                buf.extend_from_slice(data);
-            } else {
-                assert_eq!(data.len(), last_line.len());
-                buf.extend(
-                    data.iter()
-                        .zip(last_line.iter())
-                        .map(|(cur, last)| cur.wrapping_sub(*last)),
-                );
-            };
-        }
-        3 => {
-            for (i, byte) in data.iter().enumerate() {
-                if last_line.is_empty() {
-                    buf.push(match i.checked_sub(bpp) {
-                        Some(x) => byte.wrapping_sub(data[x] >> 1),
-                        None => *byte,
-                    });
-                } else {
-                    buf.push(match i.checked_sub(bpp) {
-                        Some(x) => byte.wrapping_sub(
-                            ((u16::from(data[x]) + u16::from(last_line[i])) >> 1) as u8,
-                        ),
-                        None => byte.wrapping_sub(last_line[i] >> 1),
-                    });
-                };
-            }
-        }
-        4 => {
-            for (i, byte) in data.iter().enumerate() {
-                if last_line.is_empty() {
-                    buf.push(match i.checked_sub(bpp) {
-                        Some(x) => byte.wrapping_sub(data[x]),
-                        None => *byte,
-                    });
-                } else {
-                    buf.push(match i.checked_sub(bpp) {
-                        Some(x) => {
-                            byte.wrapping_sub(paeth_predictor(data[x], last_line[i], last_line[x]))
-                        }
-                        None => byte.wrapping_sub(last_line[i]),
-                    });
-                };
-            }
-        }
-        _ => unreachable!(),
+        unsafe { transmute(value as i8) }
     }
 }
 
-pub fn unfilter_line(
-    filter: u8,
-    bpp: usize,
-    data: &[u8],
-    last_line: &[u8],
-    buf: &mut Vec<u8>,
-) -> Result<(), PngError> {
-    buf.clear();
-    buf.reserve(data.len());
-    assert!(data.len() >= bpp);
-    assert_eq!(data.len(), last_line.len());
-    match filter {
-        0 => {
-            buf.extend_from_slice(data);
-        }
-        1 => {
-            for (i, &cur) in data.iter().enumerate() {
-                let prev_byte = i.checked_sub(bpp).and_then(|x| buf.get(x).copied());
-                buf.push(match prev_byte {
-                    Some(b) => cur.wrapping_add(b),
-                    None => cur,
-                });
+impl Display for RowFilter {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "{:8}",
+            match *self {
+                Self::None => "None",
+                Self::Sub => "Sub",
+                Self::Up => "Up",
+                Self::Average => "Average",
+                Self::Paeth => "Paeth",
+                Self::MinSum => "MinSum",
             }
-        }
-        2 => {
-            buf.extend(
-                data.iter()
-                    .zip(last_line)
-                    .map(|(&cur, &last)| cur.wrapping_add(last)),
-            );
-        }
-        3 => {
-            for (i, (&cur, &last)) in data.iter().zip(last_line).enumerate() {
-                let prev_byte = i.checked_sub(bpp).and_then(|x| buf.get(x).copied());
-                buf.push(match prev_byte {
-                    Some(b) => cur.wrapping_add(((u16::from(b) + u16::from(last)) >> 1) as u8),
-                    None => cur.wrapping_add(last >> 1),
-                });
+        )
+    }
+}
+
+impl RowFilter {
+    pub const LAST: u8 = Self::MinSum as u8;
+    pub const STANDARD: [Self; 5] = [Self::None, Self::Sub, Self::Up, Self::Average, Self::Paeth];
+
+    pub fn filter_line(self, bpp: usize, data: &[u8], last_line: &[u8], buf: &mut Vec<u8>) {
+        assert!(data.len() >= bpp);
+        assert!(last_line.is_empty() || data.len() == last_line.len());
+        buf.reserve(data.len());
+        match self {
+            Self::None => {
+                buf.extend_from_slice(data);
             }
-        }
-        4 => {
-            for (i, (&cur, &up)) in data.iter().zip(last_line).enumerate() {
-                buf.push(
-                    match i
-                        .checked_sub(bpp)
-                        .map(|x| (buf.get(x).copied(), last_line.get(x).copied()))
-                    {
-                        Some((Some(left), Some(left_up))) => {
-                            cur.wrapping_add(paeth_predictor(left, up, left_up))
-                        }
-                        _ => cur.wrapping_add(up),
-                    },
+            Self::Sub => {
+                buf.extend_from_slice(&data[0..bpp]);
+                buf.extend(
+                    data.iter()
+                        .skip(bpp)
+                        .zip(data.iter())
+                        .map(|(cur, last)| cur.wrapping_sub(*last)),
                 );
             }
+            Self::Up => {
+                if last_line.is_empty() {
+                    buf.extend_from_slice(data);
+                } else {
+                    assert_eq!(data.len(), last_line.len());
+                    buf.extend(
+                        data.iter()
+                            .zip(last_line.iter())
+                            .map(|(cur, last)| cur.wrapping_sub(*last)),
+                    );
+                };
+            }
+            Self::Average => {
+                for (i, byte) in data.iter().enumerate() {
+                    if last_line.is_empty() {
+                        buf.push(match i.checked_sub(bpp) {
+                            Some(x) => byte.wrapping_sub(data[x] >> 1),
+                            None => *byte,
+                        });
+                    } else {
+                        buf.push(match i.checked_sub(bpp) {
+                            Some(x) => byte.wrapping_sub(
+                                ((u16::from(data[x]) + u16::from(last_line[i])) >> 1) as u8,
+                            ),
+                            None => byte.wrapping_sub(last_line[i] >> 1),
+                        });
+                    };
+                }
+            }
+            Self::Paeth => {
+                for (i, byte) in data.iter().enumerate() {
+                    if last_line.is_empty() {
+                        buf.push(match i.checked_sub(bpp) {
+                            Some(x) => byte.wrapping_sub(data[x]),
+                            None => *byte,
+                        });
+                    } else {
+                        buf.push(match i.checked_sub(bpp) {
+                            Some(x) => byte.wrapping_sub(paeth_predictor(
+                                data[x],
+                                last_line[i],
+                                last_line[x],
+                            )),
+                            None => byte.wrapping_sub(last_line[i]),
+                        });
+                    };
+                }
+            }
+            _ => unreachable!(),
         }
-        _ => return Err(PngError::InvalidData),
     }
-    Ok(())
+
+    pub fn unfilter_line(
+        self,
+        bpp: usize,
+        data: &[u8],
+        last_line: &[u8],
+        buf: &mut Vec<u8>,
+    ) -> Result<(), PngError> {
+        buf.clear();
+        buf.reserve(data.len());
+        assert!(data.len() >= bpp);
+        assert_eq!(data.len(), last_line.len());
+        match self {
+            Self::None => {
+                buf.extend_from_slice(data);
+            }
+            Self::Sub => {
+                for (i, &cur) in data.iter().enumerate() {
+                    let prev_byte = i.checked_sub(bpp).and_then(|x| buf.get(x).copied());
+                    buf.push(match prev_byte {
+                        Some(b) => cur.wrapping_add(b),
+                        None => cur,
+                    });
+                }
+            }
+            Self::Up => {
+                buf.extend(
+                    data.iter()
+                        .zip(last_line)
+                        .map(|(&cur, &last)| cur.wrapping_add(last)),
+                );
+            }
+            Self::Average => {
+                for (i, (&cur, &last)) in data.iter().zip(last_line).enumerate() {
+                    let prev_byte = i.checked_sub(bpp).and_then(|x| buf.get(x).copied());
+                    buf.push(match prev_byte {
+                        Some(b) => cur.wrapping_add(((u16::from(b) + u16::from(last)) >> 1) as u8),
+                        None => cur.wrapping_add(last >> 1),
+                    });
+                }
+            }
+            Self::Paeth => {
+                for (i, (&cur, &up)) in data.iter().zip(last_line).enumerate() {
+                    buf.push(
+                        match i
+                            .checked_sub(bpp)
+                            .map(|x| (buf.get(x).copied(), last_line.get(x).copied()))
+                        {
+                            Some((Some(left), Some(left_up))) => {
+                                cur.wrapping_add(paeth_predictor(left, up, left_up))
+                            }
+                            _ => cur.wrapping_add(up),
+                        },
+                    );
+                }
+            }
+            _ => return Err(PngError::InvalidData),
+        }
+        Ok(())
+    }
 }
 
 fn paeth_predictor(a: u8, b: u8, c: u8) -> u8 {

--- a/src/filters.rs
+++ b/src/filters.rs
@@ -16,6 +16,7 @@ pub enum RowFilter {
     Entropy,
     Bigrams,
     BigEnt,
+    Brute,
 }
 
 impl TryFrom<u8> for RowFilter {
@@ -44,13 +45,14 @@ impl Display for RowFilter {
                 Self::Entropy => "Entropy",
                 Self::Bigrams => "Bigrams",
                 Self::BigEnt => "BigEnt",
+                Self::Brute => "Brute",
             }
         )
     }
 }
 
 impl RowFilter {
-    pub const LAST: u8 = Self::BigEnt as u8;
+    pub const LAST: u8 = Self::Brute as u8;
     pub const STANDARD: [Self; 5] = [Self::None, Self::Sub, Self::Up, Self::Average, Self::Paeth];
     pub const SINGLE_LINE: [Self; 2] = [Self::None, Self::Sub];
 

--- a/src/filters.rs
+++ b/src/filters.rs
@@ -13,6 +13,7 @@ pub enum RowFilter {
     Paeth,
     // Heuristic strategies
     MinSum,
+    Entropy,
 }
 
 impl TryFrom<u8> for RowFilter {
@@ -38,14 +39,16 @@ impl Display for RowFilter {
                 Self::Average => "Average",
                 Self::Paeth => "Paeth",
                 Self::MinSum => "MinSum",
+                Self::Entropy => "Entropy",
             }
         )
     }
 }
 
 impl RowFilter {
-    pub const LAST: u8 = Self::MinSum as u8;
+    pub const LAST: u8 = Self::Entropy as u8;
     pub const STANDARD: [Self; 5] = [Self::None, Self::Sub, Self::Up, Self::Average, Self::Paeth];
+    pub const SINGLE_LINE: [Self; 2] = [Self::None, Self::Sub];
 
     pub fn filter_line(self, bpp: usize, data: &[u8], last_line: &[u8], buf: &mut Vec<u8>) {
         assert!(data.len() >= bpp);

--- a/src/filters.rs
+++ b/src/filters.rs
@@ -50,7 +50,9 @@ impl RowFilter {
     pub fn filter_line(self, bpp: usize, data: &[u8], last_line: &[u8], buf: &mut Vec<u8>) {
         assert!(data.len() >= bpp);
         assert!(last_line.is_empty() || data.len() == last_line.len());
-        buf.reserve(data.len());
+        buf.clear();
+        buf.reserve(data.len() + 1);
+        buf.push(self as u8);
         match self {
             Self::None => {
                 buf.extend_from_slice(data);

--- a/src/filters.rs
+++ b/src/filters.rs
@@ -14,6 +14,7 @@ pub enum RowFilter {
     // Heuristic strategies
     MinSum,
     Entropy,
+    Bigrams,
 }
 
 impl TryFrom<u8> for RowFilter {
@@ -40,13 +41,14 @@ impl Display for RowFilter {
                 Self::Paeth => "Paeth",
                 Self::MinSum => "MinSum",
                 Self::Entropy => "Entropy",
+                Self::Bigrams => "Bigrams",
             }
         )
     }
 }
 
 impl RowFilter {
-    pub const LAST: u8 = Self::Entropy as u8;
+    pub const LAST: u8 = Self::Bigrams as u8;
     pub const STANDARD: [Self; 5] = [Self::None, Self::Sub, Self::Up, Self::Average, Self::Paeth];
     pub const SINGLE_LINE: [Self; 2] = [Self::None, Self::Sub];
 

--- a/src/filters.rs
+++ b/src/filters.rs
@@ -15,6 +15,7 @@ pub enum RowFilter {
     MinSum,
     Entropy,
     Bigrams,
+    BigEnt,
 }
 
 impl TryFrom<u8> for RowFilter {
@@ -42,13 +43,14 @@ impl Display for RowFilter {
                 Self::MinSum => "MinSum",
                 Self::Entropy => "Entropy",
                 Self::Bigrams => "Bigrams",
+                Self::BigEnt => "BigEnt",
             }
         )
     }
 }
 
 impl RowFilter {
-    pub const LAST: u8 = Self::Bigrams as u8;
+    pub const LAST: u8 = Self::BigEnt as u8;
     pub const STANDARD: [Self; 5] = [Self::None, Self::Sub, Self::Up, Self::Average, Self::Paeth];
     pub const SINGLE_LINE: [Self; 2] = [Self::None, Self::Sub];
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -269,7 +269,20 @@ fn main() {
     -o max =>                       (stable alias for the max compression)
 
     Manually specifying a compression option (zc, f, etc.) will override the optimization preset,
-    regardless of the order you write the arguments.",
+    regardless of the order you write the arguments.
+
+PNG delta filters:
+    0  =>  None
+    1  =>  Sub
+    2  =>  Up
+    3  =>  Average
+    4  =>  Paeth
+Heuristic filter selection strategies:
+    5  =>  MinSum    Minimum sum of absolute differences
+    6  =>  Entropy   Highest Shannon entropy
+    7  =>  Bigrams   Lowest count of distinct bigrams
+    8  =>  BigEnt    Highest Shannon entropy of bigrams
+    9  =>  Brute     Smallest compressed size (slow)",
         )
         .get_matches_from(wild::args());
 

--- a/src/png/mod.rs
+++ b/src/png/mod.rs
@@ -382,8 +382,8 @@ impl PngImage {
                         for try_filter in try_filters {
                             try_filter.filter_line(bpp, line.data, last_line, &mut f_buf);
                             let mut set = bitarr![0; 0x10000];
-                            for i in 1..f_buf.len() {
-                                let bigram = (f_buf[i - 1] as usize) << 8 | f_buf[i] as usize;
+                            for pair in f_buf.windows(2) {
+                                let bigram = (pair[0] as usize) << 8 | pair[1] as usize;
                                 set.set(bigram, true);
                             }
                             let size = set.count_ones();
@@ -401,8 +401,8 @@ impl PngImage {
                         for try_filter in try_filters {
                             try_filter.filter_line(bpp, line.data, last_line, &mut f_buf);
                             counts.clear();
-                            for i in 1..f_buf.len() {
-                                let bigram = (f_buf[i - 1] as u16) << 8 | f_buf[i] as u16;
+                            for pair in f_buf.windows(2) {
+                                let bigram = (pair[0] as u16) << 8 | pair[1] as u16;
                                 counts.entry(bigram).and_modify(|e| *e += 1).or_insert(1);
                             }
                             let size = counts.values().fold(0, |acc, &x| acc + ilog2i(x)) as i32;

--- a/src/png/mod.rs
+++ b/src/png/mod.rs
@@ -306,7 +306,6 @@ impl PngImage {
         let mut last_pass: Option<u8> = None;
         let mut f_buf = Vec::new();
         for line in self.scan_lines() {
-            f_buf.clear();
             if last_pass != line.pass {
                 last_line = &[];
             }
@@ -315,7 +314,6 @@ impl PngImage {
                     // Heuristically guess best filter per line
                     // Uses MSAD algorithm mentioned in libpng reference docs
                     // http://www.libpng.org/pub/png/book/chapter09.html
-                    let mut best_filter = RowFilter::None;
                     let mut best_line = Vec::new();
                     let mut best_size = u64::MAX;
 
@@ -331,12 +329,9 @@ impl PngImage {
                         });
                         if size < best_size {
                             best_size = size;
-                            best_filter = try_filter;
                             std::mem::swap(&mut best_line, &mut f_buf);
                         }
-                        f_buf.clear() //discard buffer, and start again
                     }
-                    filtered.push(best_filter as u8);
                     filtered.extend_from_slice(&best_line);
                 }
                 _ => {
@@ -345,7 +340,6 @@ impl PngImage {
                     } else {
                         RowFilter::None
                     };
-                    filtered.push(filter as u8);
                     filter.filter_line(bpp, line.data, last_line, &mut f_buf);
                     filtered.extend_from_slice(&f_buf);
                 }

--- a/src/reduction/color.rs
+++ b/src/reduction/color.rs
@@ -4,7 +4,10 @@ use crate::png::PngImage;
 use indexmap::IndexMap;
 use itertools::Itertools;
 use rgb::{FromSlice, RGB8, RGBA8};
-use std::hash::Hash;
+use rustc_hash::FxHasher;
+use std::hash::{BuildHasherDefault, Hash};
+
+type FxIndexMap<K, V> = IndexMap<K, V, BuildHasherDefault<FxHasher>>;
 
 #[must_use]
 pub fn reduce_rgba_to_grayscale_alpha(png: &PngImage) -> Option<PngImage> {
@@ -78,7 +81,7 @@ pub fn reduce_rgba_to_grayscale_alpha(png: &PngImage) -> Option<PngImage> {
 
 fn reduce_scanline_to_palette<T>(
     iter: impl IntoIterator<Item = T>,
-    palette: &mut IndexMap<T, u8>,
+    palette: &mut FxIndexMap<T, u8>,
     reduced: &mut Vec<u8>,
 ) -> bool
 where
@@ -107,7 +110,8 @@ pub fn reduced_color_to_palette(png: &PngImage) -> Option<PngImage> {
         return None;
     }
     let mut raw_data = Vec::with_capacity(png.data.len());
-    let mut palette = IndexMap::with_capacity(257);
+    let mut palette = FxIndexMap::default();
+    palette.reserve(257);
     let transparency_pixel = png
         .transparency_pixel
         .as_ref()

--- a/tests/filters.rs
+++ b/tests/filters.rs
@@ -1,5 +1,5 @@
 use indexmap::IndexSet;
-use oxipng::internal_tests::*;
+use oxipng::{internal_tests::*, RowFilter};
 use oxipng::{InFile, OutFile};
 use std::fs::remove_file;
 use std::path::Path;
@@ -11,7 +11,7 @@ fn get_opts(input: &Path) -> (OutFile, oxipng::Options) {
         ..Default::default()
     };
     let mut filter = IndexSet::new();
-    filter.insert(0);
+    filter.insert(RowFilter::None);
     options.filter = filter;
 
     (
@@ -22,7 +22,7 @@ fn get_opts(input: &Path) -> (OutFile, oxipng::Options) {
 
 fn test_it_converts(
     input: &str,
-    filter: u8,
+    filter: RowFilter,
     color_type_in: ColorType,
     bit_depth_in: BitDepth,
     color_type_out: ColorType,
@@ -67,7 +67,7 @@ fn test_it_converts(
 fn filter_0_for_rgba_16() {
     test_it_converts(
         "tests/files/filter_0_for_rgba_16.png",
-        0,
+        RowFilter::None,
         ColorType::RGBA,
         BitDepth::Sixteen,
         ColorType::RGBA,
@@ -79,7 +79,7 @@ fn filter_0_for_rgba_16() {
 fn filter_1_for_rgba_16() {
     test_it_converts(
         "tests/files/filter_1_for_rgba_16.png",
-        1,
+        RowFilter::Sub,
         ColorType::RGBA,
         BitDepth::Sixteen,
         ColorType::RGBA,
@@ -91,7 +91,7 @@ fn filter_1_for_rgba_16() {
 fn filter_2_for_rgba_16() {
     test_it_converts(
         "tests/files/filter_2_for_rgba_16.png",
-        2,
+        RowFilter::Up,
         ColorType::RGBA,
         BitDepth::Sixteen,
         ColorType::RGBA,
@@ -103,7 +103,7 @@ fn filter_2_for_rgba_16() {
 fn filter_3_for_rgba_16() {
     test_it_converts(
         "tests/files/filter_3_for_rgba_16.png",
-        3,
+        RowFilter::Average,
         ColorType::RGBA,
         BitDepth::Sixteen,
         ColorType::RGBA,
@@ -115,7 +115,7 @@ fn filter_3_for_rgba_16() {
 fn filter_4_for_rgba_16() {
     test_it_converts(
         "tests/files/filter_4_for_rgba_16.png",
-        4,
+        RowFilter::Paeth,
         ColorType::RGBA,
         BitDepth::Sixteen,
         ColorType::RGBA,
@@ -127,7 +127,7 @@ fn filter_4_for_rgba_16() {
 fn filter_5_for_rgba_16() {
     test_it_converts(
         "tests/files/filter_5_for_rgba_16.png",
-        5,
+        RowFilter::MinSum,
         ColorType::RGBA,
         BitDepth::Sixteen,
         ColorType::RGBA,
@@ -139,7 +139,7 @@ fn filter_5_for_rgba_16() {
 fn filter_0_for_rgba_8() {
     test_it_converts(
         "tests/files/filter_0_for_rgba_8.png",
-        0,
+        RowFilter::None,
         ColorType::RGBA,
         BitDepth::Eight,
         ColorType::RGBA,
@@ -151,7 +151,7 @@ fn filter_0_for_rgba_8() {
 fn filter_1_for_rgba_8() {
     test_it_converts(
         "tests/files/filter_1_for_rgba_8.png",
-        1,
+        RowFilter::Sub,
         ColorType::RGBA,
         BitDepth::Eight,
         ColorType::RGBA,
@@ -163,7 +163,7 @@ fn filter_1_for_rgba_8() {
 fn filter_2_for_rgba_8() {
     test_it_converts(
         "tests/files/filter_2_for_rgba_8.png",
-        2,
+        RowFilter::Up,
         ColorType::RGBA,
         BitDepth::Eight,
         ColorType::RGBA,
@@ -175,7 +175,7 @@ fn filter_2_for_rgba_8() {
 fn filter_3_for_rgba_8() {
     test_it_converts(
         "tests/files/filter_3_for_rgba_8.png",
-        3,
+        RowFilter::Average,
         ColorType::RGBA,
         BitDepth::Eight,
         ColorType::RGBA,
@@ -187,7 +187,7 @@ fn filter_3_for_rgba_8() {
 fn filter_4_for_rgba_8() {
     test_it_converts(
         "tests/files/filter_4_for_rgba_8.png",
-        4,
+        RowFilter::Paeth,
         ColorType::RGBA,
         BitDepth::Eight,
         ColorType::RGBA,
@@ -199,7 +199,7 @@ fn filter_4_for_rgba_8() {
 fn filter_5_for_rgba_8() {
     test_it_converts(
         "tests/files/filter_5_for_rgba_8.png",
-        5,
+        RowFilter::MinSum,
         ColorType::RGBA,
         BitDepth::Eight,
         ColorType::RGBA,
@@ -211,7 +211,7 @@ fn filter_5_for_rgba_8() {
 fn filter_0_for_rgb_16() {
     test_it_converts(
         "tests/files/filter_0_for_rgb_16.png",
-        0,
+        RowFilter::None,
         ColorType::RGB,
         BitDepth::Sixteen,
         ColorType::RGB,
@@ -223,7 +223,7 @@ fn filter_0_for_rgb_16() {
 fn filter_1_for_rgb_16() {
     test_it_converts(
         "tests/files/filter_1_for_rgb_16.png",
-        1,
+        RowFilter::Sub,
         ColorType::RGB,
         BitDepth::Sixteen,
         ColorType::RGB,
@@ -235,7 +235,7 @@ fn filter_1_for_rgb_16() {
 fn filter_2_for_rgb_16() {
     test_it_converts(
         "tests/files/filter_2_for_rgb_16.png",
-        2,
+        RowFilter::Up,
         ColorType::RGB,
         BitDepth::Sixteen,
         ColorType::RGB,
@@ -247,7 +247,7 @@ fn filter_2_for_rgb_16() {
 fn filter_3_for_rgb_16() {
     test_it_converts(
         "tests/files/filter_3_for_rgb_16.png",
-        3,
+        RowFilter::Average,
         ColorType::RGB,
         BitDepth::Sixteen,
         ColorType::RGB,
@@ -259,7 +259,7 @@ fn filter_3_for_rgb_16() {
 fn filter_4_for_rgb_16() {
     test_it_converts(
         "tests/files/filter_4_for_rgb_16.png",
-        4,
+        RowFilter::Paeth,
         ColorType::RGB,
         BitDepth::Sixteen,
         ColorType::RGB,
@@ -271,7 +271,7 @@ fn filter_4_for_rgb_16() {
 fn filter_5_for_rgb_16() {
     test_it_converts(
         "tests/files/filter_5_for_rgb_16.png",
-        5,
+        RowFilter::MinSum,
         ColorType::RGB,
         BitDepth::Sixteen,
         ColorType::RGB,
@@ -283,7 +283,7 @@ fn filter_5_for_rgb_16() {
 fn filter_0_for_rgb_8() {
     test_it_converts(
         "tests/files/filter_0_for_rgb_8.png",
-        0,
+        RowFilter::None,
         ColorType::RGB,
         BitDepth::Eight,
         ColorType::RGB,
@@ -295,7 +295,7 @@ fn filter_0_for_rgb_8() {
 fn filter_1_for_rgb_8() {
     test_it_converts(
         "tests/files/filter_1_for_rgb_8.png",
-        1,
+        RowFilter::Sub,
         ColorType::RGB,
         BitDepth::Eight,
         ColorType::RGB,
@@ -307,7 +307,7 @@ fn filter_1_for_rgb_8() {
 fn filter_2_for_rgb_8() {
     test_it_converts(
         "tests/files/filter_2_for_rgb_8.png",
-        2,
+        RowFilter::Up,
         ColorType::RGB,
         BitDepth::Eight,
         ColorType::RGB,
@@ -319,7 +319,7 @@ fn filter_2_for_rgb_8() {
 fn filter_3_for_rgb_8() {
     test_it_converts(
         "tests/files/filter_3_for_rgb_8.png",
-        3,
+        RowFilter::Average,
         ColorType::RGB,
         BitDepth::Eight,
         ColorType::RGB,
@@ -331,7 +331,7 @@ fn filter_3_for_rgb_8() {
 fn filter_4_for_rgb_8() {
     test_it_converts(
         "tests/files/filter_4_for_rgb_8.png",
-        4,
+        RowFilter::Paeth,
         ColorType::RGB,
         BitDepth::Eight,
         ColorType::RGB,
@@ -343,7 +343,7 @@ fn filter_4_for_rgb_8() {
 fn filter_5_for_rgb_8() {
     test_it_converts(
         "tests/files/filter_5_for_rgb_8.png",
-        5,
+        RowFilter::MinSum,
         ColorType::RGB,
         BitDepth::Eight,
         ColorType::RGB,
@@ -355,7 +355,7 @@ fn filter_5_for_rgb_8() {
 fn filter_0_for_grayscale_alpha_16() {
     test_it_converts(
         "tests/files/filter_0_for_grayscale_alpha_16.png",
-        0,
+        RowFilter::None,
         ColorType::GrayscaleAlpha,
         BitDepth::Sixteen,
         ColorType::GrayscaleAlpha,
@@ -367,7 +367,7 @@ fn filter_0_for_grayscale_alpha_16() {
 fn filter_1_for_grayscale_alpha_16() {
     test_it_converts(
         "tests/files/filter_1_for_grayscale_alpha_16.png",
-        1,
+        RowFilter::Sub,
         ColorType::GrayscaleAlpha,
         BitDepth::Sixteen,
         ColorType::GrayscaleAlpha,
@@ -379,7 +379,7 @@ fn filter_1_for_grayscale_alpha_16() {
 fn filter_2_for_grayscale_alpha_16() {
     test_it_converts(
         "tests/files/filter_2_for_grayscale_alpha_16.png",
-        2,
+        RowFilter::Up,
         ColorType::GrayscaleAlpha,
         BitDepth::Sixteen,
         ColorType::GrayscaleAlpha,
@@ -391,7 +391,7 @@ fn filter_2_for_grayscale_alpha_16() {
 fn filter_3_for_grayscale_alpha_16() {
     test_it_converts(
         "tests/files/filter_3_for_grayscale_alpha_16.png",
-        3,
+        RowFilter::Average,
         ColorType::GrayscaleAlpha,
         BitDepth::Sixteen,
         ColorType::GrayscaleAlpha,
@@ -403,7 +403,7 @@ fn filter_3_for_grayscale_alpha_16() {
 fn filter_4_for_grayscale_alpha_16() {
     test_it_converts(
         "tests/files/filter_4_for_grayscale_alpha_16.png",
-        4,
+        RowFilter::Paeth,
         ColorType::GrayscaleAlpha,
         BitDepth::Sixteen,
         ColorType::GrayscaleAlpha,
@@ -415,7 +415,7 @@ fn filter_4_for_grayscale_alpha_16() {
 fn filter_5_for_grayscale_alpha_16() {
     test_it_converts(
         "tests/files/filter_5_for_grayscale_alpha_16.png",
-        5,
+        RowFilter::MinSum,
         ColorType::GrayscaleAlpha,
         BitDepth::Sixteen,
         ColorType::GrayscaleAlpha,
@@ -427,7 +427,7 @@ fn filter_5_for_grayscale_alpha_16() {
 fn filter_0_for_grayscale_alpha_8() {
     test_it_converts(
         "tests/files/filter_0_for_grayscale_alpha_8.png",
-        0,
+        RowFilter::None,
         ColorType::GrayscaleAlpha,
         BitDepth::Eight,
         ColorType::GrayscaleAlpha,
@@ -439,7 +439,7 @@ fn filter_0_for_grayscale_alpha_8() {
 fn filter_1_for_grayscale_alpha_8() {
     test_it_converts(
         "tests/files/filter_1_for_grayscale_alpha_8.png",
-        1,
+        RowFilter::Sub,
         ColorType::GrayscaleAlpha,
         BitDepth::Eight,
         ColorType::GrayscaleAlpha,
@@ -451,7 +451,7 @@ fn filter_1_for_grayscale_alpha_8() {
 fn filter_2_for_grayscale_alpha_8() {
     test_it_converts(
         "tests/files/filter_2_for_grayscale_alpha_8.png",
-        2,
+        RowFilter::Up,
         ColorType::GrayscaleAlpha,
         BitDepth::Eight,
         ColorType::GrayscaleAlpha,
@@ -463,7 +463,7 @@ fn filter_2_for_grayscale_alpha_8() {
 fn filter_3_for_grayscale_alpha_8() {
     test_it_converts(
         "tests/files/filter_3_for_grayscale_alpha_8.png",
-        3,
+        RowFilter::Average,
         ColorType::GrayscaleAlpha,
         BitDepth::Eight,
         ColorType::GrayscaleAlpha,
@@ -475,7 +475,7 @@ fn filter_3_for_grayscale_alpha_8() {
 fn filter_4_for_grayscale_alpha_8() {
     test_it_converts(
         "tests/files/filter_4_for_grayscale_alpha_8.png",
-        4,
+        RowFilter::Paeth,
         ColorType::GrayscaleAlpha,
         BitDepth::Eight,
         ColorType::GrayscaleAlpha,
@@ -487,7 +487,7 @@ fn filter_4_for_grayscale_alpha_8() {
 fn filter_5_for_grayscale_alpha_8() {
     test_it_converts(
         "tests/files/filter_5_for_grayscale_alpha_8.png",
-        5,
+        RowFilter::MinSum,
         ColorType::GrayscaleAlpha,
         BitDepth::Eight,
         ColorType::GrayscaleAlpha,
@@ -499,7 +499,7 @@ fn filter_5_for_grayscale_alpha_8() {
 fn filter_0_for_grayscale_16() {
     test_it_converts(
         "tests/files/filter_0_for_grayscale_16.png",
-        0,
+        RowFilter::None,
         ColorType::Grayscale,
         BitDepth::Sixteen,
         ColorType::Grayscale,
@@ -511,7 +511,7 @@ fn filter_0_for_grayscale_16() {
 fn filter_1_for_grayscale_16() {
     test_it_converts(
         "tests/files/filter_1_for_grayscale_16.png",
-        1,
+        RowFilter::Sub,
         ColorType::Grayscale,
         BitDepth::Sixteen,
         ColorType::Grayscale,
@@ -523,7 +523,7 @@ fn filter_1_for_grayscale_16() {
 fn filter_2_for_grayscale_16() {
     test_it_converts(
         "tests/files/filter_2_for_grayscale_16.png",
-        2,
+        RowFilter::Up,
         ColorType::Grayscale,
         BitDepth::Sixteen,
         ColorType::Grayscale,
@@ -535,7 +535,7 @@ fn filter_2_for_grayscale_16() {
 fn filter_3_for_grayscale_16() {
     test_it_converts(
         "tests/files/filter_3_for_grayscale_16.png",
-        3,
+        RowFilter::Average,
         ColorType::Grayscale,
         BitDepth::Sixteen,
         ColorType::Grayscale,
@@ -547,7 +547,7 @@ fn filter_3_for_grayscale_16() {
 fn filter_4_for_grayscale_16() {
     test_it_converts(
         "tests/files/filter_4_for_grayscale_16.png",
-        4,
+        RowFilter::Paeth,
         ColorType::Grayscale,
         BitDepth::Sixteen,
         ColorType::Grayscale,
@@ -559,7 +559,7 @@ fn filter_4_for_grayscale_16() {
 fn filter_5_for_grayscale_16() {
     test_it_converts(
         "tests/files/filter_5_for_grayscale_16.png",
-        5,
+        RowFilter::MinSum,
         ColorType::Grayscale,
         BitDepth::Sixteen,
         ColorType::Grayscale,
@@ -571,7 +571,7 @@ fn filter_5_for_grayscale_16() {
 fn filter_0_for_grayscale_8() {
     test_it_converts(
         "tests/files/filter_0_for_grayscale_8.png",
-        0,
+        RowFilter::None,
         ColorType::Grayscale,
         BitDepth::Eight,
         ColorType::Grayscale,
@@ -583,7 +583,7 @@ fn filter_0_for_grayscale_8() {
 fn filter_1_for_grayscale_8() {
     test_it_converts(
         "tests/files/filter_1_for_grayscale_8.png",
-        1,
+        RowFilter::Sub,
         ColorType::Grayscale,
         BitDepth::Eight,
         ColorType::Grayscale,
@@ -595,7 +595,7 @@ fn filter_1_for_grayscale_8() {
 fn filter_2_for_grayscale_8() {
     test_it_converts(
         "tests/files/filter_2_for_grayscale_8.png",
-        2,
+        RowFilter::Up,
         ColorType::Grayscale,
         BitDepth::Eight,
         ColorType::Grayscale,
@@ -607,7 +607,7 @@ fn filter_2_for_grayscale_8() {
 fn filter_3_for_grayscale_8() {
     test_it_converts(
         "tests/files/filter_3_for_grayscale_8.png",
-        3,
+        RowFilter::Average,
         ColorType::Grayscale,
         BitDepth::Eight,
         ColorType::Grayscale,
@@ -619,7 +619,7 @@ fn filter_3_for_grayscale_8() {
 fn filter_4_for_grayscale_8() {
     test_it_converts(
         "tests/files/filter_4_for_grayscale_8.png",
-        4,
+        RowFilter::Paeth,
         ColorType::Grayscale,
         BitDepth::Eight,
         ColorType::Grayscale,
@@ -631,7 +631,7 @@ fn filter_4_for_grayscale_8() {
 fn filter_5_for_grayscale_8() {
     test_it_converts(
         "tests/files/filter_5_for_grayscale_8.png",
-        5,
+        RowFilter::MinSum,
         ColorType::Grayscale,
         BitDepth::Eight,
         ColorType::Grayscale,
@@ -643,7 +643,7 @@ fn filter_5_for_grayscale_8() {
 fn filter_0_for_palette_4() {
     test_it_converts(
         "tests/files/filter_0_for_palette_4.png",
-        0,
+        RowFilter::None,
         ColorType::Indexed,
         BitDepth::Four,
         ColorType::Indexed,
@@ -655,7 +655,7 @@ fn filter_0_for_palette_4() {
 fn filter_1_for_palette_4() {
     test_it_converts(
         "tests/files/filter_1_for_palette_4.png",
-        1,
+        RowFilter::Sub,
         ColorType::Indexed,
         BitDepth::Four,
         ColorType::Indexed,
@@ -667,7 +667,7 @@ fn filter_1_for_palette_4() {
 fn filter_2_for_palette_4() {
     test_it_converts(
         "tests/files/filter_2_for_palette_4.png",
-        2,
+        RowFilter::Up,
         ColorType::Indexed,
         BitDepth::Four,
         ColorType::Indexed,
@@ -679,7 +679,7 @@ fn filter_2_for_palette_4() {
 fn filter_3_for_palette_4() {
     test_it_converts(
         "tests/files/filter_3_for_palette_4.png",
-        3,
+        RowFilter::Average,
         ColorType::Indexed,
         BitDepth::Four,
         ColorType::Indexed,
@@ -691,7 +691,7 @@ fn filter_3_for_palette_4() {
 fn filter_4_for_palette_4() {
     test_it_converts(
         "tests/files/filter_4_for_palette_4.png",
-        4,
+        RowFilter::Paeth,
         ColorType::Indexed,
         BitDepth::Four,
         ColorType::Indexed,
@@ -703,7 +703,7 @@ fn filter_4_for_palette_4() {
 fn filter_5_for_palette_4() {
     test_it_converts(
         "tests/files/filter_5_for_palette_4.png",
-        5,
+        RowFilter::MinSum,
         ColorType::Indexed,
         BitDepth::Four,
         ColorType::Indexed,
@@ -715,7 +715,7 @@ fn filter_5_for_palette_4() {
 fn filter_0_for_palette_2() {
     test_it_converts(
         "tests/files/filter_0_for_palette_2.png",
-        0,
+        RowFilter::None,
         ColorType::Indexed,
         BitDepth::Two,
         ColorType::Indexed,
@@ -727,7 +727,7 @@ fn filter_0_for_palette_2() {
 fn filter_1_for_palette_2() {
     test_it_converts(
         "tests/files/filter_1_for_palette_2.png",
-        1,
+        RowFilter::Sub,
         ColorType::Indexed,
         BitDepth::Two,
         ColorType::Indexed,
@@ -739,7 +739,7 @@ fn filter_1_for_palette_2() {
 fn filter_2_for_palette_2() {
     test_it_converts(
         "tests/files/filter_2_for_palette_2.png",
-        2,
+        RowFilter::Up,
         ColorType::Indexed,
         BitDepth::Two,
         ColorType::Indexed,
@@ -751,7 +751,7 @@ fn filter_2_for_palette_2() {
 fn filter_3_for_palette_2() {
     test_it_converts(
         "tests/files/filter_3_for_palette_2.png",
-        3,
+        RowFilter::Average,
         ColorType::Indexed,
         BitDepth::Two,
         ColorType::Indexed,
@@ -763,7 +763,7 @@ fn filter_3_for_palette_2() {
 fn filter_4_for_palette_2() {
     test_it_converts(
         "tests/files/filter_4_for_palette_2.png",
-        4,
+        RowFilter::Paeth,
         ColorType::Indexed,
         BitDepth::Two,
         ColorType::Indexed,
@@ -775,7 +775,7 @@ fn filter_4_for_palette_2() {
 fn filter_5_for_palette_2() {
     test_it_converts(
         "tests/files/filter_5_for_palette_2.png",
-        5,
+        RowFilter::MinSum,
         ColorType::Indexed,
         BitDepth::Two,
         ColorType::Indexed,
@@ -787,7 +787,7 @@ fn filter_5_for_palette_2() {
 fn filter_0_for_palette_1() {
     test_it_converts(
         "tests/files/filter_0_for_palette_1.png",
-        0,
+        RowFilter::None,
         ColorType::Indexed,
         BitDepth::One,
         ColorType::Indexed,
@@ -799,7 +799,7 @@ fn filter_0_for_palette_1() {
 fn filter_1_for_palette_1() {
     test_it_converts(
         "tests/files/filter_1_for_palette_1.png",
-        1,
+        RowFilter::Sub,
         ColorType::Indexed,
         BitDepth::One,
         ColorType::Indexed,
@@ -811,7 +811,7 @@ fn filter_1_for_palette_1() {
 fn filter_2_for_palette_1() {
     test_it_converts(
         "tests/files/filter_2_for_palette_1.png",
-        2,
+        RowFilter::Up,
         ColorType::Indexed,
         BitDepth::One,
         ColorType::Indexed,
@@ -823,7 +823,7 @@ fn filter_2_for_palette_1() {
 fn filter_3_for_palette_1() {
     test_it_converts(
         "tests/files/filter_3_for_palette_1.png",
-        3,
+        RowFilter::Average,
         ColorType::Indexed,
         BitDepth::One,
         ColorType::Indexed,
@@ -835,7 +835,7 @@ fn filter_3_for_palette_1() {
 fn filter_4_for_palette_1() {
     test_it_converts(
         "tests/files/filter_4_for_palette_1.png",
-        4,
+        RowFilter::Paeth,
         ColorType::Indexed,
         BitDepth::One,
         ColorType::Indexed,
@@ -847,7 +847,7 @@ fn filter_4_for_palette_1() {
 fn filter_5_for_palette_1() {
     test_it_converts(
         "tests/files/filter_5_for_palette_1.png",
-        5,
+        RowFilter::MinSum,
         ColorType::Indexed,
         BitDepth::One,
         ColorType::Indexed,

--- a/tests/flags.rs
+++ b/tests/flags.rs
@@ -1,5 +1,5 @@
 use indexmap::IndexSet;
-use oxipng::internal_tests::*;
+use oxipng::{internal_tests::*, RowFilter};
 use oxipng::{InFile, OutFile};
 #[cfg(feature = "filetime")]
 use std::cell::RefCell;
@@ -16,7 +16,7 @@ fn get_opts(input: &Path) -> (OutFile, oxipng::Options) {
         ..Default::default()
     };
     let mut filter = IndexSet::new();
-    filter.insert(0);
+    filter.insert(RowFilter::None);
     options.filter = filter;
 
     (
@@ -173,7 +173,7 @@ fn verbose_mode() {
     assert_eq!(logs.len(), 1);
     logs.sort();
     for (i, log) in logs.into_iter().enumerate() {
-        let expected_prefix = format!("    zc = 11  f = 0 ");
+        let expected_prefix = format!("    zc = 11  f = None ");
         assert!(
             log.starts_with(&expected_prefix),
             "logs[{}] = {:?} doesn't start with {:?}",
@@ -454,7 +454,7 @@ fn interlaced_0_to_1_other_filter_mode() {
     let (output, mut opts) = get_opts(&input);
     opts.interlace = Some(1);
     let mut filter = IndexSet::new();
-    filter.insert(4);
+    filter.insert(RowFilter::Paeth);
     opts.filter = filter;
 
     let png = PngData::new(&input, opts.fix_errors).unwrap();

--- a/tests/interlaced.rs
+++ b/tests/interlaced.rs
@@ -1,5 +1,5 @@
 use indexmap::IndexSet;
-use oxipng::internal_tests::*;
+use oxipng::{internal_tests::*, RowFilter};
 use oxipng::{InFile, OutFile};
 use std::fs::remove_file;
 use std::path::Path;
@@ -11,7 +11,7 @@ fn get_opts(input: &Path) -> (OutFile, oxipng::Options) {
         ..Default::default()
     };
     let mut filter = IndexSet::new();
-    filter.insert(0);
+    filter.insert(RowFilter::None);
     options.filter = filter;
 
     (

--- a/tests/interlacing.rs
+++ b/tests/interlacing.rs
@@ -1,0 +1,202 @@
+use indexmap::IndexSet;
+use oxipng::{internal_tests::*, RowFilter};
+use oxipng::{InFile, OutFile};
+use std::fs::remove_file;
+use std::path::Path;
+use std::path::PathBuf;
+
+fn get_opts(input: &Path) -> (OutFile, oxipng::Options) {
+    let mut options = oxipng::Options {
+        force: true,
+        ..Default::default()
+    };
+    let mut filter = IndexSet::new();
+    filter.insert(RowFilter::None);
+    options.filter = filter;
+
+    (
+        OutFile::Path(Some(input.with_extension("out.png"))),
+        options,
+    )
+}
+
+fn test_it_converts(
+    input: &str,
+    interlace: u8,
+    color_type_in: ColorType,
+    bit_depth_in: BitDepth,
+    color_type_out: ColorType,
+    bit_depth_out: BitDepth,
+) {
+    let input = PathBuf::from(input);
+    let (output, mut opts) = get_opts(&input);
+    let png = PngData::new(&input, opts.fix_errors).unwrap();
+    opts.interlace = Some(interlace);
+    assert_eq!(png.raw.ihdr.color_type, color_type_in);
+    assert_eq!(png.raw.ihdr.bit_depth, bit_depth_in);
+    assert_eq!(png.raw.ihdr.interlaced, if interlace == 1 { 0 } else { 1 });
+
+    match oxipng::optimize(&InFile::Path(input), &output, &opts) {
+        Ok(_) => (),
+        Err(x) => panic!("{}", x),
+    };
+    let output = output.path().unwrap();
+    assert!(output.exists());
+
+    let png = match PngData::new(output, opts.fix_errors) {
+        Ok(x) => x,
+        Err(x) => {
+            remove_file(output).ok();
+            panic!("{}", x)
+        }
+    };
+
+    assert_eq!(png.raw.ihdr.color_type, color_type_out);
+    assert_eq!(png.raw.ihdr.bit_depth, bit_depth_out);
+
+    remove_file(output).ok();
+}
+
+#[test]
+fn deinterlace_rgb_16() {
+    test_it_converts(
+        "tests/files/interlaced_rgb_16_should_be_rgb_16.png",
+        0,
+        ColorType::RGB,
+        BitDepth::Sixteen,
+        ColorType::RGB,
+        BitDepth::Sixteen,
+    );
+}
+
+#[test]
+fn deinterlace_rgb_8() {
+    test_it_converts(
+        "tests/files/interlaced_rgb_8_should_be_rgb_8.png",
+        0,
+        ColorType::RGB,
+        BitDepth::Eight,
+        ColorType::RGB,
+        BitDepth::Eight,
+    );
+}
+
+#[test]
+fn deinterlace_palette_8() {
+    test_it_converts(
+        "tests/files/interlaced_palette_8_should_be_palette_8.png",
+        0,
+        ColorType::Indexed,
+        BitDepth::Eight,
+        ColorType::Indexed,
+        BitDepth::Eight,
+    );
+}
+
+#[test]
+fn deinterlace_palette_4() {
+    test_it_converts(
+        "tests/files/interlaced_palette_4_should_be_palette_4.png",
+        0,
+        ColorType::Indexed,
+        BitDepth::Four,
+        ColorType::Indexed,
+        BitDepth::Four,
+    );
+}
+
+#[test]
+fn deinterlace_palette_2() {
+    test_it_converts(
+        "tests/files/interlaced_palette_2_should_be_palette_2.png",
+        0,
+        ColorType::Indexed,
+        BitDepth::Two,
+        ColorType::Indexed,
+        BitDepth::Two,
+    );
+}
+
+#[test]
+fn deinterlace_palette_1() {
+    test_it_converts(
+        "tests/files/interlaced_palette_1_should_be_palette_1.png",
+        0,
+        ColorType::Indexed,
+        BitDepth::One,
+        ColorType::Indexed,
+        BitDepth::One,
+    );
+}
+
+#[test]
+fn interlace_rgb_16() {
+    test_it_converts(
+        "tests/files/rgb_16_should_be_rgb_16.png",
+        1,
+        ColorType::RGB,
+        BitDepth::Sixteen,
+        ColorType::RGB,
+        BitDepth::Sixteen,
+    );
+}
+
+#[test]
+fn interlace_rgb_8() {
+    test_it_converts(
+        "tests/files/rgb_8_should_be_rgb_8.png",
+        1,
+        ColorType::RGB,
+        BitDepth::Eight,
+        ColorType::RGB,
+        BitDepth::Eight,
+    );
+}
+
+#[test]
+fn interlace_palette_8() {
+    test_it_converts(
+        "tests/files/palette_8_should_be_palette_8.png",
+        1,
+        ColorType::Indexed,
+        BitDepth::Eight,
+        ColorType::Indexed,
+        BitDepth::Eight,
+    );
+}
+
+#[test]
+fn interlace_palette_4() {
+    test_it_converts(
+        "tests/files/palette_4_should_be_palette_4.png",
+        1,
+        ColorType::Indexed,
+        BitDepth::Four,
+        ColorType::Indexed,
+        BitDepth::Four,
+    );
+}
+
+#[test]
+fn interlace_palette_2() {
+    test_it_converts(
+        "tests/files/palette_2_should_be_palette_2.png",
+        1,
+        ColorType::Indexed,
+        BitDepth::Two,
+        ColorType::Indexed,
+        BitDepth::Two,
+    );
+}
+
+#[test]
+fn interlace_palette_1() {
+    test_it_converts(
+        "tests/files/palette_1_should_be_palette_1.png",
+        1,
+        ColorType::Indexed,
+        BitDepth::One,
+        ColorType::Indexed,
+        BitDepth::One,
+    );
+}

--- a/tests/reduction.rs
+++ b/tests/reduction.rs
@@ -1,5 +1,5 @@
 use indexmap::IndexSet;
-use oxipng::internal_tests::*;
+use oxipng::{internal_tests::*, RowFilter};
 use oxipng::{InFile, OutFile};
 use std::fs::remove_file;
 use std::path::Path;
@@ -11,7 +11,7 @@ fn get_opts(input: &Path) -> (OutFile, oxipng::Options) {
         ..Default::default()
     };
     let mut filter = IndexSet::new();
-    filter.insert(0);
+    filter.insert(RowFilter::None);
     options.filter = filter;
 
     (

--- a/tests/regression.rs
+++ b/tests/regression.rs
@@ -1,5 +1,5 @@
 use indexmap::IndexSet;
-use oxipng::internal_tests::*;
+use oxipng::{internal_tests::*, RowFilter};
 use oxipng::{InFile, OutFile};
 use std::fs::remove_file;
 use std::path::Path;
@@ -11,7 +11,7 @@ fn get_opts(input: &Path) -> (OutFile, oxipng::Options) {
         ..Default::default()
     };
     let mut filter = IndexSet::new();
-    filter.insert(0);
+    filter.insert(RowFilter::None);
     options.filter = filter;
 
     (
@@ -288,7 +288,7 @@ fn issue_92_filter_0() {
 fn issue_92_filter_5() {
     let input = "tests/files/issue-92.png";
     let (_, mut opts) = get_opts(Path::new(input));
-    opts.filter = [5].iter().cloned().collect();
+    opts.filter = [RowFilter::MinSum].iter().cloned().collect();
     let output = OutFile::Path(Some(Path::new(input).with_extension("-f5-out.png")));
 
     test_it_converts(

--- a/tests/strategies.rs
+++ b/tests/strategies.rs
@@ -1,0 +1,124 @@
+use indexmap::IndexSet;
+use oxipng::{internal_tests::*, RowFilter};
+use oxipng::{InFile, OutFile};
+use std::fs::remove_file;
+use std::path::Path;
+use std::path::PathBuf;
+
+fn get_opts(input: &Path) -> (OutFile, oxipng::Options) {
+    let mut options = oxipng::Options {
+        force: true,
+        ..Default::default()
+    };
+    let mut filter = IndexSet::new();
+    filter.insert(RowFilter::None);
+    options.filter = filter;
+
+    (
+        OutFile::Path(Some(input.with_extension("out.png"))),
+        options,
+    )
+}
+
+fn test_it_converts(
+    input: &str,
+    filter: RowFilter,
+    color_type_in: ColorType,
+    bit_depth_in: BitDepth,
+    color_type_out: ColorType,
+    bit_depth_out: BitDepth,
+) {
+    let input = PathBuf::from(input);
+
+    let (output, mut opts) = get_opts(&input);
+    let png = PngData::new(&input, opts.fix_errors).unwrap();
+    opts.filter = IndexSet::new();
+    opts.filter.insert(filter);
+    assert_eq!(png.raw.ihdr.color_type, color_type_in);
+    assert_eq!(png.raw.ihdr.bit_depth, bit_depth_in);
+
+    match oxipng::optimize(&InFile::Path(input), &output, &opts) {
+        Ok(_) => (),
+        Err(x) => panic!("{}", x),
+    };
+    let output = output.path().unwrap();
+    assert!(output.exists());
+
+    let png = match PngData::new(output, opts.fix_errors) {
+        Ok(x) => x,
+        Err(x) => {
+            remove_file(output).ok();
+            panic!("{}", x)
+        }
+    };
+
+    assert_eq!(png.raw.ihdr.color_type, color_type_out);
+    assert_eq!(png.raw.ihdr.bit_depth, bit_depth_out);
+    if let Some(palette) = png.raw.palette.as_ref() {
+        assert!(palette.len() <= 1 << (png.raw.ihdr.bit_depth.as_u8() as usize));
+    } else {
+        assert_ne!(png.raw.ihdr.color_type, ColorType::Indexed);
+    }
+
+    remove_file(output).ok();
+}
+
+#[test]
+fn filter_minsum() {
+    test_it_converts(
+        "tests/files/rgb_16_should_be_rgb_16.png",
+        RowFilter::MinSum,
+        ColorType::RGB,
+        BitDepth::Sixteen,
+        ColorType::RGB,
+        BitDepth::Sixteen,
+    );
+}
+
+#[test]
+fn filter_entropy() {
+    test_it_converts(
+        "tests/files/rgb_8_should_be_rgb_8.png",
+        RowFilter::Entropy,
+        ColorType::RGB,
+        BitDepth::Eight,
+        ColorType::RGB,
+        BitDepth::Eight,
+    );
+}
+
+#[test]
+fn filter_bigrams() {
+    test_it_converts(
+        "tests/files/rgba_8_should_be_rgba_8.png",
+        RowFilter::Bigrams,
+        ColorType::RGBA,
+        BitDepth::Eight,
+        ColorType::RGBA,
+        BitDepth::Eight,
+    );
+}
+
+#[test]
+fn filter_bigent() {
+    test_it_converts(
+        "tests/files/grayscale_8_should_be_grayscale_8.png",
+        RowFilter::BigEnt,
+        ColorType::Grayscale,
+        BitDepth::Eight,
+        ColorType::Grayscale,
+        BitDepth::Eight,
+    );
+}
+
+#[test]
+fn filter_brute() {
+    test_it_converts(
+        "tests/files/palette_8_should_be_palette_8.png",
+        RowFilter::Brute,
+        ColorType::Indexed,
+        BitDepth::Eight,
+        ColorType::Indexed,
+        BitDepth::Eight,
+    );
+}


### PR DESCRIPTION
This PR adds 4 new heuristic filter strategies. These are all generally better than the standard number 5 strategy (MinSum) and can save even more when combined together.
- 6: Shannon entropy algorithm, as seen in [LodePNG](https://github.com/lvandeve/lodepng)/Zopfli.
- 7: Count of distinct bigrams, as seen in [pngwolf](https://bjoern.hoehrmann.de/pngwolf/).
- 8: Shannon entropy of bigrams, inspired by the two above.
- 9: Brute force by compressing each filter on each line. This is currently configured to compress 4 lines at a time (the current filter attempt plus 3 previous lines to provide context). It's very effective and not as slow as one might expect, thanks to libdeflate's high-speed level 1.

Benchmarks on a set of test files with `-o4 -a -i0 -s`:
| Filters | Total size | Time | Filters | Total size | Time |
|-|-|-|-|-|-|
| 0,5 | 27572705 | 1:24 | 0,1,2,3,4,5 | 27411540 | 1:49 |
| 0,6 | 27404150 | 1:24 | 0,1,2,3,4,6 | 27321509 | 1:50 |
| 0,7 | 27376244 | 1:23 | 0,1,2,3,4,7 | 27292046 | 1:51 |
| 0,8 | 27406071 | 1:30 | 0,1,2,3,4,8 | 27305417 | 1:57 |
| 0,9 | 27348063 | 1:38 | 0,1,2,3,4,9 | 27170547 | 2:06 |
| | | | 0-9 | 27147885 | 3:29* |

*My machine has 8 threads, so using all 10 filters pushed me over my thread count.

Additional changes made in this PR:
- Filter types now use an enum, making it much easier to keep track of them all.
- The filter byte is included in the output from `filter_line`, which means this is included in all heuristic evaluations. This is how LodePNG does it with the entropy strategy, and I think it makes sense.
- [bit-vec](https://crates.io/crates/bit-vec) has been replaced with [bitvec](https://crates.io/crates/bitvec), which includes a fast bitset necessary for the bigrams strategy. As a bonus, reductions are now about 10% faster.
- [rustc-hash](https://crates.io/crates/rustc-hash) has been added, so the bigram entropy strategy can use the fast FxHasher (this strategy is still relatively slow though, I'm open to ideas about faster approaches that might be used). Color to palette reductions now also use this hasher for a 30% speed improvement.
- Additional tests added for changing interlacing, which helped me ensure the interlacing was correct when I replaced the bitvec.
- List of all filters shown in help.

Note that these filters are currently all opt-in. I will investigate including these in the default optimisation levels in future.

Closes #183