### PR TITLE
Update CI

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -6,8 +6,9 @@ on:
       - 'v*.*.*'
 
 jobs:
-
   create-windows-binaries:
+    runs-on: windows-latest
+    if: github.repository == 'shssoichiro/oxipng'
 
     strategy:
       matrix:
@@ -16,51 +17,53 @@ jobs:
 # and I don't have a Windows machine set up to experiment with fixing it.
 #        conf: [x86_64, i686]
 
-    runs-on: windows-latest
-
     steps:
-    - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
+        with:
+          persist-credentials: false
 
-    - name: Install stable
-      uses: actions-rs/toolchain@v1
-      with:
-        profile: minimal
-        toolchain: stable
-        target: ${{ matrix.conf }}-pc-windows-msvc
-        override: true
+      - name: Install stable
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          target: ${{ matrix.conf }}-pc-windows-msvc
+          override: true
 
-    - name: Build oxipng
-      run: |
-        cargo build --release --target ${{ matrix.conf }}-pc-windows-msvc
+      - name: Build oxipng
+        run: |
+          cargo build --release --target ${{ matrix.conf }}-pc-windows-msvc
 
-    - name: Get the version
-      shell: bash
-      id: tagName
-      run: |
-        VERSION=$(cargo pkgid | cut -d# -f2 | cut -d: -f2)
-        echo "::set-output name=tag::$VERSION"
+      - name: Get the version
+        shell: bash
+        id: tagName
+        run: |
+          VERSION=$(cargo pkgid | cut -d# -f2 | cut -d: -f2)
+          echo "::set-output name=tag::$VERSION"
 
-    - name: Build package
-      id: package
-      shell: bash
-      run: |
-        ARCHIVE_TARGET="${{ matrix.conf }}-pc-windows-msvc"
-        ARCHIVE_NAME="oxipng-${{ steps.tagName.outputs.tag }}-$ARCHIVE_TARGET"
-        ARCHIVE_FILE="${ARCHIVE_NAME}.zip"
-        mv LICENSE LICENSE.txt
-        7z a ${ARCHIVE_FILE} \
-             ./target/${{ matrix.conf }}-pc-windows-msvc/release/oxipng.exe \
-             ./CHANGELOG.md ./LICENSE.txt ./README.md
-        echo "::set-output name=file::${ARCHIVE_FILE}"
-        echo "::set-output name=name::${ARCHIVE_NAME}.zip"
+      - name: Build package
+        id: package
+        shell: bash
+        run: |
+          ARCHIVE_TARGET="${{ matrix.conf }}-pc-windows-msvc"
+          ARCHIVE_NAME="oxipng-${{ steps.tagName.outputs.tag }}-$ARCHIVE_TARGET"
+          ARCHIVE_FILE="${ARCHIVE_NAME}.zip"
+          mv LICENSE LICENSE.txt
+          7z a ${ARCHIVE_FILE} \
+               ./target/${{ matrix.conf }}-pc-windows-msvc/release/oxipng.exe \
+               ./CHANGELOG.md ./LICENSE.txt ./README.md
+          echo "::set-output name=file::${ARCHIVE_FILE}"
+          echo "::set-output name=name::${ARCHIVE_NAME}.zip"
 
-    - name: Upload artifacts
-      uses: actions/upload-artifact@v2
-      with:
-        name: ${{ steps.package.outputs.name }}
-        path: ${{ steps.package.outputs.file }}
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v3
+        with:
+          name: ${{ steps.package.outputs.name }}
+          path: ${{ steps.package.outputs.file }}
 
   create-unix-binaries:
+    runs-on: ${{ matrix.os }}
+    if: github.repository == 'shssoichiro/oxipng'
 
     strategy:
       matrix:
@@ -71,67 +74,68 @@ jobs:
           - os: macos-latest
             target: x86_64-apple-darwin
 
-    runs-on: ${{ matrix.os }}
-
     steps:
-    - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
+        with:
+          persist-credentials: false
 
-    - name: Install Rust
-      uses: actions-rs/toolchain@v1
-      with:
-        profile: minimal
-        toolchain: stable
-        target: ${{ matrix.target }}
-        override: true
+      - name: Install Rust
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          target: ${{ matrix.target }}
+          override: true
 
-    - name: Install musl
-      if: contains(matrix.target, 'linux-musl')
-      run: |
-        sudo apt-get install musl-tools
+      - name: Install musl
+        if: contains(matrix.target, 'linux-musl')
+        run: |
+          sudo apt-get install musl-tools
 
-    - name: Build oxipng
-      run: |
-        cargo build --release --target ${{ matrix.target }}
+      - name: Build oxipng
+        run: |
+          cargo build --release --target ${{ matrix.target }}
 
-    - name: Strip binary
-      run: |
-        strip target/${{ matrix.target }}/release/oxipng
+      - name: Strip binary
+        run: |
+          strip target/${{ matrix.target }}/release/oxipng
 
-    - name: Get the version
-      id: tagName
-      run: |
-        VERSION=$(cargo pkgid | cut -d# -f2 | cut -d: -f2)
-        echo "::set-output name=tag::$VERSION"
+      - name: Get the version
+        id: tagName
+        run: |
+          VERSION=$(cargo pkgid | cut -d# -f2 | cut -d: -f2)
+          echo "::set-output name=tag::$VERSION"
 
-    - name: Build package
-      id: package
-      run: |
-        ARCHIVE_TARGET=${{ matrix.target }}
-        ARCHIVE_NAME="oxipng-${{ steps.tagName.outputs.tag }}-$ARCHIVE_TARGET"
-        ARCHIVE_FILE="${ARCHIVE_NAME}.tar.gz"
-        mkdir "/tmp/${ARCHIVE_NAME}"
-        cp README.md CHANGELOG.md LICENSE \
-           target/${{ matrix.target }}/release/oxipng \
-           /tmp/${ARCHIVE_NAME}
-        tar -czf ${PWD}/${ARCHIVE_FILE} -C /tmp/ ${ARCHIVE_NAME}
-        echo ::set-output "name=file::${ARCHIVE_FILE}"
-        echo ::set-output "name=name::${ARCHIVE_NAME}.tar.gz"
+      - name: Build package
+        id: package
+        run: |
+          ARCHIVE_TARGET=${{ matrix.target }}
+          ARCHIVE_NAME="oxipng-${{ steps.tagName.outputs.tag }}-$ARCHIVE_TARGET"
+          ARCHIVE_FILE="${ARCHIVE_NAME}.tar.gz"
+          mkdir "/tmp/${ARCHIVE_NAME}"
+          cp README.md CHANGELOG.md LICENSE \
+             target/${{ matrix.target }}/release/oxipng \
+             /tmp/${ARCHIVE_NAME}
+          tar -czf ${PWD}/${ARCHIVE_FILE} -C /tmp/ ${ARCHIVE_NAME}
+          echo ::set-output "name=file::${ARCHIVE_FILE}"
+          echo ::set-output "name=name::${ARCHIVE_NAME}.tar.gz"
 
-    - name: Upload artifacts
-      uses: actions/upload-artifact@v2
-      with:
-        name: ${{ steps.package.outputs.name }}
-        path: ${{ steps.package.outputs.file }}
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v3
+        with:
+          name: ${{ steps.package.outputs.name }}
+          path: ${{ steps.package.outputs.file }}
 
 
   deploy:
-
+    runs-on: ubuntu-latest
+    if: github.repository == 'shssoichiro/oxipng'
     needs: [create-windows-binaries, create-unix-binaries]
 
-    runs-on: ubuntu-latest
-
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
+        with:
+          persist-credentials: false
 
       - name: Get version and release description
         id: tagName
@@ -141,7 +145,7 @@ jobs:
           echo "::set-output name=tag::$VERSION"
 
       - name: Download artifacts
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
         with:
           path: ./binaries
 

--- a/.github/workflows/oxipng.yml
+++ b/.github/workflows/oxipng.yml
@@ -7,10 +7,13 @@ on:
   pull_request:
     branches:
       - master
+  workflow_dispatch:
 
 jobs:
   test:
+    runs-on: ${{ matrix.os }}
     strategy:
+      fail-fast: false
       matrix:
         target:
           - x86_64-unknown-linux-gnu
@@ -45,12 +48,25 @@ jobs:
             toolchain: beta
           - target: x86_64-unknown-linux-musl
             toolchain: nightly
-    runs-on: ${{ matrix.os }}
+
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
+        with:
+          persist-credentials: false
       - name: Install musl tools
         run: sudo apt-get install musl-tools
         if: "contains(matrix.target, 'musl')"
+      - name: Cache cargo registry
+        uses: actions/cache@v3
+        with:
+          path: |
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+          key: ${{ runner.os }}-${{ matrix.toolchain }}-cargo-registry-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-${{ matrix.toolchain }}-cargo-registry-
       - name: Install ${{ matrix.toolchain }}
         uses: actions-rs/toolchain@v1
         with:
@@ -58,13 +74,6 @@ jobs:
           toolchain: ${{ matrix.toolchain }}
           override: true
           components: clippy, rustfmt
-      - name: Cache cargo registry
-        uses: actions/cache@v1
-        with:
-          path: ~/.cargo/registry/cache
-          key: ${{ matrix.target }}-${{ matrix.toolchain }}-cargo-registry-${{ hashFiles('**/Cargo.lock') }}
-          restore-keys: |
-            ${{ matrix.target }}-${{ matrix.toolchain }}-cargo-registry-
       - name: Run rustfmt
         if: matrix.toolchain == 'stable'
         uses: actions-rs/cargo@v1


### PR DESCRIPTION
* add `workflow_dispatch` for manual running
* add `fail-fast` false in matrix
* specify `persist-credentials: false` for actions/checkout
* update actions to the latest versions
* move cache before installing the toolchain
* cache more stuff
* limit deploy to shssoichiro/oxipng repository
* reindent

Non-whitespace diff: https://github.com/shssoichiro/oxipng/pull/491/files?w=1

---

There's one warning which needs to be fixed later regarding `set-output`:

>The `set-output` command is deprecated and will be disabled soon. Please upgrade to using Environment Files. For more information see: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/

The other warning about Node.js 12 actions that were not updated in this PR because there's no newer version, needs to be fixed upstream, e.g. in https://github.com/actions-rs/toolchain:

> Node.js 12 actions are deprecated. Please update the following actions to use Node.js 16: actions/checkout@v2, actions-rs/toolchain@v1. For more information see: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/.
