### PR TITLE
Fix reduction reporting

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -509,7 +509,9 @@ fn optimize_png(
     perform_reductions(png.raw.clone(), opts, &deadline, &eval);
     let mut eval_filter = if let Some(result) = eval.get_best_candidate() {
         *png = result.image;
-        reduction_occurred = true;
+        if result.is_reduction {
+            reduction_occurred = true;
+        }
         Some(result.filter)
     } else {
         None

--- a/src/reduction/bit_depth.rs
+++ b/src/reduction/bit_depth.rs
@@ -73,7 +73,6 @@ pub fn reduce_bit_depth_8_or_less(png: &PngImage, mut minimum_bits: usize) -> Op
         }
     } else {
         // Checking for grayscale depth reduction is quite different than for indexed
-        // Note: In rare cases, padding bits in the data may cause this to incorrectly return None
         let mut mask = (1 << minimum_bits) - 1;
         let mut divisions = 1..(bit_depth / minimum_bits);
         for &b in &png.data {

--- a/tests/regression.rs
+++ b/tests/regression.rs
@@ -400,19 +400,6 @@ fn issue_159() {
 }
 
 #[test]
-#[cfg(target_pointer_width = "64")]
-fn issue_167() {
-    test_it_converts(
-        "tests/files/issue-167.png",
-        None,
-        ColorType::Grayscale,
-        BitDepth::Eight,
-        ColorType::Grayscale,
-        BitDepth::Eight,
-    );
-}
-
-#[test]
 fn issue_171() {
     test_it_converts(
         "tests/files/issue-171.png",


### PR DESCRIPTION
I made a little mistake in #476: A reduction would always be reported even if the baseline was chosen by the evaluator.
This PR fixes that, plus makes a couple of tidy ups:
- Removed an incorrect comment I added in the grayscale depth reduction (I thought it was true at the time 😅)
- Removed test-167, following up from #481