### PR TITLE
skip non png files, if `--recursive` is used

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -355,7 +355,6 @@ fn collect_files(
     out_dir: &Option<PathBuf>,
     out_file: &OutFile,
     recursive: bool,
-    include_non_png: bool,
     top_level: bool, //explicitly specify files
 ) -> Vec<(InFile, OutFile)> {
     let mut in_out_pairs = Vec::new();
@@ -367,14 +366,8 @@ fn collect_files(
                 match input.read_dir() {
                     Ok(dir) => {
                         let files = dir.filter_map(|x| x.ok().map(|x| x.path())).collect();
-                        in_out_pairs.extend(collect_files(
-                            files,
-                            out_dir,
-                            out_file,
-                            recursive,
-                            include_non_png,
-                            false,
-                        ));
+                        in_out_pairs
+                            .extend(collect_files(files, out_dir, out_file, recursive, false));
                     }
                     Err(e) => {
                         warn!("{}: {}", input.display(), e);

--- a/src/main.rs
+++ b/src/main.rs
@@ -71,12 +71,6 @@ fn main() {
                 .action(ArgAction::SetTrue),
         )
         .arg(
-            Arg::new("include-non-png")
-                .help("compress also files with non png extensions if --recursive flag is used")
-                .long("include-non-png")
-                .action(ArgAction::SetTrue),
-        )
-        .arg(
             Arg::new("output_dir")
                 .help("Write output file(s) to <directory>")
                 .long("dir")
@@ -402,7 +396,7 @@ fn collect_files(
         } else {
             //skip non png files if recusive flag is used.
             //(still allow the user to convert a non png file if recusive flag is not used);
-            if !top_level && recursive && !include_non_png && {
+            if !top_level && recursive && {
                 let extension = input.extension().map(|f| f.to_ascii_lowercase());
                 extension != Some(OsString::from("png"))
                     && extension != Some(OsString::from("apng"))

--- a/src/main.rs
+++ b/src/main.rs
@@ -26,6 +26,7 @@ use oxipng::StripChunks;
 use oxipng::{InFile, OutFile};
 use rayon::prelude::*;
 use std::ffi::OsStr;
+use std::ffi::OsString;
 use std::fs::DirBuilder;
 use std::io::Write;
 #[cfg(feature = "zopfli")]
@@ -401,8 +402,12 @@ fn collect_files(
             InFile::StdIn
         } else {
             //skip non png files if recusive flag is used.
-            //(still allow the user to convert a non png file if recusive flag is not used)
-            if Some(OsStr::new("png")) != input.extension() && recursive && !include_non_png {
+            //(still allow the user to convert a non png file if recusive flag is not used);
+            if recursive && !include_non_png && {
+                let extension = input.extension().map(|f| f.to_ascii_lowercase());
+                extension != Some(OsString::from("png"))
+                    && extension != Some(OsString::from("apng"))
+            } {
                 continue;
             }
             InFile::Path(input)

--- a/src/main.rs
+++ b/src/main.rs
@@ -25,7 +25,6 @@ use oxipng::RowFilter;
 use oxipng::StripChunks;
 use oxipng::{InFile, OutFile};
 use rayon::prelude::*;
-use std::ffi::OsStr;
 use std::ffi::OsString;
 use std::fs::DirBuilder;
 use std::io::Write;

--- a/src/main.rs
+++ b/src/main.rs
@@ -65,7 +65,7 @@ fn main() {
         )
         .arg(
             Arg::new("recursive")
-                .help("Recurse into subdirectories")
+                .help("Recurse into subdirectories and optimize all *.png/*.apng files")
                 .short('r')
                 .long("recursive")
                 .action(ArgAction::SetTrue),

--- a/src/main.rs
+++ b/src/main.rs
@@ -324,7 +324,6 @@ Heuristic filter selection strategies:
         &out_dir,
         &out_file,
         matches.get_flag("recursive"),
-        matches.get_flag("include-non-png"),
         true,
     );
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -25,6 +25,7 @@ use oxipng::RowFilter;
 use oxipng::StripChunks;
 use oxipng::{InFile, OutFile};
 use rayon::prelude::*;
+use std::ffi::OsStr;
 use std::fs::DirBuilder;
 use std::io::Write;
 #[cfg(feature = "zopfli")]
@@ -327,6 +328,7 @@ Heuristic filter selection strategies:
     );
 
     let success = files.into_par_iter().filter(|(input, output)| {
+        
         match oxipng::optimize(input, output, &opts) {
             // For optimizing single files, this will return the correct exit code always.
             // For recursive optimization, the correct choice is a bit subjective.
@@ -385,6 +387,11 @@ fn collect_files(
         let in_file = if using_stdin {
             InFile::StdIn
         } else {
+            //skip non png files if recusive flag is used.
+            //(still allow the user to convert a non png file if recusive flag is not used)
+            if Some(OsStr::new("png")) != input.extension() && recursive {
+                continue;
+            }
             InFile::Path(input)
         };
         in_out_pairs.push((in_file, out_file));

--- a/src/main.rs
+++ b/src/main.rs
@@ -363,10 +363,10 @@ fn collect_files(
     out_file: &OutFile,
     recursive: bool,
     include_non_png: bool,
-    allow_stdin: bool,
+    top_level: bool, //explicitly specify files
 ) -> Vec<(InFile, OutFile)> {
     let mut in_out_pairs = Vec::new();
-    let allow_stdin = allow_stdin && files.len() == 1;
+    let allow_stdin = top_level && files.len() == 1;
     for input in files {
         let using_stdin = allow_stdin && input.to_str().map_or(false, |p| p == "-");
         if !using_stdin && input.is_dir() {
@@ -403,7 +403,7 @@ fn collect_files(
         } else {
             //skip non png files if recusive flag is used.
             //(still allow the user to convert a non png file if recusive flag is not used);
-            if recursive && !include_non_png && {
+            if !top_level && recursive && !include_non_png && {
                 let extension = input.extension().map(|f| f.to_ascii_lowercase());
                 extension != Some(OsString::from("png"))
                     && extension != Some(OsString::from("apng"))

--- a/src/main.rs
+++ b/src/main.rs
@@ -386,9 +386,8 @@ fn collect_files(
         let in_file = if using_stdin {
             InFile::StdIn
         } else {
-            //skip non png files if recusive flag is used.
-            //(still allow the user to convert a non png file if recusive flag is not used);
-            if !top_level && recursive && {
+            // Skip non png files if not given on top level
+            if !top_level && {
                 let extension = input.extension().map(|f| f.to_ascii_lowercase());
                 extension != Some(OsString::from("png"))
                     && extension != Some(OsString::from("apng"))

--- a/src/main.rs
+++ b/src/main.rs
@@ -328,7 +328,6 @@ Heuristic filter selection strategies:
     );
 
     let success = files.into_par_iter().filter(|(input, output)| {
-        
         match oxipng::optimize(input, output, &opts) {
             // For optimizing single files, this will return the correct exit code always.
             // For recursive optimization, the correct choice is a bit subjective.


### PR DESCRIPTION
Fix #547 

Files with non `png` extensions are skipped now, if the `--recursive` flag is used.
If `--recursive` is not used non `png` files "can" still be compressed.

How @TPS has suggested I have also add an flag, to keep the current behavior.
I am not sure if `--include-non-png` is the best name for this.

Please squash merge.


TODO:
- [x]  allow  explicitly specified non pngs (see https://github.com/shssoichiro/oxipng/pull/548#issuecomment-1666967656)
- [x] check for `apng` extension
- [x] case-insensitive comparison on the extension
- [x]  remove `--include-non-png` flag ~~?~~