### PR TITLE
Update `zopfli` to v0.8.0

### DIFF
--- a/.github/workflows/oxipng.yml
+++ b/.github/workflows/oxipng.yml
@@ -171,7 +171,7 @@ jobs:
         uses: Swatinem/rust-cache@v2
 
       - name: Install MSRV Rust toolchain
-        uses: dtolnay/rust-toolchain@1.65.0
+        uses: dtolnay/rust-toolchain@1.66.0
 
       - name: Install nextest
         uses: taiki-e/install-action@nextest

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -385,9 +385,9 @@ checksum = "ef53942eb7bf7ff43a617b3e2c1c4a5ecf5944a7c1bc12d7ee39bbb15e5c1519"
 
 [[package]]
 name = "log"
-version = "0.4.19"
+version = "0.4.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b06a4cde4c0f271a446782e3eff8de789548ce57dbc8eca9292c27f4a42004b4"
+checksum = "b5e6163cb8c49088c2c36f57875e58ccd8c87c7427f7fbd50ea6710b2f3f2e8f"
 
 [[package]]
 name = "memoffset"
@@ -571,9 +571,9 @@ checksum = "bebd363326d05ec3e2f532ab7660680f3b02130d780c299bca73469d521bc0ed"
 
 [[package]]
 name = "simd-adler32"
-version = "0.3.5"
+version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "238abfbb77c1915110ad968465608b68e869e0772622c9656714e73e5a1a522f"
+checksum = "d66dc143e6b11c1eddc06d5c423cfc97062865baf299914ab64caa38182078fe"
 
 [[package]]
 name = "strsim"
@@ -716,9 +716,9 @@ dependencies = [
 
 [[package]]
 name = "zopfli"
-version = "0.7.4"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e0650ae6a051326d798eb099b632f1afb0d323d25ee4ec82ffb0779512084d5"
+checksum = "5c1f48f3508a3a3f2faee01629564400bc12260f6214a056d06a3aaaa6ef0736"
 dependencies = [
  "crc32fast",
  "log",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ name = "zopfli"
 required-features = ["zopfli"]
 
 [dependencies]
-zopfli = { version = "0.7.4", optional = true, default-features = false, features = ["std", "zlib"] }
+zopfli = { version = "0.8.0", optional = true, default-features = false, features = ["std", "zlib"] }
 rgb = "0.8.36"
 indexmap = "2.0.0"
 libdeflater = "1.19.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ license = "MIT"
 name = "oxipng"
 repository = "https://github.com/shssoichiro/oxipng"
 version = "8.0.0"
-rust-version = "1.65.0"
+rust-version = "1.66.0"
 
 [badges]
 travis-ci = { repository = "shssoichiro/oxipng", branch = "master" }

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ cargo build --release
 cp target/release/oxipng /usr/local/bin
 ```
 
-The current minimum supported Rust version is **1.65.0**.
+The current minimum supported Rust version is **1.66.0**.
 
 Oxipng follows Semantic Versioning.
 

--- a/README.template.md
+++ b/README.template.md
@@ -32,7 +32,7 @@ cargo build --release
 cp target/release/oxipng /usr/local/bin
 ```
 
-The current minimum supported Rust version is **1.65.0**.
+The current minimum supported Rust version is **1.66.0**.
 
 Oxipng follows Semantic Versioning.
 

--- a/src/deflate/zopfli_oxipng.rs
+++ b/src/deflate/zopfli_oxipng.rs
@@ -2,9 +2,7 @@ use crate::{PngError, PngResult};
 use std::num::NonZeroU8;
 
 pub fn deflate(data: &[u8], iterations: NonZeroU8) -> PngResult<Vec<u8>> {
-    use std::cmp::max;
-
-    let mut output = Vec::with_capacity(max(1024, data.len() / 20));
+    let mut output = Vec::with_capacity(data.len());
     let options = zopfli::Options {
         iteration_count: iterations.into(),
         ..Default::default()

--- a/src/deflate/zopfli_oxipng.rs
+++ b/src/deflate/zopfli_oxipng.rs
@@ -6,10 +6,10 @@ pub fn deflate(data: &[u8], iterations: NonZeroU8) -> PngResult<Vec<u8>> {
 
     let mut output = Vec::with_capacity(max(1024, data.len() / 20));
     let options = zopfli::Options {
-        iteration_count: iterations,
+        iteration_count: iterations.into(),
         ..Default::default()
     };
-    match zopfli::compress(&options, &zopfli::Format::Zlib, data, &mut output) {
+    match zopfli::compress(options, zopfli::Format::Zlib, data, &mut output) {
         Ok(_) => (),
         Err(_) => return Err(PngError::new("Failed to compress in zopfli")),
     };


### PR DESCRIPTION
This update brings several parameterization and usage flexibility improvements on Zopfli, allowing users to choose to limit execution time by a number of iterations without improvement, and exposing a more advanced `ZlibEncoder` struct to tune compression block sizes and DEFLATE block types. Some minor microoptimizations were also made.

For now, I don't expect this PR to substantially affect how OxiPNG compresses images using its Zopfli mode, but the additional parameter customization may come in handy for future work improving how Zopfli is used in OxiPNG.