### PR TITLE
Update libdeflate to v1.19

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -361,18 +361,18 @@ checksum = "f92be4933c13fd498862a9e02a3055f8a8d9c039ce33db97306fd5a6caa7f29b"
 
 [[package]]
 name = "libdeflate-sys"
-version = "0.14.0"
+version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "012437ac39c1e7d7ba12af3aceceb5c93149779aa17c2b1c483f33954957ddc8"
+checksum = "67921a7f85100c1559efc3d1c7c472091b7da05f304b4bbd5356f075e97f1cc2"
 dependencies = [
  "cc",
 ]
 
 [[package]]
 name = "libdeflater"
-version = "0.14.0"
+version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "58b30f982ddb14aae2a24a7ed7b3d512d687c2483493f95de7a6d167942a19c3"
+checksum = "3a31b22f662350ec294b13859f935aea772ba7b2bc8776269f4a5627308eab7d"
 dependencies = [
  "libdeflate-sys",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,7 @@ required-features = ["zopfli"]
 zopfli = { version = "0.7.4", optional = true, default-features = false, features = ["std", "zlib"] }
 rgb = "0.8.36"
 indexmap = "2.0.0"
-libdeflater = "0.14.0"
+libdeflater = "1.19.0"
 log = "0.4.19"
 bitvec = "1.0.1"
 rustc-hash = "1.1.0"

--- a/src/deflate/deflater.rs
+++ b/src/deflate/deflater.rs
@@ -4,16 +4,14 @@ use libdeflater::*;
 
 pub fn deflate(data: &[u8], level: u8, max_size: &AtomicMin) -> PngResult<Vec<u8>> {
     let mut compressor = Compressor::new(CompressionLvl::new(level.into()).unwrap());
-    // If adhering to a max_size we need to include at least 9 extra bytes of slack space (as specified in docs).
     let capacity = max_size
         .get()
-        .unwrap_or_else(|| compressor.zlib_compress_bound(data.len()))
-        + 9;
+        .unwrap_or_else(|| compressor.zlib_compress_bound(data.len()));
     let mut dest = vec![0; capacity];
     let len = compressor
         .zlib_compress(data, &mut dest)
         .map_err(|err| match err {
-            CompressionError::InsufficientSpace => PngError::DeflatedDataTooLong(capacity - 9),
+            CompressionError::InsufficientSpace => PngError::DeflatedDataTooLong(capacity),
         })?;
     dest.truncate(len);
     Ok(dest)


### PR DESCRIPTION
Small improvements, plus the new version no longer requires the 9 bytes of slack space.