### PR TITLE
Refactor use_heuristics for fast filter evaluation

### DIFF
--- a/src/atomicmin.rs
+++ b/src/atomicmin.rs
@@ -27,7 +27,8 @@ impl AtomicMin {
         &self.val
     }
 
-    pub fn set_min(&self, new_val: usize) {
-        self.val.fetch_min(new_val, SeqCst);
+    /// Try a new value, returning true if it is the new minimum
+    pub fn set_min(&self, new_val: usize) -> bool {
+        new_val < self.val.fetch_min(new_val, SeqCst)
     }
 }

--- a/src/deflate/mod.rs
+++ b/src/deflate/mod.rs
@@ -1,5 +1,3 @@
-use indexmap::IndexSet;
-
 mod deflater;
 pub use deflater::crc32;
 pub use deflater::deflate;
@@ -17,8 +15,8 @@ pub use zopfli_oxipng::deflate as zopfli_deflate;
 pub enum Deflaters {
     /// Use libdeflater.
     Libdeflater {
-        /// Which compression levels to try on the file (1-12)
-        compression: IndexSet<u8>,
+        /// Which compression level to use on the file (1-12)
+        compression: u8,
     },
     #[cfg(feature = "zopfli")]
     /// Use the better but slower Zopfli implementation
@@ -29,3 +27,5 @@ pub enum Deflaters {
         iterations: NonZeroU8,
     },
 }
+
+impl Copy for Deflaters {}

--- a/src/deflate/mod.rs
+++ b/src/deflate/mod.rs
@@ -10,7 +10,7 @@ mod zopfli_oxipng;
 #[cfg(feature = "zopfli")]
 pub use zopfli_oxipng::deflate as zopfli_deflate;
 
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 /// DEFLATE algorithms supported by oxipng
 pub enum Deflaters {
     /// Use libdeflater.
@@ -27,5 +27,3 @@ pub enum Deflaters {
         iterations: NonZeroU8,
     },
 }
-
-impl Copy for Deflaters {}

--- a/src/evaluate.rs
+++ b/src/evaluate.rs
@@ -90,6 +90,11 @@ impl Evaluator {
         self.try_image_inner(image, false)
     }
 
+    /// Set best size, if known in advance
+    pub fn set_best_size(&self, size: usize) {
+        self.best_candidate_size.set_min(size);
+    }
+
     /// Check if the image is smaller than others
     pub fn try_image(&self, image: Arc<PngImage>) {
         self.try_image_inner(image, true)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -506,9 +506,9 @@ fn optimize_png(
         eval.set_baseline(png.raw.clone());
     }
     perform_reductions(png.raw.clone(), opts, &deadline, &eval);
-    let reduction_occurred = if let Some(result) = eval.get_result() {
-        *png = result;
-        true
+    let reduction_occurred = if let Some(result) = eval.get_best_candidate() {
+        *png = result.image;
+        result.is_reduction
     } else {
         false
     };
@@ -593,9 +593,11 @@ fn optimize_png(
                 opts.filter,
                 png.idat_data.len()
             );
-        } else if reduction_occurred {
+        } else {
             *png = original_png;
         }
+    } else if png.idat_data.len() > idat_original_size {
+        *png = original_png;
     }
 
     perform_strip(png, opts);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -192,12 +192,12 @@ pub struct Options {
     ///
     /// Default: `Libdeflater`
     pub deflate: Deflaters,
-    /// Whether to use heuristics to pick the best filter and compression
+    /// Whether to use fast evaluation to pick the best filter
     ///
     /// Intended for use with `-o 1` from the CLI interface
     ///
     /// Default: `false`
-    pub use_heuristics: bool,
+    pub fast_evaluation: bool,
 
     /// Maximum amount of time to spend on optimizations.
     /// Further potential optimizations are skipped if the timeout is exceeded.
@@ -234,7 +234,7 @@ impl Options {
         if let Deflaters::Libdeflater { compression } = &mut self.deflate {
             *compression = 5;
         }
-        self.use_heuristics = true;
+        self.fast_evaluation = true;
         self
     }
 
@@ -243,7 +243,7 @@ impl Options {
         if let Deflaters::Libdeflater { compression } = &mut self.deflate {
             *compression = 10;
         }
-        self.use_heuristics = true;
+        self.fast_evaluation = true;
         self
     }
 
@@ -295,7 +295,7 @@ impl Default for Options {
             idat_recoding: true,
             strip: Headers::None,
             deflate: Deflaters::Libdeflater { compression: 11 },
-            use_heuristics: false,
+            fast_evaluation: false,
             timeout: None,
         }
     }
@@ -446,6 +446,7 @@ struct TrialOptions {
     pub filter: RowFilter,
     pub compression: u8,
 }
+type TrialWithData = (TrialOptions, Vec<u8>);
 
 /// Perform optimization on the input PNG object using the options provided
 fn optimize_png(
@@ -454,8 +455,6 @@ fn optimize_png(
     opts: &Options,
     deadline: Arc<Deadline>,
 ) -> PngResult<Vec<u8>> {
-    type TrialWithData = (TrialOptions, Vec<u8>);
-
     let original_png = png.clone();
 
     // Print png info
@@ -482,102 +481,106 @@ fn optimize_png(
     info!("    IDAT size = {} bytes", idat_original_size);
     info!("    File size = {} bytes", file_original_size);
 
-    let mut filter = opts.filter.clone();
-
-    if filter.is_empty() {
-        // Heuristically determine which set of options to use
-        if png.raw.ihdr.bit_depth.as_u8() >= 8
-            && png.raw.ihdr.color_type != colors::ColorType::Indexed
-        {
-            filter.insert(RowFilter::MinSum);
-        } else {
-            filter.insert(RowFilter::None);
-        };
-    }
-
     // Must use normal (lazy) compression, as faster ones (greedy) are not representative
     let eval_compression = 5;
     let eval_filters = indexset! {RowFilter::None, RowFilter::MinSum};
     // This will collect all versions of images and pick one that compresses best
-    let eval = Evaluator::new(deadline.clone(), eval_filters, eval_compression);
+    let eval = Evaluator::new(deadline.clone(), eval_filters.clone(), eval_compression);
     perform_reductions(png.raw.clone(), opts, &deadline, &eval);
-    let reduction_occurred = if let Some(result) = eval.get_best_candidate() {
+    let (reduction_occurred, mut eval_filter) = if let Some(result) = eval.get_best_candidate() {
         *png = result.image;
-        result.is_reduction
+        (result.is_reduction, Some(result.filter))
     } else {
-        false
+        (false, None)
     };
 
     if opts.idat_recoding || reduction_occurred {
-        // Go through selected permutations and determine the best
-        let mut results: Vec<TrialOptions> = Vec::with_capacity(filter.len());
+        let mut filters = opts.filter.clone();
+        let fast_eval = opts.fast_evaluation && (filters.len() > 1 || eval_filter.is_some());
+        let best: Option<TrialWithData> = if fast_eval {
+            // Perform a fast evaluation of selected filters followed by a single main compression trial
+            if eval_filter.is_some() {
+                // Some filters have already been evaluated, we don't need to try them again
+                filters = filters.difference(&eval_filters).cloned().collect();
+            }
 
-        for f in &filter {
-            results.push(TrialOptions {
-                filter: *f,
+            if !filters.is_empty() {
+                debug!("Evaluating: {} filters", filters.len());
+                let eval = Evaluator::new(deadline, filters, eval_compression);
+                if eval_filter.is_some() {
+                    eval.set_best_size(png.idat_data.len());
+                }
+                eval.try_image(png.raw.clone());
+                if let Some(result) = eval.get_best_candidate() {
+                    *png = result.image;
+                    eval_filter = Some(result.filter);
+                }
+            }
+
+            let trial = TrialOptions {
+                filter: eval_filter.unwrap(),
                 compression: match opts.deflate {
                     Deflaters::Libdeflater { compression } => compression,
                     _ => 0,
                 },
-            });
-        }
-
-        info!("Trying: {} combinations", results.len());
-
-        let original_len = original_png.idat_data.len();
-        let added_interlacing = opts.interlace == Some(1) && original_png.raw.ihdr.interlaced == 0;
-
-        let best_size = AtomicMin::new(if opts.force { None } else { Some(original_len) });
-        let results_iter = results.into_par_iter().with_max_len(1);
-        let best = results_iter.filter_map(|trial| {
-            if deadline.passed() {
-                return None;
-            }
-            let filtered = &png.raw.filter_image(trial.filter);
-            let new_idat = match opts.deflate {
-                Deflaters::Libdeflater { .. } => {
-                    deflate::deflate(filtered, trial.compression, &best_size)
-                }
-                #[cfg(feature = "zopfli")]
-                Deflaters::Zopfli { iterations } => deflate::zopfli_deflate(filtered, iterations),
             };
+            if trial.compression <= eval_compression {
+                // No further compression required
+                if png.idat_data.len() < idat_original_size || opts.force {
+                    Some((trial, png.idat_data.clone()))
+                } else {
+                    None
+                }
+            } else {
+                info!("Trying: {}", trial.filter);
+                let original_len = idat_original_size;
+                let best_size = AtomicMin::new(if opts.force { None } else { Some(original_len) });
+                perform_trial(&png.raw, opts, trial, &best_size)
+            }
+        } else {
+            // Perform full compression trials of selected filters and determine the best
+            if filters.is_empty() {
+                // Heuristically determine which filter to use
+                if png.raw.ihdr.bit_depth.as_u8() >= 8
+                    && png.raw.ihdr.color_type != colors::ColorType::Indexed
+                {
+                    filters.insert(RowFilter::MinSum);
+                } else {
+                    filters.insert(RowFilter::None);
+                }
+            }
 
-            let new_idat = match new_idat {
-                Ok(n) => n,
-                Err(PngError::DeflatedDataTooLong(max)) => {
-                    debug!(
-                        "    zc = {}  f = {} >{} bytes",
-                        trial.compression, trial.filter, max,
-                    );
+            let mut results: Vec<TrialOptions> = Vec::with_capacity(filters.len());
+
+            for f in &filters {
+                results.push(TrialOptions {
+                    filter: *f,
+                    compression: match opts.deflate {
+                        Deflaters::Libdeflater { compression } => compression,
+                        _ => 0,
+                    },
+                });
+            }
+
+            info!("Trying: {} filters", results.len());
+
+            let original_len = idat_original_size;
+            let best_size = AtomicMin::new(if opts.force { None } else { Some(original_len) });
+            let results_iter = results.into_par_iter().with_max_len(1);
+            let best = results_iter.filter_map(|trial| {
+                if deadline.passed() {
                     return None;
                 }
-                Err(_) => return None,
-            };
-
-            // update best size across all threads
-            let new_size = new_idat.len();
-            best_size.set_min(new_size);
-
-            debug!(
-                "    zc = {}  f = {}  {} bytes",
-                trial.compression,
-                trial.filter,
-                new_idat.len()
-            );
-
-            if new_size < original_len || added_interlacing || opts.force {
-                Some((trial, new_idat))
-            } else {
-                None
-            }
-        });
-        let best: Option<TrialWithData> = best.reduce_with(|i, j| {
-            if i.1.len() < j.1.len() || (i.1.len() == j.1.len() && i.0 < j.0) {
-                i
-            } else {
-                j
-            }
-        });
+                perform_trial(&png.raw, opts, trial, &best_size)
+            });
+            best.reduce_with(|i, j| {
+                if i.1.len() < j.1.len() || (i.1.len() == j.1.len() && i.0 < j.0) {
+                    i
+                } else {
+                    j
+                }
+            })
+        };
 
         if let Some((opts, idat_data)) = best {
             png.idat_data = idat_data;
@@ -588,10 +591,10 @@ fn optimize_png(
                 opts.filter,
                 png.idat_data.len()
             );
-        } else {
+        } else if eval_filter.is_some() {
             *png = original_png;
         }
-    } else if png.idat_data.len() > idat_original_size {
+    } else if png.idat_data.len() >= idat_original_size {
         *png = original_png;
     }
 
@@ -729,6 +732,46 @@ fn perform_reductions(
         if reduction_occurred {
             eval.set_baseline(baseline);
         }
+    }
+}
+
+/// Execute a compression trial
+fn perform_trial(
+    png: &PngImage,
+    opts: &Options,
+    trial: TrialOptions,
+    best_size: &AtomicMin,
+) -> Option<TrialWithData> {
+    let filtered = &png.filter_image(trial.filter);
+    let new_idat = match opts.deflate {
+        Deflaters::Libdeflater { .. } => deflate::deflate(filtered, trial.compression, best_size),
+        #[cfg(feature = "zopfli")]
+        Deflaters::Zopfli { iterations } => deflate::zopfli_deflate(filtered, iterations),
+    };
+
+    // update best size or convert to error if not smaller
+    let new_idat = match new_idat {
+        Ok(n) if !best_size.set_min(n.len()) => Err(PngError::DeflatedDataTooLong(n.len())),
+        _ => new_idat,
+    };
+
+    match new_idat {
+        Ok(n) => {
+            let bytes = n.len();
+            debug!(
+                "    zc = {}  f = {}  {} bytes",
+                trial.compression, trial.filter, bytes
+            );
+            Some((trial, n))
+        }
+        Err(PngError::DeflatedDataTooLong(bytes)) => {
+            debug!(
+                "    zc = {}  f = {} >{} bytes",
+                trial.compression, trial.filter, bytes,
+            );
+            None
+        }
+        Err(_) => None,
     }
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -184,14 +184,11 @@ fn main() {
         )
         .arg(
             Arg::new("compression")
-                .help("zlib compression levels (1-12) - Default: 12")
+                .help("zlib compression level (1-12) - Default: 11")
                 .long("zc")
                 .takes_value(true)
-                .value_name("levels")
-                .validator(|x| match parse_numeric_range_opts(x, 1, 12) {
-                    Ok(_) => Ok(()),
-                    Err(_) => Err("Invalid option for compression".to_owned()),
-                })
+                .value_name("level")
+                .value_parser(1..=12)
                 .conflicts_with("zopfli"),
         )
         .arg(
@@ -541,8 +538,8 @@ fn parse_opts_into_struct(
             opts.deflate = Deflaters::Zopfli { iterations };
         }
     } else if let Deflaters::Libdeflater { compression } = &mut opts.deflate {
-        if let Some(x) = matches.value_of("compression") {
-            *compression = parse_numeric_range_opts(x, 1, 12).unwrap();
+        if let Some(x) = matches.get_one::<i64>("compression") {
+            *compression = *x as u8;
         }
     }
 


### PR DESCRIPTION
This PR is an intermediary step between the introduction of new filters in #461 and a future rebalancing of optimisation levels.

This is all about improving speed, including new fast filter evaluation (similar to #185).
1. The ability to set multiple compression levels has been removed. In my experience, this was highly ineffective (like saving 5 bytes in 20MB) and removing it allowed some helpful simplifications which are relevant here. E.g. filtering is now done within the trial loop rather than beforehand, which possibly helps with performance a little. The change does mean that levels 5 and 6 are currently equivalent to 4, but the intention is to adjust these later to use the new filter strategies (which *are* effective). This isn't strictly necessary though, so could be reverted if you'd prefer to keep this ability.
2. The baseline evaluator trial now passes right through the evaluator and may be selected as the best result (but will be flagged as non-reduction). This has two immediate, though minor, effects: Firstly, if there are no other compression trials and the compressed baseline happened to be smaller than the original, it can be output directly rather than always reverting to the original. Secondly, it fixes an issue of non-determinism where if a reduction evaluation happened to complete *before* the baseline, but the baseline evaluation was actually smaller, the reduction would still be chosen for the output.
3. The baseline will only be set if any reductions are being attempted. This means that if there are no reductions, no work is actually done during the evaluation step, resulting in a helpful speed boost. Additionally, this fixes an issue where the baseline was never set if the interlacing flag was used, even if the interlacing didn't actually change.
4. The evaluator compression level and filters are now passed into the constructor, rather than being fixed constants.
5. The `use_heuristics` option is now `fast_evaluate` and switches into a different path for compression trials. This will take the output of the reduction evaluation, combine it with a similar evaluation of any additional filters (ones that weren't tested in reduction), and then perform a single main compression trial with the best filter. This is much faster and is more effective when only one filter was originally selected because it still actually has two filter results to compare if reductions were attempted. It is slightly less effective for multiple filters, though this doesn't currently affect any of the default levels. Additionally, if the specified compression level matches the one used for evaluations (as it does with o0), it can just output the evaluation result directly.

Here are some results from a set of sample images (original size 42955740):

| options | master size | master time | PR size | PR time |
|-|-|-|-|-|
| -o0 | 41229590 | 9.9s | 40993901 | 6.5s |
| -o1 | 32062204 | 36.3s | 31885429 | 33.1s |
| -o2 | 30405937 | 54.3s | 30405937 | 51.7s |
| -o1 -f0-5 | 30288484 | 47.0s | 30313128 | 36.8s |

- o0 is slightly more effective because filters 0 and 5 are both always tested in reductions. It is much faster because the baseline isn't being tested when there are no reductions, and because it doesn't actually do any compression trials.
- o1 is much the same, though doesn't get the same speed boost as it still has to do a compression trial.
- o2 is unchanged in size because it doesn't set the `fast_evaluate` option, but still receives some of the speed benefits.
- o1 with additional filters is slightly less effective because the filters are using the fast evaluation, but is of course much faster.

Things that didn't make the cut:
- I wanted to keep the filtered idat data from the evaluator so it didn't have to be refiltered for the compression trial but it would only be a small improvement and I decided it wasn't worth the additional refactoring that would be necessary. Maybe another time.
- I spent a *lot* of time testing faster evaluator settings, similar to #188, but ultimately decided to leave them as is.

Apologies for the long PR, I hope this is all helpful :)


Closes #185.
(Should probably close #188 as well.)