### PR TITLE
Allow strip and keep to be used together

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -176,9 +176,7 @@ depth is changed, regardless of any options set.",
             Arg::new("keep")
                 .help("Strip all metadata except in the comma-separated list")
                 .long("keep")
-                .value_name("list")
-                .conflicts_with("strip")
-                .conflicts_with("strip-safe"),
+                .value_name("list"),
         )
         .arg(
             Arg::new("alpha")
@@ -613,14 +611,6 @@ fn parse_opts_into_struct(
         };
     }
 
-    if let Some(keep) = matches.get_one::<String>("keep") {
-        let names = keep
-            .split(',')
-            .map(parse_chunk_name)
-            .collect::<Result<_, _>>()?;
-        opts.strip = StripChunks::Keep(names)
-    }
-
     if let Some(strip) = matches.get_one::<String>("strip") {
         if strip == "safe" {
             opts.strip = StripChunks::Safe;
@@ -647,10 +637,23 @@ fn parse_opts_into_struct(
                 .collect::<Result<_, _>>()?;
             opts.strip = StripChunks::Strip(names);
         }
+    } else if matches.get_flag("strip-safe") {
+        opts.strip = StripChunks::Safe;
     }
 
-    if matches.get_flag("strip-safe") {
-        opts.strip = StripChunks::Safe;
+    if let Some(keep) = matches.get_one::<String>("keep") {
+        if matches!(opts.strip, StripChunks::Strip(_)) {
+            return Err("--strip <list> and --keep cannot be used together".to_owned());
+        }
+        let mut names: IndexSet<_> = keep
+            .split(',')
+            .map(parse_chunk_name)
+            .collect::<Result<_, _>>()?;
+        if opts.strip == StripChunks::Safe {
+            // Add the keep safe chunks to the list
+            names.extend(StripChunks::KEEP_SAFE.iter().cloned());
+        }
+        opts.strip = StripChunks::Keep(names);
     }
 
     if matches.get_flag("zopfli") {


### PR DESCRIPTION
This is a minor change that allows using both `--strip` and `--keep` at the same time.

E.g. `--strip safe --keep eXIf` will strip chunks while preserving both the ones that aren't "safe" to remove *and* eXIf. Essentially it's a convenience to allow extending the default list used by `--strip safe`.

Specifying chunk names for both options is not permitted, e.g. `--strip eXIf --keep eXIf` will error.

Use of `--strip all` with `--keep` is redundant, but is permitted.