### PR TITLE
Add scale16 option to force 16-bit reduction

### DIFF
--- a/benches/reductions.rs
+++ b/benches/reductions.rs
@@ -13,7 +13,15 @@ fn reductions_16_to_8_bits(b: &mut Bencher) {
     let input = test::black_box(PathBuf::from("tests/files/rgb_16_should_be_rgb_8.png"));
     let png = PngData::new(&input, &Options::default()).unwrap();
 
-    b.iter(|| bit_depth::reduced_bit_depth_16_to_8(&png.raw));
+    b.iter(|| bit_depth::reduced_bit_depth_16_to_8(&png.raw, false));
+}
+
+#[bench]
+fn reductions_16_to_8_bits_scaled(b: &mut Bencher) {
+    let input = test::black_box(PathBuf::from("tests/files/rgb_16_should_be_rgb_16.png"));
+    let png = PngData::new(&input, &Options::default()).unwrap();
+
+    b.iter(|| bit_depth::reduced_bit_depth_16_to_8(&png.raw, true));
 }
 
 #[bench]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -186,6 +186,10 @@ pub struct Options {
     ///
     /// Default: `true`
     pub idat_recoding: bool,
+    /// Whether to forcibly reduce 16-bit to 8-bit by scaling
+    ///
+    /// Default: `false`
+    pub scale_16: bool,
     /// Which chunks to strip from the PNG file, if any
     ///
     /// Default: `None`
@@ -303,6 +307,7 @@ impl Default for Options {
             palette_reduction: true,
             grayscale_reduction: true,
             idat_recoding: true,
+            scale_16: false,
             strip: StripChunks::None,
             deflate: Deflaters::Libdeflater { compression: 11 },
             fast_evaluation: true,

--- a/src/main.rs
+++ b/src/main.rs
@@ -154,6 +154,11 @@ fn main() {
                 .possible_value("keep"),
         )
         .arg(
+            Arg::new("scale16")
+                .help("Forcibly reduce 16-bit images to 8-bit")
+                .long("scale16"),
+        )
+        .arg(
             Arg::new("verbose")
                 .help("Run in verbose mode (use multiple times to increase verbosity)")
                 .short('v')
@@ -444,6 +449,10 @@ fn parse_opts_into_struct(
 
     if matches.is_present("alpha") {
         opts.optimize_alpha = true;
+    }
+
+    if matches.is_present("scale16") {
+        opts.scale_16 = true;
     }
 
     if matches.is_present("fast") {

--- a/src/reduction/mod.rs
+++ b/src/reduction/mod.rs
@@ -42,7 +42,7 @@ pub(crate) fn perform_reductions(
     // Attempt to reduce 16-bit to 8-bit
     // This is just removal of bytes and does not need to be evaluated
     if opts.bit_depth_reduction && !deadline.passed() {
-        if let Some(reduced) = reduced_bit_depth_16_to_8(&png) {
+        if let Some(reduced) = reduced_bit_depth_16_to_8(&png, opts.scale_16) {
             png = Arc::new(reduced);
             reduction_occurred = true;
         }

--- a/tests/flags.rs
+++ b/tests/flags.rs
@@ -605,6 +605,23 @@ fn fix_errors() {
 }
 
 #[test]
+fn scale_16() {
+    let input = PathBuf::from("tests/files/rgb_16_should_be_rgb_16.png");
+    let (output, mut opts) = get_opts(&input);
+    opts.scale_16 = true;
+
+    test_it_converts(
+        input,
+        &output,
+        &opts,
+        RGB,
+        BitDepth::Sixteen,
+        RGB,
+        BitDepth::Eight,
+    );
+}
+
+#[test]
 #[cfg(feature = "zopfli")]
 fn zopfli_mode() {
     let input = PathBuf::from("tests/files/zopfli_mode.png");


### PR DESCRIPTION
This adds a new option `--scale16` (or `opts.scale_16 = true`) to force reduction of 16-bit to 8-bit. For improved accuracy it does this by scaling the values rather than just dropping bytes, matching libpng's `PNG_TRANSFORM_SCALE_16` option. This probably isn't a concern for anyone but it has the benefit that it still passes the sanity checks (apparently the image crate is doing the same scaling).