### PR TITLE
Include palette and transparency size in evaluations

### DIFF
--- a/src/evaluate.rs
+++ b/src/evaluate.rs
@@ -30,7 +30,7 @@ pub struct Candidate {
 impl Candidate {
     fn cmp_key(&self) -> impl Ord {
         (
-            self.image.idat_data.len(),
+            self.image.estimated_output_size(),
             self.image.raw.data.len(),
             self.image.raw.ihdr.bit_depth,
             self.filter,
@@ -134,7 +134,6 @@ impl Evaluator {
                 if let Ok(idat_data) =
                     deflate::deflate(&filtered, compression, &best_candidate_size)
                 {
-                    best_candidate_size.set_min(idat_data.len());
                     let new = Candidate {
                         image: PngData {
                             idat_data,
@@ -145,6 +144,7 @@ impl Evaluator {
                         is_reduction,
                         nth,
                     };
+                    best_candidate_size.set_min(new.image.estimated_output_size());
 
                     #[cfg(feature = "parallel")]
                     {

--- a/tests/regression.rs
+++ b/tests/regression.rs
@@ -147,7 +147,7 @@ fn issue_52_02() {
         None,
         RGBA,
         BitDepth::Eight,
-        INDEXED,
+        RGBA,
         BitDepth::Eight,
     );
 }
@@ -159,7 +159,7 @@ fn issue_52_03() {
         None,
         RGBA,
         BitDepth::Eight,
-        INDEXED,
+        RGBA,
         BitDepth::Eight,
     );
 }
@@ -195,8 +195,8 @@ fn issue_52_06() {
         None,
         RGBA,
         BitDepth::Eight,
-        INDEXED,
-        BitDepth::Two,
+        RGBA,
+        BitDepth::Eight,
     );
 }
 


### PR DESCRIPTION
This is super minor but I started it back in January (in relation to #485) and thought I might as well open a PR for it.

For very small data, including the palette size in evaluations can sometimes achieve a better result.

issue-52-02 master: 1379 bytes
issue-52-02 PR: 1171 bytes

issue-52-03 master: 1555 bytes
issue-52-03 PR: 1315 bytes

issue-52-06 master: 249 bytes
issue-52-06 PR: 231 bytes (apparently 32bpp can be smaller than 2bpp!!)

I also tested this on the images mentioned in #418 and found oxipng now gives a better overall result than leanify.