### PR TITLE
Dockerize Oxipng

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,8 @@ RUN rustup update 1.64 && rustup default 1.64
 
 RUN apk update \
     && apk add \
-        gcc
+        gcc \
+        g++
 
 RUN cd /src && cargo build --release
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,5 +15,6 @@ FROM alpine as tool
 
 COPY --from=base /src/target/release/oxipng /usr/local/bin
 
+WORKDIR /src
 ENTRYPOINT [ "oxipng" ]
 CMD [ "--help" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,18 @@
+FROM rust:alpine as base
+
+COPY . /src
+
+RUN rustup update 1.64 && rustup default 1.64
+
+RUN apk update \
+    && apk add \
+        gcc
+
+RUN cd /src && cargo build --release
+
+FROM alpine as tool
+
+COPY --from=base /src/target/release/oxipng /usr/local/bin
+
+ENTRYPOINT [ "oxipng" ]
+CMD [ "--help" ]


### PR DESCRIPTION
This Draft PR is not yet ready. It aims to dockerize `oxipng` so that system deps are self-contained in a docker image.
This ensures reproducibility and portability.