### PR TITLE
Gate dependency on `crossbeam-channel` behind the `parallel` feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,9 +30,12 @@ indexmap = "1.9.1"
 libdeflater = "0.11.0"
 log = "0.4.17"
 stderrlog = { version = "0.5.3", optional = true, default-features = false }
-crossbeam-channel = "0.5.6"
 bitvec = "1.0.1"
 rustc-hash = "1.1.0"
+
+[dependencies.crossbeam-channel]
+optional = true
+version = "0.5.6"
 
 [dependencies.filetime]
 optional = true
@@ -61,7 +64,7 @@ rustc_version = "0.4.0"
 [features]
 binary = ["clap", "wild", "stderrlog"]
 default = ["binary", "filetime", "parallel", "zopfli"]
-parallel = ["rayon", "indexmap/rayon"]
+parallel = ["rayon", "indexmap/rayon", "crossbeam-channel"]
 freestanding = ["libdeflater/freestanding"]
 
 [lib]

--- a/tests/flags.rs
+++ b/tests/flags.rs
@@ -4,6 +4,7 @@ use oxipng::{InFile, OutFile};
 #[cfg(feature = "filetime")]
 use std::cell::RefCell;
 use std::fs::remove_file;
+#[cfg(feature = "zopfli")]
 use std::num::NonZeroU8;
 #[cfg(feature = "filetime")]
 use std::ops::Deref;
@@ -95,9 +96,12 @@ fn test_it_converts(
 
 #[test]
 fn verbose_mode() {
+    #[cfg(feature = "parallel")]
     use crossbeam_channel::{unbounded, Sender};
     use log::{set_logger, set_max_level, Level, LevelFilter, Log, Metadata, Record};
     use std::cell::RefCell;
+    #[cfg(not(feature = "parallel"))]
+    use std::sync::mpsc::{channel as unbounded, Sender};
 
     // Rust runs tests in parallel by default.
     // We want to make sure that we verify only logs from our test.
@@ -169,7 +173,7 @@ fn verbose_mode() {
         thread_exec();
     });
 
-    let mut logs: Vec<_> = receiver.into_iter().collect();
+    let logs: Vec<_> = receiver.into_iter().collect();
     println!("logs={:?}", logs);
     assert_eq!(logs.len(), 9);
     let expected_logs = [


### PR DESCRIPTION
`crossbeam-channel` is only used if the `parallel` flag is enabled, so it can be gated behind that feature flag to potentially reduce the size of the build dependency tree for dependent projects.

While at it, I've fixed several warnings emitted in `tests/flags.rs`.