### PR TITLE
Fix grayscale_reduction option

### DIFF
--- a/benches/reductions.rs
+++ b/benches/reductions.rs
@@ -257,7 +257,7 @@ fn reductions_palette_8_to_grayscale_8(b: &mut Bencher) {
     ));
     let png = PngData::new(&input, &Options::default()).unwrap();
 
-    b.iter(|| color::indexed_to_channels(&png.raw));
+    b.iter(|| color::indexed_to_channels(&png.raw, true));
 }
 
 #[bench]

--- a/src/reduction/color.rs
+++ b/src/reduction/color.rs
@@ -132,7 +132,7 @@ pub fn reduced_rgb_to_grayscale(png: &PngImage) -> Option<PngImage> {
 
 /// Attempt to convert indexed to a different color type, returning the resulting image if successful
 #[must_use]
-pub fn indexed_to_channels(png: &PngImage) -> Option<PngImage> {
+pub fn indexed_to_channels(png: &PngImage, allow_grayscale: bool) -> Option<PngImage> {
     if png.ihdr.bit_depth != BitDepth::Eight {
         return None;
     }
@@ -142,7 +142,11 @@ pub fn indexed_to_channels(png: &PngImage) -> Option<PngImage> {
     };
 
     // Determine which channels are required
-    let is_gray = palette.iter().all(|c| c.r == c.g && c.g == c.b);
+    let is_gray = if allow_grayscale {
+        palette.iter().all(|c| c.r == c.g && c.g == c.b)
+    } else {
+        false
+    };
     let has_alpha = palette.iter().any(|c| c.a != 255);
     let color_type = match (is_gray, has_alpha) {
         (false, true) => ColorType::RGBA,

--- a/src/reduction/mod.rs
+++ b/src/reduction/mod.rs
@@ -50,7 +50,7 @@ pub(crate) fn perform_reductions(
 
     // Attempt to reduce RGB to grayscale
     // This is just removal of bytes and does not need to be evaluated
-    if opts.color_type_reduction && !deadline.passed() {
+    if opts.color_type_reduction && opts.grayscale_reduction && !deadline.passed() {
         if let Some(reduced) = reduced_rgb_to_grayscale(&png) {
             png = Arc::new(reduced);
             reduction_occurred = true;
@@ -98,7 +98,7 @@ pub(crate) fn perform_reductions(
     // Attempt to convert from indexed to channels
     // This may give a better result due to dropping the PLTE chunk
     if opts.color_type_reduction && !deadline.passed() {
-        if let Some(reduced) = indexed_to_channels(&png) {
+        if let Some(reduced) = indexed_to_channels(&png, opts.grayscale_reduction) {
             // This result should not be passed on to subsequent reductions
             eval.try_image(Arc::new(reduced));
             evaluation_added = true;


### PR DESCRIPTION
Seems I accidentally removed the grayscale_reduction checks at some point. This adds them back in, so the `--ng` flag works again.