### PR TITLE
Allow APNG with reductions disabled

### DIFF
--- a/src/headers.rs
+++ b/src/headers.rs
@@ -86,7 +86,9 @@ pub enum StripChunks {
 
 impl StripChunks {
     /// List of chunks that will be kept when using the `Safe` option
-    pub const KEEP_SAFE: [[u8; 4]; 4] = [*b"cICP", *b"iCCP", *b"sRGB", *b"pHYs"];
+    pub const KEEP_SAFE: [[u8; 4]; 7] = [
+        *b"cICP", *b"iCCP", *b"sRGB", *b"pHYs", *b"acTL", *b"fcTL", *b"fdAT",
+    ];
 
     pub(crate) fn keep(&self, name: &[u8; 4]) -> bool {
         match &self {

--- a/src/main.rs
+++ b/src/main.rs
@@ -120,7 +120,7 @@ fn main() {
         )
         .arg(
             Arg::new("strip")
-                .help("Strip metadata objects ['safe', 'all', or comma-separated list]")
+                .help("Strip metadata objects ['safe', 'all', or comma-separated list]\nCAUTION: stripping 'all' will convert APNGs to standard PNGs")
                 .long("strip")
                 .value_name("mode")
                 .conflicts_with("strip-safe"),

--- a/src/png/mod.rs
+++ b/src/png/mod.rs
@@ -7,6 +7,7 @@ use crate::interlace::{deinterlace_image, interlace_image, Interlacing};
 use crate::Options;
 use bitvec::bitarr;
 use libdeflater::{CompressionLvl, Compressor};
+use log::warn;
 use rgb::ComponentSlice;
 use rustc_hash::FxHashMap;
 use std::fs::File;
@@ -112,6 +113,10 @@ impl PngData {
                             name: chunk.name,
                             data: chunk.data.to_owned(),
                         })
+                    } else if chunk.name == *b"acTL" {
+                        warn!(
+                            "Stripping animation data from APNG - image will become standard PNG"
+                        );
                     }
                 }
             }

--- a/src/rayon.rs
+++ b/src/rayon.rs
@@ -26,6 +26,12 @@ pub trait IntoParallelRefIterator<'data> {
     fn par_iter(&'data self) -> Self::Iter;
 }
 
+pub trait IntoParallelRefMutIterator<'data> {
+    type Iter: ParallelIterator<Item = Self::Item>;
+    type Item: Send + 'data;
+    fn par_iter_mut(&'data mut self) -> Self::Iter;
+}
+
 impl<I: IntoIterator> IntoParallelIterator for I
 where
     I::Item: Send,
@@ -46,6 +52,18 @@ where
     type Item = <&'data I as IntoParallelIterator>::Item;
 
     fn par_iter(&'data self) -> Self::Iter {
+        self.into_par_iter()
+    }
+}
+
+impl<'data, I: 'data + ?Sized> IntoParallelRefMutIterator<'data> for I
+where
+    &'data mut I: IntoParallelIterator,
+{
+    type Iter = <&'data mut I as IntoParallelIterator>::Iter;
+    type Item = <&'data mut I as IntoParallelIterator>::Item;
+
+    fn par_iter_mut(&'data mut self) -> Self::Iter {
         self.into_par_iter()
     }
 }

--- a/src/sanity_checks.rs
+++ b/src/sanity_checks.rs
@@ -1,15 +1,14 @@
-use image::{DynamicImage, GenericImageView, ImageFormat, Pixel};
+use image::{codecs::png::PngDecoder, *};
 use log::{error, warn};
-use std::io::Cursor;
 
 /// Validate that the output png data still matches the original image
 pub fn validate_output(output: &[u8], original_data: &[u8]) -> bool {
-    let (old_png, new_png) = rayon::join(
+    let (old_frames, new_frames) = rayon::join(
         || load_png_image_from_memory(original_data),
         || load_png_image_from_memory(output),
     );
 
-    match (new_png, old_png) {
+    match (new_frames, old_frames) {
         (Err(new_err), _) => {
             error!("Failed to read output image for validation: {}", new_err);
             false
@@ -21,26 +20,40 @@ pub fn validate_output(output: &[u8], original_data: &[u8]) -> bool {
             warn!("Failed to read input image for validation: {}", old_err);
             true
         }
-        (Ok(new_png), Ok(old_png)) => images_equal(&old_png, &new_png),
+        (Ok(new_frames), Ok(old_frames)) if new_frames.len() != old_frames.len() => false,
+        (Ok(new_frames), Ok(old_frames)) => {
+            for (a, b) in old_frames.iter().zip(new_frames) {
+                if !images_equal(&a, &b) {
+                    return false;
+                }
+            }
+            true
+        }
     }
 }
 
-/// Loads a PNG image from memory to a [DynamicImage]
-fn load_png_image_from_memory(png_data: &[u8]) -> Result<DynamicImage, image::ImageError> {
-    let mut reader = image::io::Reader::new(Cursor::new(png_data));
-    reader.set_format(ImageFormat::Png);
-    reader.no_limits();
-    reader.decode()
+/// Loads a PNG image from memory to frames of [RgbaImage]
+fn load_png_image_from_memory(png_data: &[u8]) -> Result<Vec<RgbaImage>, image::ImageError> {
+    let decoder = PngDecoder::new(png_data)?;
+    if decoder.is_apng() {
+        decoder
+            .apng()
+            .into_frames()
+            .map(|f| f.map(|f| f.into_buffer()))
+            .collect()
+    } else {
+        DynamicImage::from_decoder(decoder).map(|i| vec![i.into_rgba8()])
+    }
 }
 
 /// Compares images pixel by pixel for equivalent content
-fn images_equal(old_png: &DynamicImage, new_png: &DynamicImage) -> bool {
+fn images_equal(old_png: &RgbaImage, new_png: &RgbaImage) -> bool {
     let a = old_png.pixels().filter(|x| {
-        let p = x.2.channels();
+        let p = x.channels();
         !(p.len() == 4 && p[3] == 0)
     });
     let b = new_png.pixels().filter(|x| {
-        let p = x.2.channels();
+        let p = x.channels();
         !(p.len() == 4 && p[3] == 0)
     });
     a.eq(b)

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -30,7 +30,7 @@ fn optimize_from_memory_apng() {
     in_file.read_to_end(&mut in_file_buf).unwrap();
 
     let result = oxipng::optimize_from_memory(&in_file_buf, &Options::default());
-    assert!(result.is_err());
+    assert!(result.is_ok());
 }
 
 #[test]
@@ -58,9 +58,9 @@ fn optimize_apng() {
     let result = oxipng::optimize(
         &"tests/files/apng_file.png".into(),
         &OutFile::Path(None),
-        &Options::default(),
+        &Options::from_preset(0),
     );
-    assert!(result.is_err());
+    assert!(result.is_ok());
 }
 
 #[test]


### PR DESCRIPTION
This is a bit of a hack, not sure if it's something that should actually be added, but it provides rudimentary support for APNG files by disabling all reductions and preserving original chunk order. See #79.
The savings to the test file `apng_file.png` are indeed minimal, achieving only 0.19% with default options and 0.41% with `-o6 -a`.

Note the required chunks are retained with strip safe, though you could still opt to strip all to turn it into a standard png.