### PR TITLE
Overhaul help

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -48,13 +48,16 @@ jobs:
           name: Oxipng binary (${{ matrix.target }})
           path: target
 
+      - name: Generate up to date manual
+        run: scripts/manual.sh
+
       - name: Build archives
         working-directory: target
         run: |
           ARCHIVE_NAME="oxipng-${{ steps.oxipngMeta.outputs.version }}-${{ matrix.target }}"
 
           mkdir "$ARCHIVE_NAME"
-          cp ../CHANGELOG.md ../README.md "$ARCHIVE_NAME"
+          cp ../CHANGELOG.md ../README.md ../MANUAL.txt "$ARCHIVE_NAME"
 
           case '${{ matrix.target }}' in
             *-windows-*)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -125,6 +125,7 @@ dependencies = [
  "bitflags",
  "clap_lex",
  "strsim",
+ "terminal_size",
 ]
 
 [[package]]
@@ -594,6 +595,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bab24d30b911b2376f3a13cc2cd443142f0c81dda04c118693e35b3835757755"
 dependencies = [
  "winapi-util",
+]
+
+[[package]]
+name = "terminal_size"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e6bf6f19e9f8ed8d4048dc22981458ebcf406d67e94cd422e5ecd73d63b3237"
+dependencies = [
+ "rustix",
+ "windows-sys",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,6 +56,7 @@ version = "1.7.0"
 [dependencies.clap]
 optional = true
 version = "4.3.8"
+features = ["wrap_help"]
 
 [target.'cfg(windows)'.dependencies.glob]
 optional = true

--- a/MANUAL.txt
+++ b/MANUAL.txt
@@ -70,8 +70,8 @@ Options:
   -a, --alpha
           Perform additional optimization on images with an alpha channel, by altering the color
           values of fully transparent pixels. This is generally recommended for better compression,
-          but take care as this is technically a lossy transformation and may be unsuitable for some
-          applications.
+          but take care as while this is “visually lossless”, it is technically a lossy
+          transformation and may be unsuitable for some applications.
 
   -i, --interlace <type>
           Set the PNG interlacing type, where <type> is one of:
@@ -86,8 +86,13 @@ Options:
           [default: 0]
 
       --scale16
-          Forcibly reduce 16-bit images to 8-bit. Reduction is performed by scaling the values, such
-          that e.g. 0x00FF is reduced to 0x01 rather than 0x00.
+          Forcibly reduce images with 16 bits per channel to 8 bits per channel. This is a lossy
+          operation but can provide significant savings when you have no need for higher depth.
+          Reduction is performed by scaling the values such that, e.g. 0x00FF is reduced to 0x01
+          rather than 0x00.
+          
+          Without this flag, 16-bit images will only be reduced in depth if it can be done
+          losslessly.
 
   -v, --verbose...
           Run in verbose mode (use twice to increase verbosity)
@@ -96,7 +101,7 @@ Options:
           Run in quiet mode
 
   -f, --filters <list>
-          Peform compression trials with each of the given filter types. You can specify a
+          Perform compression trials with each of the given filter types. You can specify a
           comma-separated list, or a range of values. E.g. '-f 0-3' is the same as '-f 0,1,2,3'.
           
           PNG delta filters (apply the same filter to every line)

--- a/MANUAL.txt
+++ b/MANUAL.txt
@@ -9,10 +9,9 @@ Arguments:
 
 Options:
   -o, --opt <level>
-          Set the optimization level preset. The default level 2 is quite fast
-          and provides good compression. Lower levels are faster, higher levels
-          provide better compression, though with increasingly diminishing
-          returns.
+          Set the optimization level preset. The default level 2 is quite fast and provides good
+          compression. Lower levels are faster, higher levels provide better compression, though
+          with increasingly diminishing returns.
           
           0   => --zc 5 --fast               (1 trial, determined heuristically)
           1   => --zc 10 --fast              (1 trial, determined heuristically)
@@ -23,20 +22,19 @@ Options:
           6   => --zc 12 -f 0-9              (10 trials)
           max =>                             (stable alias for the max level)
           
-          Manually specifying a compression option (zc, f, etc.) will override
-          the optimization preset, regardless of the order you write the
-          arguments.
+          Manually specifying a compression option (zc, f, etc.) will override the optimization
+          preset, regardless of the order you write the arguments.
           
           [default: 2]
 
   -r, --recursive
-          When directories are given as input, traverse the directory trees and
-          optimize all PNG files found (files with “.png” or “.apng” extension).
+          When directories are given as input, traverse the directory trees and optimize all PNG
+          files found (files with “.png” or “.apng” extension).
 
       --dir <directory>
-          Write output file(s) to <directory>. If the directory does not exist,
-          it will be created. Note that this will not preserve the directory
-          structure of the input files when used with '--recursive'.
+          Write output file(s) to <directory>. If the directory does not exist, it will be created.
+          Note that this will not preserve the directory structure of the input files when used with
+          '--recursive'.
 
       --out <file>
           Write output file to <file>
@@ -63,17 +61,16 @@ Options:
           
           CAUTION: 'all' will convert APNGs to standard PNGs.
           
-          Note that 'bKGD', 'sBIT' and 'hIST' will be forcibly stripped if the
-          color type or bit depth is changed, regardless of any options set.
+          Note that 'bKGD', 'sBIT' and 'hIST' will be forcibly stripped if the color type or bit
+          depth is changed, regardless of any options set.
 
       --keep <list>
           Strip all metadata except in the comma-separated list
 
   -a, --alpha
-          Perform additional optimization on images with an alpha channel, by
-          altering the color values of fully transparent pixels. This is
-          generally recommended for better compression, but take care as this is
-          technically a lossy transformation and may be unsuitable for some
+          Perform additional optimization on images with an alpha channel, by altering the color
+          values of fully transparent pixels. This is generally recommended for better compression,
+          but take care as this is technically a lossy transformation and may be unsuitable for some
           applications.
 
   -i, --interlace <type>
@@ -83,16 +80,14 @@ Options:
           1     =>  Apply Adam7 interlacing on all images that are processed
           keep  =>  Keep the existing interlacing type of each image
           
-          Note that interlacing can add 25-50% to the size of an optimized
-          image. Only use it if you believe the benefits outweigh the costs for
-          your use case.
+          Note that interlacing can add 25-50% to the size of an optimized image. Only use it if you
+          believe the benefits outweigh the costs for your use case.
           
           [default: 0]
 
       --scale16
-          Forcibly reduce 16-bit images to 8-bit. Reduction is performed by
-          scaling the values, such that e.g. 0x00FF is reduced to 0x01 rather
-          than 0x00.
+          Forcibly reduce 16-bit images to 8-bit. Reduction is performed by scaling the values, such
+          that e.g. 0x00FF is reduced to 0x01 rather than 0x00.
 
   -v, --verbose...
           Run in verbose mode (use twice to increase verbosity)
@@ -101,9 +96,8 @@ Options:
           Run in quiet mode
 
   -f, --filters <list>
-          Peform compression trials with each of the given filter types. You can
-          specify a comma-separated list, or a range of values. E.g. '-f 0-3' is
-          the same as '-f 0,1,2,3'.
+          Peform compression trials with each of the given filter types. You can specify a
+          comma-separated list, or a range of values. E.g. '-f 0-3' is the same as '-f 0,1,2,3'.
           
           PNG delta filters (apply the same filter to every line)
               0  =>  None      (recommended to always include this filter)
@@ -121,13 +115,13 @@ Options:
           The default value depends on the optimization level preset.
 
       --fast
-          Perform a fast compression evaluation of each enabled filter, followed
-          by a single main compression trial of the best result. Recommended
-          if you have more filters enabled than CPU cores.
+          Perform a fast compression evaluation of each enabled filter, followed by a single main
+          compression trial of the best result. Recommended if you have more filters enabled than
+          CPU cores.
 
       --zc <level>
-          Deflate compression level (1-12) for main compression trials. The
-          levels here are defined by the libdeflate compression library.
+          Deflate compression level (1-12) for main compression trials. The levels here are defined
+          by the libdeflate compression library.
           
           The default value depends on the optimization level preset.
 
@@ -147,29 +141,27 @@ Options:
           Do not perform any transformations and do not deinterlace by default.
 
       --nz
-          Do not recompress IDAT unless required due to transformations.
-          Recompression of other compressed chunks (such as iCCP) will also be
-          disabled. Note that the combination of '--nx' and '--nz' will fully
-          disable all optimization.
+          Do not recompress IDAT unless required due to transformations. Recompression of other
+          compressed chunks (such as iCCP) will also be disabled. Note that the combination of
+          '--nx' and '--nz' will fully disable all optimization.
 
       --fix
-          Do not perform checksum validation of PNG chunks. This may allow some
-          files with errors to be processed successfully.
+          Do not perform checksum validation of PNG chunks. This may allow some files with errors to
+          be processed successfully.
 
       --force
           Write the output even if it is larger than the input
 
   -Z, --zopfli
-          Use the much slower but stronger Zopfli compressor for main
-          compression trials. Recommended use is with '-o max' and '--fast'.
+          Use the much slower but stronger Zopfli compressor for main compression trials.
+          Recommended use is with '-o max' and '--fast'.
 
       --timeout <secs>
-          Maximum amount of time, in seconds, to spend on optimizations. Oxipng
-          will check the timeout before each transformation or compression
-          trial, and will stop trying to optimize the file if the timeout is
-          exceeded. Note that this does not cut short any operations that are
-          already in progress, so it is currently of limited effectiveness for
-          large files with high compression levels.
+          Maximum amount of time, in seconds, to spend on optimizations. Oxipng will check the
+          timeout before each transformation or compression trial, and will stop trying to optimize
+          the file if the timeout is exceeded. Note that this does not cut short any operations that
+          are already in progress, so it is currently of limited effectiveness for large files with
+          high compression levels.
 
   -t, --threads <num>
           Set number of threads to use [default: num CPU cores]

--- a/MANUAL.txt
+++ b/MANUAL.txt
@@ -45,10 +45,7 @@ Options:
           Write output to stdout
 
   -p, --preserve
-          Preserve file permissions and timestamps if possible.
-          
-          Timestamps can only be preserved if oxipng was compiled with the
-          `filetime` feature.
+          Preserve file permissions and timestamps if possible
 
   -P, --pretend
           Do not write any files, only show compression results
@@ -65,6 +62,9 @@ Options:
           <list>  =>  Strip chunks in the comma-separated list, e.g. 'bKGD,cHRM'
           
           CAUTION: 'all' will convert APNGs to standard PNGs.
+          
+          Note that 'bKGD', 'sBIT' and 'hIST' will be forcibly stripped if the
+          color type or bit depth is changed, regardless of any options set.
 
       --keep <list>
           Strip all metadata except in the comma-separated list
@@ -126,28 +126,31 @@ Options:
           if you have more filters enabled than CPU cores.
 
       --zc <level>
-          zlib compression level (1-12)
+          Deflate compression level (1-12) for main compression trials. The
+          levels here are defined by the libdeflate compression library.
+          
+          The default value depends on the optimization level preset.
 
       --nb
-          No bit depth reduction
+          Do not change bit depth
 
       --nc
-          No color type reduction
+          Do not change color type
 
       --np
-          No palette reduction
+          Do not change color palette
 
       --ng
-          No grayscale reduction
+          Do not change to or from grayscale
 
       --nx
-          No reductions or deinterlacing
+          Do not perform any transformations and do not deinterlace by default.
 
       --nz
-          No recompression of IDAT unless reductions occur. Recompression of
-          other compressed chunks (such as iCCP) will also be disabled. Note
-          that the combination of '--nx' and '--nz' will fully disable all
-          optimization.
+          Do not recompress IDAT unless required due to transformations.
+          Recompression of other compressed chunks (such as iCCP) will also be
+          disabled. Note that the combination of '--nx' and '--nz' will fully
+          disable all optimization.
 
       --fix
           Do not perform checksum validation of PNG chunks. This may allow some
@@ -157,25 +160,19 @@ Options:
           Write the output even if it is larger than the input
 
   -Z, --zopfli
-          Use the slow but stronger Zopfli compressor. Recommended use is with
-          '-o max' and '--fast'.
-          
-          This option is only available if oxipng was compiled with the `zopfli`
-          feature.
+          Use the much slower but stronger Zopfli compressor for main
+          compression trials. Recommended use is with '-o max' and '--fast'.
 
       --timeout <secs>
           Maximum amount of time, in seconds, to spend on optimizations. Oxipng
-          will check the timeout before each reduction or compression trial, and
-          will stop trying to optimize the file if the timeout is exceeded. Note
-          that this does not cut short any compression trials that are already
-          in progress, so it is currently of limited effectiveness for large
-          files or high compression levels.
+          will check the timeout before each transformation or compression
+          trial, and will stop trying to optimize the file if the timeout is
+          exceeded. Note that this does not cut short any operations that are
+          already in progress, so it is currently of limited effectiveness for
+          large files with high compression levels.
 
   -t, --threads <num>
           Set number of threads to use [default: num CPU cores]
-          
-          This option is only available if oxipng was compiled with the
-          `parallel` feature.
 
   -h, --help
           Print help (see a summary with '-h')

--- a/MANUAL.txt
+++ b/MANUAL.txt
@@ -1,0 +1,184 @@
+oxipng 9.0.0
+Losslessly improve compression of PNG files
+
+Usage: oxipng [OPTIONS] <files>...
+
+Arguments:
+  <files>...
+          File(s) to compress (use '-' for stdin)
+
+Options:
+  -o, --opt <level>
+          Set the optimization level preset. The default level 2 is quite fast
+          and provides good compression. Lower levels are faster, higher levels
+          provide better compression, though with increasingly diminishing
+          returns.
+          
+          0   => --zc 5 --fast               (1 trial, determined heuristically)
+          1   => --zc 10 --fast              (1 trial, determined heuristically)
+          2   => --zc 11 -f 0,1,6,7 --fast   (4 fast trials, 1 main trial)
+          3   => --zc 11 -f 0,7,8,9          (4 trials)
+          4   => --zc 12 -f 0,7,8,9          (4 trials)
+          5   => --zc 12 -f 0,1,2,5,6,7,8,9  (8 trials)
+          6   => --zc 12 -f 0-9              (10 trials)
+          max =>                             (stable alias for the max level)
+          
+          Manually specifying a compression option (zc, f, etc.) will override
+          the optimization preset, regardless of the order you write the
+          arguments.
+          
+          [default: 2]
+
+  -r, --recursive
+          When directories are given as input, traverse the directory trees and
+          optimize all PNG files found (files with “.png” or “.apng” extension).
+
+      --dir <directory>
+          Write output file(s) to <directory>. If the directory does not exist,
+          it will be created. Note that this will not preserve the directory
+          structure of the input files when used with '--recursive'.
+
+      --out <file>
+          Write output file to <file>
+
+      --stdout
+          Write output to stdout
+
+  -p, --preserve
+          Preserve file permissions and timestamps if possible.
+          
+          Timestamps can only be preserved if oxipng was compiled with the
+          `filetime` feature.
+
+  -P, --pretend
+          Do not write any files, only show compression results
+
+  -s
+          Strip safely-removable chunks, same as '--strip safe'
+
+      --strip <mode>
+          Strip metadata chunks, where <mode> is one of:
+          
+          safe    =>  Strip all non-critical chunks, except for the following:
+                          cICP, iCCP, sRGB, pHYs, acTL, fcTL, fdAT
+          all     =>  Strip all non-critical chunks
+          <list>  =>  Strip chunks in the comma-separated list, e.g. 'bKGD,cHRM'
+          
+          CAUTION: 'all' will convert APNGs to standard PNGs.
+
+      --keep <list>
+          Strip all metadata except in the comma-separated list
+
+  -a, --alpha
+          Perform additional optimization on images with an alpha channel, by
+          altering the color values of fully transparent pixels. This is
+          generally recommended for better compression, but take care as this is
+          technically a lossy transformation and may be unsuitable for some
+          applications.
+
+  -i, --interlace <type>
+          Set the PNG interlacing type, where <type> is one of:
+          
+          0     =>  Remove interlacing from all images that are processed
+          1     =>  Apply Adam7 interlacing on all images that are processed
+          keep  =>  Keep the existing interlacing type of each image
+          
+          Note that interlacing can add 25-50% to the size of an optimized
+          image. Only use it if you believe the benefits outweigh the costs for
+          your use case.
+          
+          [default: 0]
+
+      --scale16
+          Forcibly reduce 16-bit images to 8-bit. Reduction is performed by
+          scaling the values, such that e.g. 0x00FF is reduced to 0x01 rather
+          than 0x00.
+
+  -v, --verbose...
+          Run in verbose mode (use twice to increase verbosity)
+
+  -q, --quiet
+          Run in quiet mode
+
+  -f, --filters <list>
+          Peform compression trials with each of the given filter types. You can
+          specify a comma-separated list, or a range of values. E.g. '-f 0-3' is
+          the same as '-f 0,1,2,3'.
+          
+          PNG delta filters (apply the same filter to every line)
+              0  =>  None      (recommended to always include this filter)
+              1  =>  Sub
+              2  =>  Up
+              3  =>  Average
+              4  =>  Paeth
+          Heuristic strategies (try to find the best delta filter for each line)
+              5  =>  MinSum    Minimum sum of absolute differences
+              6  =>  Entropy   Highest Shannon entropy
+              7  =>  Bigrams   Lowest count of distinct bigrams
+              8  =>  BigEnt    Highest Shannon entropy of bigrams
+              9  =>  Brute     Smallest compressed size (slow)
+          
+          The default value depends on the optimization level preset.
+
+      --fast
+          Perform a fast compression evaluation of each enabled filter, followed
+          by a single main compression trial of the best result. Recommended
+          if you have more filters enabled than CPU cores.
+
+      --zc <level>
+          zlib compression level (1-12)
+
+      --nb
+          No bit depth reduction
+
+      --nc
+          No color type reduction
+
+      --np
+          No palette reduction
+
+      --ng
+          No grayscale reduction
+
+      --nx
+          No reductions or deinterlacing
+
+      --nz
+          No recompression of IDAT unless reductions occur. Recompression of
+          other compressed chunks (such as iCCP) will also be disabled. Note
+          that the combination of '--nx' and '--nz' will fully disable all
+          optimization.
+
+      --fix
+          Do not perform checksum validation of PNG chunks. This may allow some
+          files with errors to be processed successfully.
+
+      --force
+          Write the output even if it is larger than the input
+
+  -Z, --zopfli
+          Use the slow but stronger Zopfli compressor. Recommended use is with
+          '-o max' and '--fast'.
+          
+          This option is only available if oxipng was compiled with the `zopfli`
+          feature.
+
+      --timeout <secs>
+          Maximum amount of time, in seconds, to spend on optimizations. Oxipng
+          will check the timeout before each reduction or compression trial, and
+          will stop trying to optimize the file if the timeout is exceeded. Note
+          that this does not cut short any compression trials that are already
+          in progress, so it is currently of limited effectiveness for large
+          files or high compression levels.
+
+  -t, --threads <num>
+          Set number of threads to use [default: num CPU cores]
+          
+          This option is only available if oxipng was compiled with the
+          `parallel` feature.
+
+  -h, --help
+          Print help (see a summary with '-h')
+
+  -V, --version
+          Print version

--- a/scripts/manual.sh
+++ b/scripts/manual.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+cargo build
+
+./target/debug/oxipng -V > MANUAL.txt
+./target/debug/oxipng --help >> MANUAL.txt

--- a/src/main.rs
+++ b/src/main.rs
@@ -35,9 +35,11 @@ use std::process::exit;
 use std::time::Duration;
 
 fn main() {
-    // Note: Long help descriptions should wrap at 70 characters (column 71)
-    // Indentation is 10 spaces, so this allows it to fit on an 80 character terminal
-    // Short help descriptions should ideally be no more than 54 characters
+    // Note: clap 'wrap_help' is enabled to automatically wrap lines according to terminal width.
+    // To keep things tidy though, short help descriptions should be no more than 54 characters,
+    // so that they can fit on a single line in an 80 character terminal.
+    // Long help descriptions are soft wrapped here at 90 characters (column 91) but this does not
+    // affect output, it simply matches what is rendered when help is output to a file.
     let matches = Command::new("oxipng")
         .version(env!("CARGO_PKG_VERSION"))
         .author("Joshua Holmer <jholmer.in@gmail.com>")
@@ -55,10 +57,9 @@ fn main() {
             Arg::new("optimization")
                 .help("Optimization level (0-6, or max)")
                 .long_help("\
-Set the optimization level preset. The default level 2 is quite fast
-and provides good compression. Lower levels are faster, higher levels
-provide better compression, though with increasingly diminishing
-returns.
+Set the optimization level preset. The default level 2 is quite fast and provides good \
+compression. Lower levels are faster, higher levels provide better compression, though \
+with increasingly diminishing returns.
 
 0   => --zc 5 --fast               (1 trial, determined heuristically)
 1   => --zc 10 --fast              (1 trial, determined heuristically)
@@ -69,9 +70,8 @@ returns.
 6   => --zc 12 -f 0-9              (10 trials)
 max =>                             (stable alias for the max level)
 
-Manually specifying a compression option (zc, f, etc.) will override
-the optimization preset, regardless of the order you write the
-arguments.")
+Manually specifying a compression option (zc, f, etc.) will override the optimization \
+preset, regardless of the order you write the arguments.")
                 .short('o')
                 .long("opt")
                 .value_name("level")
@@ -91,8 +91,8 @@ arguments.")
             Arg::new("recursive")
                 .help("Recurse input directories, optimizing all PNG files")
                 .long_help("\
-When directories are given as input, traverse the directory trees and
-optimize all PNG files found (files with “.png” or “.apng” extension).")
+When directories are given as input, traverse the directory trees and optimize all PNG \
+files found (files with “.png” or “.apng” extension).")
                 .short('r')
                 .long("recursive")
                 .action(ArgAction::SetTrue),
@@ -101,9 +101,9 @@ optimize all PNG files found (files with “.png” or “.apng” extension).")
             Arg::new("output_dir")
                 .help("Write output file(s) to <directory>")
                 .long_help("\
-Write output file(s) to <directory>. If the directory does not exist,
-it will be created. Note that this will not preserve the directory
-structure of the input files when used with '--recursive'.")
+Write output file(s) to <directory>. If the directory does not exist, it will be created. \
+Note that this will not preserve the directory structure of the input files when used with \
+'--recursive'.")
                 .long("dir")
                 .value_name("directory")
                 .value_parser(value_parser!(PathBuf))
@@ -161,8 +161,8 @@ all     =>  Strip all non-critical chunks
 
 CAUTION: 'all' will convert APNGs to standard PNGs.
 
-Note that 'bKGD', 'sBIT' and 'hIST' will be forcibly stripped if the
-color type or bit depth is changed, regardless of any options set.",
+Note that 'bKGD', 'sBIT' and 'hIST' will be forcibly stripped if the color type or bit \
+depth is changed, regardless of any options set.",
                     StripChunks::KEEP_SAFE
                         .iter()
                         .map(|c| String::from_utf8_lossy(c))
@@ -184,10 +184,9 @@ color type or bit depth is changed, regardless of any options set.",
             Arg::new("alpha")
                 .help("Perform additional alpha channel optimization")
                 .long_help("\
-Perform additional optimization on images with an alpha channel, by
-altering the color values of fully transparent pixels. This is
-generally recommended for better compression, but take care as this is
-technically a lossy transformation and may be unsuitable for some
+Perform additional optimization on images with an alpha channel, by altering the color \
+values of fully transparent pixels. This is generally recommended for better compression, \
+but take care as this is technically a lossy transformation and may be unsuitable for some \
 applications.")
                 .short('a')
                 .long("alpha")
@@ -203,9 +202,8 @@ Set the PNG interlacing type, where <type> is one of:
 1     =>  Apply Adam7 interlacing on all images that are processed
 keep  =>  Keep the existing interlacing type of each image
 
-Note that interlacing can add 25-50% to the size of an optimized
-image. Only use it if you believe the benefits outweigh the costs for
-your use case.")
+Note that interlacing can add 25-50% to the size of an optimized image. Only use it if you \
+believe the benefits outweigh the costs for your use case.")
                 .short('i')
                 .long("interlace")
                 .value_name("type")
@@ -217,9 +215,8 @@ your use case.")
             Arg::new("scale16")
                 .help("Forcibly reduce 16-bit images to 8-bit")
                 .long_help("\
-Forcibly reduce 16-bit images to 8-bit. Reduction is performed by
-scaling the values, such that e.g. 0x00FF is reduced to 0x01 rather
-than 0x00.")
+Forcibly reduce 16-bit images to 8-bit. Reduction is performed by scaling the values, such \
+that e.g. 0x00FF is reduced to 0x01 rather than 0x00.")
                 .long("scale16")
                 .action(ArgAction::SetTrue),
         )
@@ -243,9 +240,8 @@ than 0x00.")
             Arg::new("filters")
                 .help(format!("Filters to try (0-{}; see '--help' for details)", RowFilter::LAST))
                 .long_help("\
-Peform compression trials with each of the given filter types. You can
-specify a comma-separated list, or a range of values. E.g. '-f 0-3' is
-the same as '-f 0,1,2,3'.
+Peform compression trials with each of the given filter types. You can specify a \
+comma-separated list, or a range of values. E.g. '-f 0-3' is the same as '-f 0,1,2,3'.
 
 PNG delta filters (apply the same filter to every line)
     0  =>  None      (recommended to always include this filter)
@@ -273,9 +269,9 @@ The default value depends on the optimization level preset.")
             Arg::new("fast")
                 .help("Use fast filter evaluation")
                 .long_help("\
-Perform a fast compression evaluation of each enabled filter, followed
-by a single main compression trial of the best result. Recommended
-if you have more filters enabled than CPU cores.")
+Perform a fast compression evaluation of each enabled filter, followed by a single main \
+compression trial of the best result. Recommended if you have more filters enabled than \
+CPU cores.")
                 .long("fast")
                 .action(ArgAction::SetTrue),
         )
@@ -283,8 +279,8 @@ if you have more filters enabled than CPU cores.")
             Arg::new("compression")
                 .help("Deflate compression level (1-12)")
                 .long_help("\
-Deflate compression level (1-12) for main compression trials. The
-levels here are defined by the libdeflate compression library.
+Deflate compression level (1-12) for main compression trials. The levels here are defined \
+by the libdeflate compression library.
 
 The default value depends on the optimization level preset.")
                 .long("zc")
@@ -328,10 +324,9 @@ Do not perform any transformations and do not deinterlace by default.")
             Arg::new("no-recoding")
                 .help("Do not recompress unless transformations occur")
                 .long_help("\
-Do not recompress IDAT unless required due to transformations.
-Recompression of other compressed chunks (such as iCCP) will also be
-disabled. Note that the combination of '--nx' and '--nz' will fully
-disable all optimization.")
+Do not recompress IDAT unless required due to transformations. Recompression of other \
+compressed chunks (such as iCCP) will also be disabled. Note that the combination of \
+'--nx' and '--nz' will fully disable all optimization.")
                 .long("nz")
                 .action(ArgAction::SetTrue),
         )
@@ -339,8 +334,8 @@ disable all optimization.")
             Arg::new("fix")
                 .help("Disable checksum validation")
                 .long_help("\
-Do not perform checksum validation of PNG chunks. This may allow some
-files with errors to be processed successfully.")
+Do not perform checksum validation of PNG chunks. This may allow some files with errors to \
+be processed successfully.")
                 .long("fix")
                 .action(ArgAction::SetTrue),
         )
@@ -354,8 +349,8 @@ files with errors to be processed successfully.")
             Arg::new("zopfli")
                 .help("Use the much slower but stronger Zopfli compressor")
                 .long_help("\
-Use the much slower but stronger Zopfli compressor for main
-compression trials. Recommended use is with '-o max' and '--fast'.")
+Use the much slower but stronger Zopfli compressor for main compression trials. \
+Recommended use is with '-o max' and '--fast'.")
                 .short('Z')
                 .long("zopfli")
                 .action(ArgAction::SetTrue),
@@ -364,12 +359,11 @@ compression trials. Recommended use is with '-o max' and '--fast'.")
             Arg::new("timeout")
                 .help("Maximum amount of time to spend on optimizations")
                 .long_help("\
-Maximum amount of time, in seconds, to spend on optimizations. Oxipng
-will check the timeout before each transformation or compression
-trial, and will stop trying to optimize the file if the timeout is
-exceeded. Note that this does not cut short any operations that are
-already in progress, so it is currently of limited effectiveness for
-large files with high compression levels.")
+Maximum amount of time, in seconds, to spend on optimizations. Oxipng will check the \
+timeout before each transformation or compression trial, and will stop trying to optimize \
+the file if the timeout is exceeded. Note that this does not cut short any operations that \
+are already in progress, so it is currently of limited effectiveness for large files with \
+high compression levels.")
                 .value_name("secs")
                 .long("timeout")
                 .value_parser(value_parser!(u64)),

--- a/src/main.rs
+++ b/src/main.rs
@@ -186,8 +186,8 @@ depth is changed, regardless of any options set.",
                 .long_help("\
 Perform additional optimization on images with an alpha channel, by altering the color \
 values of fully transparent pixels. This is generally recommended for better compression, \
-but take care as this is technically a lossy transformation and may be unsuitable for some \
-applications.")
+but take care as while this is “visually lossless”, it is technically a lossy \
+transformation and may be unsuitable for some applications.")
                 .short('a')
                 .long("alpha")
                 .action(ArgAction::SetTrue),
@@ -213,10 +213,15 @@ believe the benefits outweigh the costs for your use case.")
         )
         .arg(
             Arg::new("scale16")
-                .help("Forcibly reduce 16-bit images to 8-bit")
+                .help("Forcibly reduce 16-bit images to 8-bit (lossy)")
                 .long_help("\
-Forcibly reduce 16-bit images to 8-bit. Reduction is performed by scaling the values, such \
-that e.g. 0x00FF is reduced to 0x01 rather than 0x00.")
+Forcibly reduce images with 16 bits per channel to 8 bits per channel. This is a lossy \
+operation but can provide significant savings when you have no need for higher depth. \
+Reduction is performed by scaling the values such that, e.g. 0x00FF is reduced to 0x01 \
+rather than 0x00.
+
+Without this flag, 16-bit images will only be reduced in depth if it can be done \
+losslessly.")
                 .long("scale16")
                 .action(ArgAction::SetTrue),
         )
@@ -240,7 +245,7 @@ that e.g. 0x00FF is reduced to 0x01 rather than 0x00.")
             Arg::new("filters")
                 .help(format!("Filters to try (0-{}; see '--help' for details)", RowFilter::LAST))
                 .long_help("\
-Peform compression trials with each of the given filter types. You can specify a \
+Perform compression trials with each of the given filter types. You can specify a \
 comma-separated list, or a range of values. E.g. '-f 0-3' is the same as '-f 0,1,2,3'.
 
 PNG delta filters (apply the same filter to every line)

--- a/src/main.rs
+++ b/src/main.rs
@@ -35,13 +35,16 @@ use std::process::exit;
 use std::time::Duration;
 
 fn main() {
+    // Note: Long help descriptions should wrap at 70 characters (column 71)
+    // Indentation is 10 spaces, so this allows it to fit on an 80 character terminal
+    // Short help descriptions should ideally be no more than 54 characters
     let matches = Command::new("oxipng")
         .version(env!("CARGO_PKG_VERSION"))
         .author("Joshua Holmer <jholmer.in@gmail.com>")
-        .about("Losslessly improves compression of PNG files")
+        .about("Losslessly improve compression of PNG files")
         .arg(
             Arg::new("files")
-                .help("File(s) to compress (use \"-\" for stdin)")
+                .help("File(s) to compress (use '-' for stdin)")
                 .index(1)
                 .num_args(1..)
                 .use_value_delimiter(false)
@@ -50,11 +53,31 @@ fn main() {
         )
         .arg(
             Arg::new("optimization")
-                .help("Optimization level - Default: 2")
+                .help("Optimization level (0-6, or max)")
+                .long_help("\
+Set the optimization level preset. The default level 2 is quite fast
+and provides good compression. Lower levels are faster, higher levels
+provide better compression, though with increasingly diminishing
+returns.
+
+0   => --zc 5 --fast               (1 trial, determined heuristically)
+1   => --zc 10 --fast              (1 trial, determined heuristically)
+2   => --zc 11 -f 0,1,6,7 --fast   (4 fast trials, 1 main trial)
+3   => --zc 11 -f 0,7,8,9          (4 trials)
+4   => --zc 12 -f 0,7,8,9          (4 trials)
+5   => --zc 12 -f 0,1,2,5,6,7,8,9  (8 trials)
+6   => --zc 12 -f 0-9              (10 trials)
+max =>                             (stable alias for the max level)
+
+Manually specifying a compression option (zc, f, etc.) will override
+the optimization preset, regardless of the order you write the
+arguments.")
                 .short('o')
                 .long("opt")
                 .value_name("level")
-                .value_parser(["0", "1", "2", "3", "4", "5", "6", "max"]),
+                .default_value("2")
+                .value_parser(["0", "1", "2", "3", "4", "5", "6", "max"])
+                .hide_possible_values(true),
         )
         .arg(
             Arg::new("backup")
@@ -66,7 +89,10 @@ fn main() {
         )
         .arg(
             Arg::new("recursive")
-                .help("Recurse into subdirectories and optimize all *.png/*.apng files")
+                .help("Recurse input directories, optimizing all PNG files")
+                .long_help("\
+When directories are given as input, traverse the directory trees and
+optimize all PNG files found (files with “.png” or “.apng” extension).")
                 .short('r')
                 .long("recursive")
                 .action(ArgAction::SetTrue),
@@ -74,6 +100,10 @@ fn main() {
         .arg(
             Arg::new("output_dir")
                 .help("Write output file(s) to <directory>")
+                .long_help("\
+Write output file(s) to <directory>. If the directory does not exist,
+it will be created. Note that this will not preserve the directory
+structure of the input files when used with '--recursive'.")
                 .long("dir")
                 .value_name("directory")
                 .value_parser(value_parser!(PathBuf))
@@ -99,35 +129,54 @@ fn main() {
         )
         .arg(
             Arg::new("preserve")
-                .help("Preserve file attributes if possible")
+                .help("Preserve file permissions and timestamps if possible")
+                .long_help("\
+Preserve file permissions and timestamps if possible.
+
+Timestamps can only be preserved if oxipng was compiled with the
+`filetime` feature.")
                 .short('p')
                 .long("preserve")
                 .action(ArgAction::SetTrue),
         )
         .arg(
             Arg::new("pretend")
-                .help("Do not write any files, only calculate compression gains")
+                .help("Do not write any files, only show compression results")
                 .short('P')
                 .long("pretend")
                 .action(ArgAction::SetTrue),
         )
         .arg(
             Arg::new("strip-safe")
-                .help("Strip safely-removable metadata objects")
+                .help("Strip safely-removable chunks, same as '--strip safe'")
                 .short('s')
                 .action(ArgAction::SetTrue)
                 .conflicts_with("strip"),
         )
         .arg(
             Arg::new("strip")
-                .help("Strip metadata objects ['safe', 'all', or comma-separated list]\nCAUTION: stripping 'all' will convert APNGs to standard PNGs")
+                .help("Strip metadata (safe, all, or comma-separated list)\nCAUTION: 'all' will convert APNGs to standard PNGs")
+                .long_help(format!("\
+Strip metadata chunks, where <mode> is one of:
+
+safe    =>  Strip all non-critical chunks, except for the following:
+                {}
+all     =>  Strip all non-critical chunks
+<list>  =>  Strip chunks in the comma-separated list, e.g. 'bKGD,cHRM'
+
+CAUTION: 'all' will convert APNGs to standard PNGs.",
+                    StripChunks::KEEP_SAFE
+                        .iter()
+                        .map(|c| String::from_utf8_lossy(c))
+                        .collect::<Vec<_>>()
+                        .join(", ")))
                 .long("strip")
                 .value_name("mode")
                 .conflicts_with("strip-safe"),
         )
         .arg(
             Arg::new("keep")
-                .help("Strip all optional metadata except objects in the comma-separated list")
+                .help("Strip all metadata except in the comma-separated list")
                 .long("keep")
                 .value_name("list")
                 .conflicts_with("strip")
@@ -135,28 +184,50 @@ fn main() {
         )
         .arg(
             Arg::new("alpha")
-                .help("Perform additional alpha optimizations")
+                .help("Perform additional alpha channel optimization")
+                .long_help("\
+Perform additional optimization on images with an alpha channel, by
+altering the color values of fully transparent pixels. This is
+generally recommended for better compression, but take care as this is
+technically a lossy transformation and may be unsuitable for some
+applications.")
                 .short('a')
                 .long("alpha")
                 .action(ArgAction::SetTrue),
         )
         .arg(
             Arg::new("interlace")
-                .help("PNG interlace type - Default: 0")
+                .help("Set PNG interlacing type (0, 1, keep)")
+                .long_help("\
+Set the PNG interlacing type, where <type> is one of:
+
+0     =>  Remove interlacing from all images that are processed
+1     =>  Apply Adam7 interlacing on all images that are processed
+keep  =>  Keep the existing interlacing type of each image
+
+Note that interlacing can add 25-50% to the size of an optimized
+image. Only use it if you believe the benefits outweigh the costs for
+your use case.")
                 .short('i')
                 .long("interlace")
                 .value_name("type")
-                .value_parser(["0", "1", "keep"]),
+                .default_value("0")
+                .value_parser(["0", "1", "keep"])
+                .hide_possible_values(true),
         )
         .arg(
             Arg::new("scale16")
                 .help("Forcibly reduce 16-bit images to 8-bit")
+                .long_help("\
+Forcibly reduce 16-bit images to 8-bit. Reduction is performed by
+scaling the values, such that e.g. 0x00FF is reduced to 0x01 rather
+than 0x00.")
                 .long("scale16")
                 .action(ArgAction::SetTrue),
         )
         .arg(
             Arg::new("verbose")
-                .help("Run in verbose mode (use multiple times to increase verbosity)")
+                .help("Run in verbose mode (use twice to increase verbosity)")
                 .short('v')
                 .long("verbose")
                 .action(ArgAction::Count)
@@ -172,9 +243,29 @@ fn main() {
         )
         .arg(
             Arg::new("filters")
-                .help(format!("PNG delta filters (0-{})", RowFilter::LAST))
+                .help(format!("Filters to try (0-{}; see '--help' for details)", RowFilter::LAST))
+                .long_help("\
+Peform compression trials with each of the given filter types. You can
+specify a comma-separated list, or a range of values. E.g. '-f 0-3' is
+the same as '-f 0,1,2,3'.
+
+PNG delta filters (apply the same filter to every line)
+    0  =>  None      (recommended to always include this filter)
+    1  =>  Sub
+    2  =>  Up
+    3  =>  Average
+    4  =>  Paeth
+Heuristic strategies (try to find the best delta filter for each line)
+    5  =>  MinSum    Minimum sum of absolute differences
+    6  =>  Entropy   Highest Shannon entropy
+    7  =>  Bigrams   Lowest count of distinct bigrams
+    8  =>  BigEnt    Highest Shannon entropy of bigrams
+    9  =>  Brute     Smallest compressed size (slow)
+
+The default value depends on the optimization level preset.")
                 .short('f')
                 .long("filters")
+                .value_name("list")
                 .value_parser(|x: &str| {
                     parse_numeric_range_opts(x, 0, RowFilter::LAST)
                         .map_err(|_| "Invalid option for filters")
@@ -182,7 +273,11 @@ fn main() {
         )
         .arg(
             Arg::new("fast")
-                .help("Use fast filter evaluation (helpful when you have more filters enabled than CPU cores)")
+                .help("Use fast filter evaluation")
+                .long_help("\
+Perform a fast compression evaluation of each enabled filter, followed
+by a single main compression trial of the best result. Recommended
+if you have more filters enabled than CPU cores.")
                 .long("fast")
                 .action(ArgAction::SetTrue),
         )
@@ -226,13 +321,21 @@ fn main() {
         )
         .arg(
             Arg::new("no-recoding")
-                .help("No recoding of IDAT or other compressed chunks unless necessary")
+                .help("No recompression unless reductions occur")
+                .long_help("\
+No recompression of IDAT unless reductions occur. Recompression of
+other compressed chunks (such as iCCP) will also be disabled. Note
+that the combination of '--nx' and '--nz' will fully disable all
+optimization.")
                 .long("nz")
                 .action(ArgAction::SetTrue),
         )
         .arg(
             Arg::new("fix")
-                .help("Enable error recovery")
+                .help("Disable checksum validation")
+                .long_help("\
+Do not perform checksum validation of PNG chunks. This may allow some
+files with errors to be processed successfully.")
                 .long("fix")
                 .action(ArgAction::SetTrue),
         )
@@ -244,53 +347,46 @@ fn main() {
         )
         .arg(
             Arg::new("zopfli")
-                .help("Use the slow but stronger Zopfli compressor (recommended use is with all filters and `--fast` enabled)")
+                .help("Use the slow but stronger Zopfli compressor")
+                .long_help("\
+Use the slow but stronger Zopfli compressor. Recommended use is with
+'-o max' and '--fast'.
+
+This option is only available if oxipng was compiled with the `zopfli`
+feature.")
                 .short('Z')
                 .long("zopfli")
                 .action(ArgAction::SetTrue),
         )
         .arg(
             Arg::new("timeout")
-                .help("Maximum amount of time, in seconds, to spend on optimizations (currently of limited use due to the shift away from zlib)")
+                .help("Maximum amount of time to spend on optimizations")
+                .long_help("\
+Maximum amount of time, in seconds, to spend on optimizations. Oxipng
+will check the timeout before each reduction or compression trial, and
+will stop trying to optimize the file if the timeout is exceeded. Note
+that this does not cut short any compression trials that are already
+in progress, so it is currently of limited effectiveness for large
+files or high compression levels.")
                 .value_name("secs")
                 .long("timeout")
                 .value_parser(value_parser!(u64)),
         )
         .arg(
             Arg::new("threads")
-                .help("Set number of threads to use - Default: num CPU cores")
+                .help("Set number of threads to use [default: num CPU cores]")
+                .long_help("\
+Set number of threads to use [default: num CPU cores]
+
+This option is only available if oxipng was compiled with the
+`parallel` feature.")
                 .long("threads")
                 .short('t')
                 .value_name("num")
                 .value_parser(value_parser!(usize)),
         )
-        .after_help(
-            "Optimization levels:
-    -o 0   =>  --zc 5 --fast                (1 trial, determined heuristically)
-    -o 1   =>  --zc 10 --fast               (1 trial, determined heuristically)
-    -o 2   =>  --zc 11 -f 0,1,6,7 --fast    (1 trial, determined by fast evaluation)
-    -o 3   =>  --zc 11 -f 0,7,8,9           (4 trials)
-    -o 4   =>  --zc 12 -f 0,7,8,9           (4 trials; same as `-o 3` for zopfli)
-    -o 5   =>  --zc 12 -f 0,1,2,5,6,7,8,9   (8 trials)
-    -o 6   =>  --zc 12 -f 0-9               (10 trials)
-    -o max =>                               (stable alias for the max compression)
-
-    Manually specifying a compression option (zc, f, etc.) will override the optimization preset,
-    regardless of the order you write the arguments.
-
-PNG delta filters:
-    0  =>  None
-    1  =>  Sub
-    2  =>  Up
-    3  =>  Average
-    4  =>  Paeth
-Heuristic filter selection strategies:
-    5  =>  MinSum    Minimum sum of absolute differences
-    6  =>  Entropy   Highest Shannon entropy
-    7  =>  Bigrams   Lowest count of distinct bigrams
-    8  =>  BigEnt    Highest Shannon entropy of bigrams
-    9  =>  Brute     Smallest compressed size (slow)",
-        )
+        .after_help("Run `oxipng --help` to see full details of all options")
+        .after_long_help("")
         .get_matches_from(std::env::args());
 
     if matches.get_flag("backup") {

--- a/src/main.rs
+++ b/src/main.rs
@@ -130,11 +130,6 @@ structure of the input files when used with '--recursive'.")
         .arg(
             Arg::new("preserve")
                 .help("Preserve file permissions and timestamps if possible")
-                .long_help("\
-Preserve file permissions and timestamps if possible.
-
-Timestamps can only be preserved if oxipng was compiled with the
-`filetime` feature.")
                 .short('p')
                 .long("preserve")
                 .action(ArgAction::SetTrue),
@@ -164,7 +159,10 @@ safe    =>  Strip all non-critical chunks, except for the following:
 all     =>  Strip all non-critical chunks
 <list>  =>  Strip chunks in the comma-separated list, e.g. 'bKGD,cHRM'
 
-CAUTION: 'all' will convert APNGs to standard PNGs.",
+CAUTION: 'all' will convert APNGs to standard PNGs.
+
+Note that 'bKGD', 'sBIT' and 'hIST' will be forcibly stripped if the
+color type or bit depth is changed, regardless of any options set.",
                     StripChunks::KEEP_SAFE
                         .iter()
                         .map(|c| String::from_utf8_lossy(c))
@@ -283,7 +281,12 @@ if you have more filters enabled than CPU cores.")
         )
         .arg(
             Arg::new("compression")
-                .help("zlib compression level (1-12)")
+                .help("Deflate compression level (1-12)")
+                .long_help("\
+Deflate compression level (1-12) for main compression trials. The
+levels here are defined by the libdeflate compression library.
+
+The default value depends on the optimization level preset.")
                 .long("zc")
                 .value_name("level")
                 .value_parser(1..=12)
@@ -291,42 +294,44 @@ if you have more filters enabled than CPU cores.")
         )
         .arg(
             Arg::new("no-bit-reduction")
-                .help("No bit depth reduction")
+                .help("Do not change bit depth")
                 .long("nb")
                 .action(ArgAction::SetTrue),
         )
         .arg(
             Arg::new("no-color-reduction")
-                .help("No color type reduction")
+                .help("Do not change color type")
                 .long("nc")
                 .action(ArgAction::SetTrue),
         )
         .arg(
             Arg::new("no-palette-reduction")
-                .help("No palette reduction")
+                .help("Do not change color palette")
                 .long("np")
                 .action(ArgAction::SetTrue),
         )
         .arg(
             Arg::new("no-grayscale-reduction")
-                .help("No grayscale reduction")
+                .help("Do not change to or from grayscale")
                 .long("ng")
                 .action(ArgAction::SetTrue),
         )
         .arg(
             Arg::new("no-reductions")
-                .help("No reductions or deinterlacing")
+                .help("Do not perform any transformations")
+                .long_help("\
+Do not perform any transformations and do not deinterlace by default.")
                 .long("nx")
                 .action(ArgAction::SetTrue),
         )
         .arg(
             Arg::new("no-recoding")
-                .help("No recompression unless reductions occur")
+                .help("Do not recompress unless transformations occur")
                 .long_help("\
-No recompression of IDAT unless reductions occur. Recompression of
-other compressed chunks (such as iCCP) will also be disabled. Note
-that the combination of '--nx' and '--nz' will fully disable all
-optimization.")
+Do not recompress IDAT unless required due to transformations.
+Recompression of other compressed chunks (such as iCCP) will also be
+disabled. Note that the combination of '--nx' and '--nz' will fully
+disable all optimization.")
                 .long("nz")
                 .action(ArgAction::SetTrue),
         )
@@ -347,13 +352,10 @@ files with errors to be processed successfully.")
         )
         .arg(
             Arg::new("zopfli")
-                .help("Use the slow but stronger Zopfli compressor")
+                .help("Use the much slower but stronger Zopfli compressor")
                 .long_help("\
-Use the slow but stronger Zopfli compressor. Recommended use is with
-'-o max' and '--fast'.
-
-This option is only available if oxipng was compiled with the `zopfli`
-feature.")
+Use the much slower but stronger Zopfli compressor for main
+compression trials. Recommended use is with '-o max' and '--fast'.")
                 .short('Z')
                 .long("zopfli")
                 .action(ArgAction::SetTrue),
@@ -363,11 +365,11 @@ feature.")
                 .help("Maximum amount of time to spend on optimizations")
                 .long_help("\
 Maximum amount of time, in seconds, to spend on optimizations. Oxipng
-will check the timeout before each reduction or compression trial, and
-will stop trying to optimize the file if the timeout is exceeded. Note
-that this does not cut short any compression trials that are already
-in progress, so it is currently of limited effectiveness for large
-files or high compression levels.")
+will check the timeout before each transformation or compression
+trial, and will stop trying to optimize the file if the timeout is
+exceeded. Note that this does not cut short any operations that are
+already in progress, so it is currently of limited effectiveness for
+large files with high compression levels.")
                 .value_name("secs")
                 .long("timeout")
                 .value_parser(value_parser!(u64)),
@@ -375,11 +377,6 @@ files or high compression levels.")
         .arg(
             Arg::new("threads")
                 .help("Set number of threads to use [default: num CPU cores]")
-                .long_help("\
-Set number of threads to use [default: num CPU cores]
-
-This option is only available if oxipng was compiled with the
-`parallel` feature.")
                 .long("threads")
                 .short('t')
                 .value_name("num")


### PR DESCRIPTION
This PR brings a big overhaul to oxipng's help, with new long form descriptions of many options.

The full output (--help) is added as a text file MANUAL.txt. Critiques welcome.

The short output (-h) is simplified and appears as follows:
```
Losslessly improve compression of PNG files

Usage: oxipng [OPTIONS] <files>...

Arguments:
  <files>...  File(s) to compress (use '-' for stdin)

Options:
  -o, --opt <level>       Optimization level (0-6, or max) [default: 2]
  -r, --recursive         Recurse input directories, optimizing all PNG files
      --dir <directory>   Write output file(s) to <directory>
      --out <file>        Write output file to <file>
      --stdout            Write output to stdout
  -p, --preserve          Preserve file permissions and timestamps if possible
  -P, --pretend           Do not write any files, only show compression results
  -s                      Strip safely-removable chunks, same as '--strip safe'
      --strip <mode>      Strip metadata (safe, all, or comma-separated list)
                          CAUTION: 'all' will convert APNGs to standard PNGs
      --keep <list>       Strip all metadata except in the comma-separated list
  -a, --alpha             Perform additional alpha channel optimization
  -i, --interlace <type>  Set PNG interlacing type (0, 1, keep) [default: 0]
      --scale16           Forcibly reduce 16-bit images to 8-bit (lossy)
  -v, --verbose...        Run in verbose mode (use twice to increase verbosity)
  -q, --quiet             Run in quiet mode
  -f, --filters <list>    Filters to try (0-9; see '--help' for details)
      --fast              Use fast filter evaluation
      --zc <level>        Deflate compression level (1-12)
      --nb                Do not change bit depth
      --nc                Do not change color type
      --np                Do not change color palette
      --ng                Do not change to or from grayscale
      --nx                Do not perform any transformations
      --nz                Do not recompress unless transformations occur
      --fix               Disable checksum validation
      --force             Write the output even if it is larger than the input
  -Z, --zopfli            Use the much slower but stronger Zopfli compressor
      --timeout <secs>    Maximum amount of time to spend on optimizations
  -t, --threads <num>     Set number of threads to use [default: num CPU cores]
  -h, --help              Print help (see more with '--help')
  -V, --version           Print version

Run `oxipng --help` to see full details of all options
```