### PR TITLE
Tweaks to interlacing and format display

### DIFF
--- a/benches/interlacing.rs
+++ b/benches/interlacing.rs
@@ -3,7 +3,7 @@
 extern crate oxipng;
 extern crate test;
 
-use oxipng::internal_tests::*;
+use oxipng::{internal_tests::*, Interlacing};
 use std::path::PathBuf;
 use test::Bencher;
 
@@ -12,7 +12,7 @@ fn interlacing_16_bits(b: &mut Bencher) {
     let input = test::black_box(PathBuf::from("tests/files/rgb_16_should_be_rgb_16.png"));
     let png = PngData::new(&input, false).unwrap();
 
-    b.iter(|| png.raw.change_interlacing(1));
+    b.iter(|| png.raw.change_interlacing(Interlacing::Adam7));
 }
 
 #[bench]
@@ -20,7 +20,7 @@ fn interlacing_8_bits(b: &mut Bencher) {
     let input = test::black_box(PathBuf::from("tests/files/rgb_8_should_be_rgb_8.png"));
     let png = PngData::new(&input, false).unwrap();
 
-    b.iter(|| png.raw.change_interlacing(1));
+    b.iter(|| png.raw.change_interlacing(Interlacing::Adam7));
 }
 
 #[bench]
@@ -30,7 +30,7 @@ fn interlacing_4_bits(b: &mut Bencher) {
     ));
     let png = PngData::new(&input, false).unwrap();
 
-    b.iter(|| png.raw.change_interlacing(1));
+    b.iter(|| png.raw.change_interlacing(Interlacing::Adam7));
 }
 
 #[bench]
@@ -40,7 +40,7 @@ fn interlacing_2_bits(b: &mut Bencher) {
     ));
     let png = PngData::new(&input, false).unwrap();
 
-    b.iter(|| png.raw.change_interlacing(1));
+    b.iter(|| png.raw.change_interlacing(Interlacing::Adam7));
 }
 
 #[bench]
@@ -50,7 +50,7 @@ fn interlacing_1_bits(b: &mut Bencher) {
     ));
     let png = PngData::new(&input, false).unwrap();
 
-    b.iter(|| png.raw.change_interlacing(1));
+    b.iter(|| png.raw.change_interlacing(Interlacing::Adam7));
 }
 
 #[bench]
@@ -60,7 +60,7 @@ fn deinterlacing_16_bits(b: &mut Bencher) {
     ));
     let png = PngData::new(&input, false).unwrap();
 
-    b.iter(|| png.raw.change_interlacing(0));
+    b.iter(|| png.raw.change_interlacing(Interlacing::None));
 }
 
 #[bench]
@@ -70,7 +70,7 @@ fn deinterlacing_8_bits(b: &mut Bencher) {
     ));
     let png = PngData::new(&input, false).unwrap();
 
-    b.iter(|| png.raw.change_interlacing(0));
+    b.iter(|| png.raw.change_interlacing(Interlacing::None));
 }
 
 #[bench]
@@ -80,7 +80,7 @@ fn deinterlacing_4_bits(b: &mut Bencher) {
     ));
     let png = PngData::new(&input, false).unwrap();
 
-    b.iter(|| png.raw.change_interlacing(0));
+    b.iter(|| png.raw.change_interlacing(Interlacing::None));
 }
 
 #[bench]
@@ -90,7 +90,7 @@ fn deinterlacing_2_bits(b: &mut Bencher) {
     ));
     let png = PngData::new(&input, false).unwrap();
 
-    b.iter(|| png.raw.change_interlacing(0));
+    b.iter(|| png.raw.change_interlacing(Interlacing::None));
 }
 
 #[bench]
@@ -100,5 +100,5 @@ fn deinterlacing_1_bits(b: &mut Bencher) {
     ));
     let png = PngData::new(&input, false).unwrap();
 
-    b.iter(|| png.raw.change_interlacing(0));
+    b.iter(|| png.raw.change_interlacing(Interlacing::None));
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -46,6 +46,7 @@ pub use crate::deflate::Deflaters;
 pub use crate::error::PngError;
 pub use crate::filters::RowFilter;
 pub use crate::headers::Headers;
+pub use crate::interlace::Interlacing;
 pub use indexmap::{indexset, IndexMap, IndexSet};
 
 mod atomicmin;
@@ -157,7 +158,7 @@ pub struct Options {
     /// `Some(x)` will change the file to interlacing mode `x`.
     ///
     /// Default: `None`
-    pub interlace: Option<u8>,
+    pub interlace: Option<Interlacing>,
     /// Whether to allow transparent pixels to be altered to improve compression.
     pub optimize_alpha: bool,
     /// Whether to attempt bit depth reduction

--- a/src/main.rs
+++ b/src/main.rs
@@ -393,13 +393,13 @@ fn parse_opts_into_struct(
     };
 
     if let Some(x) = matches.value_of("interlace") {
-        opts.interlace = x.parse::<u8>().ok();
+        opts.interlace = x.parse::<u8>().unwrap().try_into().ok();
     }
 
     if let Some(x) = matches.value_of("filters") {
         opts.filter.clear();
         for f in parse_numeric_range_opts(x, 0, RowFilter::LAST).unwrap() {
-            opts.filter.insert(RowFilter::try_from(f).unwrap());
+            opts.filter.insert(f.try_into().unwrap());
         }
     }
 

--- a/src/png/scan_lines.rs
+++ b/src/png/scan_lines.rs
@@ -1,3 +1,4 @@
+use crate::interlace::Interlacing;
 use crate::png::PngImage;
 
 /// An iterator over the scan lines of a PNG image
@@ -79,7 +80,7 @@ impl ScanLineRanges {
             width: png.ihdr.width,
             height: png.ihdr.height,
             left: png.data.len(),
-            pass: if png.ihdr.interlaced == 1 {
+            pass: if png.ihdr.interlaced == Interlacing::Adam7 {
                 Some((1, 0))
             } else {
                 None

--- a/tests/flags.rs
+++ b/tests/flags.rs
@@ -1,5 +1,5 @@
 use indexmap::IndexSet;
-use oxipng::{internal_tests::*, RowFilter};
+use oxipng::{internal_tests::*, Interlacing, RowFilter};
 use oxipng::{InFile, OutFile};
 #[cfg(feature = "filetime")]
 use std::cell::RefCell;
@@ -324,11 +324,11 @@ fn strip_headers_none() {
 fn interlacing_0_to_1() {
     let input = PathBuf::from("tests/files/interlacing_0_to_1.png");
     let (output, mut opts) = get_opts(&input);
-    opts.interlace = Some(1);
+    opts.interlace = Some(Interlacing::Adam7);
 
     let png = PngData::new(&input, opts.fix_errors).unwrap();
 
-    assert_eq!(png.raw.ihdr.interlaced, 0);
+    assert_eq!(png.raw.ihdr.interlaced, Interlacing::None);
 
     match oxipng::optimize(&InFile::Path(input), &output, &opts) {
         Ok(_) => (),
@@ -345,7 +345,7 @@ fn interlacing_0_to_1() {
         }
     };
 
-    assert_eq!(png.raw.ihdr.interlaced, 1);
+    assert_eq!(png.raw.ihdr.interlaced, Interlacing::Adam7);
 
     remove_file(output).ok();
 }
@@ -354,11 +354,11 @@ fn interlacing_0_to_1() {
 fn interlacing_1_to_0() {
     let input = PathBuf::from("tests/files/interlacing_1_to_0.png");
     let (output, mut opts) = get_opts(&input);
-    opts.interlace = Some(0);
+    opts.interlace = Some(Interlacing::None);
 
     let png = PngData::new(&input, opts.fix_errors).unwrap();
 
-    assert_eq!(png.raw.ihdr.interlaced, 1);
+    assert_eq!(png.raw.ihdr.interlaced, Interlacing::Adam7);
 
     match oxipng::optimize(&InFile::Path(input), &output, &opts) {
         Ok(_) => (),
@@ -375,7 +375,7 @@ fn interlacing_1_to_0() {
         }
     };
 
-    assert_eq!(png.raw.ihdr.interlaced, 0);
+    assert_eq!(png.raw.ihdr.interlaced, Interlacing::None);
 
     remove_file(output).ok();
 }
@@ -384,11 +384,11 @@ fn interlacing_1_to_0() {
 fn interlacing_0_to_1_small_files() {
     let input = PathBuf::from("tests/files/interlacing_0_to_1_small_files.png");
     let (output, mut opts) = get_opts(&input);
-    opts.interlace = Some(1);
+    opts.interlace = Some(Interlacing::Adam7);
 
     let png = PngData::new(&input, opts.fix_errors).unwrap();
 
-    assert_eq!(png.raw.ihdr.interlaced, 0);
+    assert_eq!(png.raw.ihdr.interlaced, Interlacing::None);
     assert_eq!(png.raw.ihdr.color_type, ColorType::Indexed);
     assert_eq!(png.raw.ihdr.bit_depth, BitDepth::Eight);
 
@@ -407,7 +407,7 @@ fn interlacing_0_to_1_small_files() {
         }
     };
 
-    assert_eq!(png.raw.ihdr.interlaced, 1);
+    assert_eq!(png.raw.ihdr.interlaced, Interlacing::Adam7);
     assert_eq!(png.raw.ihdr.color_type, ColorType::Indexed);
     assert_eq!(png.raw.ihdr.bit_depth, BitDepth::One);
 
@@ -418,11 +418,11 @@ fn interlacing_0_to_1_small_files() {
 fn interlacing_1_to_0_small_files() {
     let input = PathBuf::from("tests/files/interlacing_1_to_0_small_files.png");
     let (output, mut opts) = get_opts(&input);
-    opts.interlace = Some(0);
+    opts.interlace = Some(Interlacing::None);
 
     let png = PngData::new(&input, opts.fix_errors).unwrap();
 
-    assert_eq!(png.raw.ihdr.interlaced, 1);
+    assert_eq!(png.raw.ihdr.interlaced, Interlacing::Adam7);
     assert_eq!(png.raw.ihdr.color_type, ColorType::Indexed);
     assert_eq!(png.raw.ihdr.bit_depth, BitDepth::Eight);
 
@@ -441,7 +441,7 @@ fn interlacing_1_to_0_small_files() {
         }
     };
 
-    assert_eq!(png.raw.ihdr.interlaced, 0);
+    assert_eq!(png.raw.ihdr.interlaced, Interlacing::None);
     assert_eq!(png.raw.ihdr.color_type, ColorType::Indexed);
     // the depth can't be asserted reliably, because on such small file different zlib implementations pick different depth as the best
 
@@ -452,14 +452,14 @@ fn interlacing_1_to_0_small_files() {
 fn interlaced_0_to_1_other_filter_mode() {
     let input = PathBuf::from("tests/files/interlaced_0_to_1_other_filter_mode.png");
     let (output, mut opts) = get_opts(&input);
-    opts.interlace = Some(1);
+    opts.interlace = Some(Interlacing::Adam7);
     let mut filter = IndexSet::new();
     filter.insert(RowFilter::Paeth);
     opts.filter = filter;
 
     let png = PngData::new(&input, opts.fix_errors).unwrap();
 
-    assert_eq!(png.raw.ihdr.interlaced, 0);
+    assert_eq!(png.raw.ihdr.interlaced, Interlacing::None);
 
     match oxipng::optimize(&InFile::Path(input), &output, &opts) {
         Ok(_) => (),
@@ -476,7 +476,7 @@ fn interlaced_0_to_1_other_filter_mode() {
         }
     };
 
-    assert_eq!(png.raw.ihdr.interlaced, 1);
+    assert_eq!(png.raw.ihdr.interlaced, Interlacing::Adam7);
 
     remove_file(output).ok();
 }

--- a/tests/interlaced.rs
+++ b/tests/interlaced.rs
@@ -1,5 +1,5 @@
 use indexmap::IndexSet;
-use oxipng::{internal_tests::*, RowFilter};
+use oxipng::{internal_tests::*, Interlacing, RowFilter};
 use oxipng::{InFile, OutFile};
 use std::fs::remove_file;
 use std::path::Path;
@@ -33,7 +33,7 @@ fn test_it_converts(
 
     assert_eq!(png.raw.ihdr.color_type, color_type_in);
     assert_eq!(png.raw.ihdr.bit_depth, bit_depth_in);
-    assert_eq!(png.raw.ihdr.interlaced, 1);
+    assert_eq!(png.raw.ihdr.interlaced, Interlacing::Adam7);
 
     match oxipng::optimize(&InFile::Path(input), &output, &opts) {
         Ok(_) => (),

--- a/tests/interlacing.rs
+++ b/tests/interlacing.rs
@@ -1,5 +1,5 @@
 use indexmap::IndexSet;
-use oxipng::{internal_tests::*, RowFilter};
+use oxipng::{internal_tests::*, Interlacing, RowFilter};
 use oxipng::{InFile, OutFile};
 use std::fs::remove_file;
 use std::path::Path;
@@ -22,7 +22,7 @@ fn get_opts(input: &Path) -> (OutFile, oxipng::Options) {
 
 fn test_it_converts(
     input: &str,
-    interlace: u8,
+    interlace: Interlacing,
     color_type_in: ColorType,
     bit_depth_in: BitDepth,
     color_type_out: ColorType,
@@ -34,7 +34,14 @@ fn test_it_converts(
     opts.interlace = Some(interlace);
     assert_eq!(png.raw.ihdr.color_type, color_type_in);
     assert_eq!(png.raw.ihdr.bit_depth, bit_depth_in);
-    assert_eq!(png.raw.ihdr.interlaced, if interlace == 1 { 0 } else { 1 });
+    assert_eq!(
+        png.raw.ihdr.interlaced,
+        if interlace == Interlacing::Adam7 {
+            Interlacing::None
+        } else {
+            Interlacing::Adam7
+        }
+    );
 
     match oxipng::optimize(&InFile::Path(input), &output, &opts) {
         Ok(_) => (),
@@ -61,7 +68,7 @@ fn test_it_converts(
 fn deinterlace_rgb_16() {
     test_it_converts(
         "tests/files/interlaced_rgb_16_should_be_rgb_16.png",
-        0,
+        Interlacing::None,
         ColorType::RGB,
         BitDepth::Sixteen,
         ColorType::RGB,
@@ -73,7 +80,7 @@ fn deinterlace_rgb_16() {
 fn deinterlace_rgb_8() {
     test_it_converts(
         "tests/files/interlaced_rgb_8_should_be_rgb_8.png",
-        0,
+        Interlacing::None,
         ColorType::RGB,
         BitDepth::Eight,
         ColorType::RGB,
@@ -85,7 +92,7 @@ fn deinterlace_rgb_8() {
 fn deinterlace_palette_8() {
     test_it_converts(
         "tests/files/interlaced_palette_8_should_be_palette_8.png",
-        0,
+        Interlacing::None,
         ColorType::Indexed,
         BitDepth::Eight,
         ColorType::Indexed,
@@ -97,7 +104,7 @@ fn deinterlace_palette_8() {
 fn deinterlace_palette_4() {
     test_it_converts(
         "tests/files/interlaced_palette_4_should_be_palette_4.png",
-        0,
+        Interlacing::None,
         ColorType::Indexed,
         BitDepth::Four,
         ColorType::Indexed,
@@ -109,7 +116,7 @@ fn deinterlace_palette_4() {
 fn deinterlace_palette_2() {
     test_it_converts(
         "tests/files/interlaced_palette_2_should_be_palette_2.png",
-        0,
+        Interlacing::None,
         ColorType::Indexed,
         BitDepth::Two,
         ColorType::Indexed,
@@ -121,7 +128,7 @@ fn deinterlace_palette_2() {
 fn deinterlace_palette_1() {
     test_it_converts(
         "tests/files/interlaced_palette_1_should_be_palette_1.png",
-        0,
+        Interlacing::None,
         ColorType::Indexed,
         BitDepth::One,
         ColorType::Indexed,
@@ -133,7 +140,7 @@ fn deinterlace_palette_1() {
 fn interlace_rgb_16() {
     test_it_converts(
         "tests/files/rgb_16_should_be_rgb_16.png",
-        1,
+        Interlacing::Adam7,
         ColorType::RGB,
         BitDepth::Sixteen,
         ColorType::RGB,
@@ -145,7 +152,7 @@ fn interlace_rgb_16() {
 fn interlace_rgb_8() {
     test_it_converts(
         "tests/files/rgb_8_should_be_rgb_8.png",
-        1,
+        Interlacing::Adam7,
         ColorType::RGB,
         BitDepth::Eight,
         ColorType::RGB,
@@ -157,7 +164,7 @@ fn interlace_rgb_8() {
 fn interlace_palette_8() {
     test_it_converts(
         "tests/files/palette_8_should_be_palette_8.png",
-        1,
+        Interlacing::Adam7,
         ColorType::Indexed,
         BitDepth::Eight,
         ColorType::Indexed,
@@ -169,7 +176,7 @@ fn interlace_palette_8() {
 fn interlace_palette_4() {
     test_it_converts(
         "tests/files/palette_4_should_be_palette_4.png",
-        1,
+        Interlacing::Adam7,
         ColorType::Indexed,
         BitDepth::Four,
         ColorType::Indexed,
@@ -181,7 +188,7 @@ fn interlace_palette_4() {
 fn interlace_palette_2() {
     test_it_converts(
         "tests/files/palette_2_should_be_palette_2.png",
-        1,
+        Interlacing::Adam7,
         ColorType::Indexed,
         BitDepth::Two,
         ColorType::Indexed,
@@ -193,7 +200,7 @@ fn interlace_palette_2() {
 fn interlace_palette_1() {
     test_it_converts(
         "tests/files/palette_1_should_be_palette_1.png",
-        1,
+        Interlacing::Adam7,
         ColorType::Indexed,
         BitDepth::One,
         ColorType::Indexed,

--- a/tests/reduction.rs
+++ b/tests/reduction.rs
@@ -1,5 +1,5 @@
 use indexmap::IndexSet;
-use oxipng::{internal_tests::*, RowFilter};
+use oxipng::{internal_tests::*, Interlacing, RowFilter};
 use oxipng::{InFile, OutFile};
 use std::fs::remove_file;
 use std::path::Path;
@@ -35,7 +35,7 @@ fn test_it_converts(
 
     assert_eq!(png.raw.ihdr.color_type, color_type_in);
     assert_eq!(png.raw.ihdr.bit_depth, bit_depth_in, "test file is broken");
-    assert_eq!(png.raw.ihdr.interlaced, 0);
+    assert_eq!(png.raw.ihdr.interlaced, Interlacing::None);
 
     match oxipng::optimize(&InFile::Path(input), &output, &opts) {
         Ok(_) => (),

--- a/tests/regression.rs
+++ b/tests/regression.rs
@@ -1,5 +1,5 @@
 use indexmap::IndexSet;
-use oxipng::{internal_tests::*, RowFilter};
+use oxipng::{internal_tests::*, Interlacing, RowFilter};
 use oxipng::{InFile, OutFile};
 use std::fs::remove_file;
 use std::path::Path;
@@ -92,11 +92,11 @@ fn issue_29() {
 fn issue_42() {
     let input = PathBuf::from("tests/files/issue_42.png");
     let (output, mut opts) = get_opts(&input);
-    opts.interlace = Some(1);
+    opts.interlace = Some(Interlacing::Adam7);
 
     let png = PngData::new(&input, opts.fix_errors).unwrap();
 
-    assert_eq!(png.raw.ihdr.interlaced, 0);
+    assert_eq!(png.raw.ihdr.interlaced, Interlacing::None);
     assert_eq!(png.raw.ihdr.color_type, ColorType::GrayscaleAlpha);
     assert_eq!(png.raw.ihdr.bit_depth, BitDepth::Eight);
 
@@ -115,7 +115,7 @@ fn issue_42() {
         }
     };
 
-    assert_eq!(png.raw.ihdr.interlaced, 1);
+    assert_eq!(png.raw.ihdr.interlaced, Interlacing::Adam7);
     assert_eq!(png.raw.ihdr.color_type, ColorType::GrayscaleAlpha);
     assert_eq!(png.raw.ihdr.bit_depth, BitDepth::Eight);
 
@@ -311,7 +311,7 @@ fn issue_92_filter_5() {
 fn issue_113() {
     let input = "tests/files/issue-113.png";
     let (output, mut opts) = get_opts(Path::new(input));
-    opts.interlace = Some(1);
+    opts.interlace = Some(Interlacing::Adam7);
     opts.optimize_alpha = true;
     test_it_converts(
         input,
@@ -440,7 +440,7 @@ fn issue_175() {
 fn issue_182() {
     let input = "tests/files/issue-182.png";
     let (output, mut opts) = get_opts(Path::new(input));
-    opts.interlace = Some(0);
+    opts.interlace = Some(Interlacing::Adam7);
 
     test_it_converts(
         input,


### PR DESCRIPTION
This makes a few changes to the way interlacing is handled and how reductions are reported:
- Interlacing uses an enum (fixes #403).
- Interlacing is performed prior to running the reduction evaluator. This was never evaluated against the baseline so it could happen that the evaluator ended up with only one trial in it, which of course doesn't serve any purpose. So we should see some speed improvement for images where no other reductions occur.
- Interlacing is shown when printing the format (fixes #271).
- Reduction reporting will only be done once, if any reductions occur. Previously you might see multiple "Reducing image to..." lines, which wouldn't necessarily be correct either if the evaluator ended up choosing the baseline.