### PR TITLE
Don't fail recursion on read_dir error

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -359,8 +359,8 @@ fn collect_files(
                         in_out_pairs
                             .extend(collect_files(files, out_dir, out_file, recursive, false));
                     }
-                    Err(_) => {
-                        return Vec::new();
+                    Err(e) => {
+                        warn!("{}: {}", input.display(), e);
                     }
                 }
             } else {


### PR DESCRIPTION
Fixes #170 by printing a warning instead of returning empty.