### PR TITLE
Restore executable permissions on Unix release tarball binaries

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -67,6 +67,12 @@ jobs:
             *)
               cp ../LICENSE "$ARCHIVE_NAME"
               cp oxipng "$ARCHIVE_NAME"
+              # Execute permissions are not stored in artifact files,
+              # so make the binary world-executable to meet user
+              # expectations set by preceding releases.
+              # Related issue:
+              # https://github.com/shssoichiro/oxipng/issues/575
+              chmod ugo+x "$ARCHIVE_NAME"/oxipng
               tar -vczf "${ARCHIVE_NAME}.tar.gz" "$ARCHIVE_NAME"/*;;
           esac
 


### PR DESCRIPTION
These changes resolve #575 by setting the OxiPNG binary that's about to be put in a release tarball to be world-executable during the release workflow, as such permissions are lost when fetching them from artifacts.