### PR TITLE
Add `--timeout` notice

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -256,7 +256,7 @@ fn main() {
         )
         .arg(
             Arg::new("timeout")
-                .help("Maximum amount of time, in seconds, to spend on optimizations")
+                .help("Maximum amount of time, in seconds, to spend on optimizations (not useful for compression algorithms which use fewer rounds as the timeout is checked inbetween rounds)")
                 .value_name("secs")
                 .long("timeout")
                 .value_parser(value_parser!(u64)),

--- a/src/main.rs
+++ b/src/main.rs
@@ -256,7 +256,7 @@ fn main() {
         )
         .arg(
             Arg::new("timeout")
-                .help("Maximum amount of time, in seconds, to spend on optimizations (not useful for compression algorithms which use fewer rounds as the timeout is checked inbetween rounds)")
+                .help("Maximum amount of time, in seconds, to spend on optimizations (currently of limited use due to the shift away from zlib)")
                 .value_name("secs")
                 .long("timeout")
                 .value_parser(value_parser!(u64)),


### PR DESCRIPTION
Closes: https://github.com/shssoichiro/oxipng/issues/556

Adds a statement saying that `--timeout` isn't as useful for compression algorithms which use fewer and slower rounds, which OxiPNG tends to use nowadays.