### PR TITLE
Remove now unused `itertools` dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,6 @@ path = "src/main.rs"
 required-features = ["binary"]
 
 [dependencies]
-itertools = "0.10.3"
 zopfli = { version = "0.7.1", optional = true }
 rgb = "0.8.33"
 indexmap = "1.9.1"


### PR DESCRIPTION
The `itertools` dependency became unused at a3b104a2edd7e7a7d2944d8ee06eacc77dc6da8c, so there is no point in declaring it as a dependency any longer.

This was detected with the help of the [`cargo-udeps`](https://github.com/est31/cargo-udeps) tool. I verified that it was not a false positive.