### PR TITLE
Deinterlace by default

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -159,7 +159,7 @@ pub struct Options {
     ///
     /// `Some(x)` will change the file to interlacing mode `x`.
     ///
-    /// Default: `None`
+    /// Default: `Some(None)`
     pub interlace: Option<Interlacing>,
     /// Whether to allow transparent pixels to be altered to improve compression.
     pub optimize_alpha: bool,
@@ -296,7 +296,7 @@ impl Default for Options {
             force: false,
             preserve_attrs: false,
             filter: indexset! {RowFilter::None, RowFilter::Sub, RowFilter::Entropy, RowFilter::Bigrams},
-            interlace: None,
+            interlace: Some(Interlacing::None),
             optimize_alpha: false,
             bit_depth_reduction: true,
             color_type_reduction: true,

--- a/src/main.rs
+++ b/src/main.rs
@@ -144,13 +144,14 @@ fn main() {
         )
         .arg(
             Arg::new("interlace")
-                .help("PNG interlace type")
+                .help("PNG interlace type - Default: 0")
                 .short('i')
                 .long("interlace")
                 .takes_value(true)
-                .value_name("0/1")
+                .value_name("type")
                 .possible_value("0")
-                .possible_value("1"),
+                .possible_value("1")
+                .possible_value("keep"),
         )
         .arg(
             Arg::new("verbose")
@@ -394,7 +395,11 @@ fn parse_opts_into_struct(
     };
 
     if let Some(x) = matches.value_of("interlace") {
-        opts.interlace = x.parse::<u8>().unwrap().try_into().ok();
+        opts.interlace = if x == "keep" {
+            None
+        } else {
+            x.parse::<u8>().unwrap().try_into().ok()
+        };
     }
 
     if let Some(x) = matches.value_of("filters") {


### PR DESCRIPTION
Changes the default options to deinterlace, with a new `-i keep` cli argument in case anyone wants interlacing to remain unchanged.

This was previously mentioned [here](https://github.com/shssoichiro/oxipng/pull/182#issuecomment-511820902) and I think it's a good thing to do personally, but won't mind if anyone disagrees.