### PR TITLE
Remove `backup` and `check` options

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -155,10 +155,6 @@ pub struct Options {
     ///
     /// Default: `false`
     pub fix_errors: bool,
-    /// Don't actually run any optimizations, just parse the PNG file.
-    ///
-    /// Default: `false`
-    pub check: bool,
     /// Write to output even if there was no improvement in compression.
     ///
     /// Default: `false`
@@ -308,7 +304,6 @@ impl Default for Options {
         // Default settings based on -o 2 from the CLI interface
         Options {
             backup: false,
-            check: false,
             fix_errors: false,
             force: false,
             filter: indexset! {RowFilter::None, RowFilter::Sub, RowFilter::Entropy, RowFilter::Bigrams},
@@ -461,11 +456,6 @@ pub fn optimize(input: &InFile, output: &OutFile, opts: &Options) -> PngResult<(
     };
 
     let mut png = PngData::from_slice(&in_data, opts)?;
-
-    if opts.check {
-        info!("Running in check mode, not optimizing");
-        return Ok(());
-    }
 
     // Run the optimizer on the decoded PNG.
     let mut optimized_output = optimize_png(&mut png, &in_data, opts, deadline)?;

--- a/src/main.rs
+++ b/src/main.rs
@@ -57,6 +57,14 @@ fn main() {
                 .value_parser(["0", "1", "2", "3", "4", "5", "6", "max"]),
         )
         .arg(
+            Arg::new("backup")
+                .help("Back up modified files")
+                .short('b')
+                .long("backup")
+                .hide(true)
+                .action(ArgAction::SetTrue),
+        )
+        .arg(
             Arg::new("recursive")
                 .help("Recurse into subdirectories and optimize all *.png/*.apng files")
                 .short('r')
@@ -284,6 +292,11 @@ Heuristic filter selection strategies:
     9  =>  Brute     Smallest compressed size (slow)",
         )
         .get_matches_from(std::env::args());
+
+    if matches.get_flag("backup") {
+        eprintln!("The --backup flag is no longer supported. Please use --out or --dir to preserve your existing files.");
+        exit(1)
+    }
 
     let (out_file, out_dir, opts) = match parse_opts_into_struct(&matches) {
         Ok(x) => x,

--- a/src/main.rs
+++ b/src/main.rs
@@ -57,13 +57,6 @@ fn main() {
                 .value_parser(["0", "1", "2", "3", "4", "5", "6", "max"]),
         )
         .arg(
-            Arg::new("backup")
-                .help("Back up modified files")
-                .short('b')
-                .long("backup")
-                .action(ArgAction::SetTrue),
-        )
-        .arg(
             Arg::new("recursive")
                 .help("Recurse into subdirectories and optimize all *.png/*.apng files")
                 .short('r')
@@ -484,8 +477,6 @@ fn parse_opts_into_struct(
     if matches.get_flag("fast") {
         opts.fast_evaluation = matches.get_flag("fast");
     }
-
-    opts.backup = matches.get_flag("backup");
 
     opts.force = matches.get_flag("force");
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -104,13 +104,6 @@ fn main() {
                 .action(ArgAction::SetTrue),
         )
         .arg(
-            Arg::new("check")
-                .help("Do not run any optimization passes")
-                .short('c')
-                .long("check")
-                .action(ArgAction::SetTrue),
-        )
-        .arg(
             Arg::new("pretend")
                 .help("Do not write any files, only calculate compression gains")
                 .short('P')
@@ -497,8 +490,6 @@ fn parse_opts_into_struct(
     opts.force = matches.get_flag("force");
 
     opts.fix_errors = matches.get_flag("fix");
-
-    opts.check = matches.get_flag("check");
 
     opts.bit_depth_reduction = !matches.get_flag("no-bit-reduction");
 


### PR DESCRIPTION
Tidy up the API by removing a couple of options we don't really need.
Backup was discussed in #542
Check was discussed in  #439

@shssoichiro Just say if you prefer to keep either of these 🙂