### PR TITLE
Don't force output due to interlacing flag

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -847,7 +847,7 @@ fn srgb_rendering_intent(mut iccp: &[u8]) -> Option<u8> {
 
 /// Check if an image was already optimized prior to oxipng's operations
 fn is_fully_optimized(original_size: usize, optimized_size: usize, opts: &Options) -> bool {
-    original_size <= optimized_size && !opts.force && opts.interlace.is_none()
+    original_size <= optimized_size && !opts.force
 }
 
 fn perform_backup(input_path: &Path) -> PngResult<()> {


### PR DESCRIPTION
Changes `is_fully_optimized` to not return false just because the interlacing flag was set.
This is one option to fix #485, as discussed in the comments. I think this makes the most sense (what other use case is there for `--force`?) but I'm happy to explore another option if preferred.