### PR TITLE
Add `--keep display` equivalent to `--strip safe`

### DIFF
--- a/src/headers.rs
+++ b/src/headers.rs
@@ -76,7 +76,7 @@ pub enum StripChunks {
     None,
     /// Remove specific chunks
     Strip(IndexSet<[u8; 4]>),
-    /// Remove all chunks that won't affect rendering
+    /// Remove all chunks that won't affect image display
     Safe,
     /// Remove all non-critical chunks except these
     Keep(IndexSet<[u8; 4]>),
@@ -85,8 +85,8 @@ pub enum StripChunks {
 }
 
 impl StripChunks {
-    /// List of chunks that will be kept when using the `Safe` option
-    pub const KEEP_SAFE: [[u8; 4]; 7] = [
+    /// List of chunks that affect image display and will be kept when using the `Safe` option
+    pub const DISPLAY: [[u8; 4]; 7] = [
         *b"cICP", *b"iCCP", *b"sRGB", *b"pHYs", *b"acTL", *b"fcTL", *b"fdAT",
     ];
 
@@ -95,7 +95,7 @@ impl StripChunks {
             StripChunks::None => true,
             StripChunks::Keep(names) => names.contains(name),
             StripChunks::Strip(names) => !names.contains(name),
-            StripChunks::Safe => Self::KEEP_SAFE.contains(name),
+            StripChunks::Safe => Self::DISPLAY.contains(name),
             StripChunks::All => false,
         }
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -614,10 +614,20 @@ fn parse_opts_into_struct(
     }
 
     if let Some(keep) = matches.get_one::<String>("keep") {
-        let names = keep
+        let mut keep_display = false;
+        let mut names = keep
             .split(',')
-            .map(parse_chunk_name)
-            .collect::<Result<_, _>>()?;
+            .filter_map(|x| {
+                if x == "display" {
+                    keep_display = true;
+                    return None;
+                }
+                Some(parse_chunk_name(x))
+            })
+            .collect::<Result<IndexSet<_>, _>>()?;
+        if keep_display {
+            names.extend(StripChunks::KEEP_SAFE.iter().cloned());
+        }
         opts.strip = StripChunks::Keep(names)
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -175,6 +175,12 @@ depth is changed, regardless of any options set.",
         .arg(
             Arg::new("keep")
                 .help("Strip all metadata except in the comma-separated list")
+                .long_help("\
+Strip all metadata chunks except those in the comma-separated list. The special value \
+'display' includes chunks that affect the image appearance, equivalent to '--strip safe'.
+
+E.g. '--keep eXIf,display' will strip chunks, keeping only eXIf and those that affect the \
+image appearance.")
                 .long("keep")
                 .value_name("list")
                 .conflicts_with("strip")
@@ -617,12 +623,12 @@ fn parse_opts_into_struct(
         let mut keep_display = false;
         let mut names = keep
             .split(',')
-            .filter_map(|x| {
-                if x == "display" {
+            .filter_map(|name| {
+                if name == "display" {
                     keep_display = true;
                     return None;
                 }
-                Some(parse_chunk_name(x))
+                Some(parse_chunk_name(name))
             })
             .collect::<Result<IndexSet<_>, _>>()?;
         if keep_display {

--- a/src/main.rs
+++ b/src/main.rs
@@ -163,7 +163,7 @@ CAUTION: 'all' will convert APNGs to standard PNGs.
 
 Note that 'bKGD', 'sBIT' and 'hIST' will be forcibly stripped if the color type or bit \
 depth is changed, regardless of any options set.",
-                    StripChunks::KEEP_SAFE
+                    StripChunks::DISPLAY
                         .iter()
                         .map(|c| String::from_utf8_lossy(c))
                         .collect::<Vec<_>>()
@@ -632,7 +632,7 @@ fn parse_opts_into_struct(
             })
             .collect::<Result<IndexSet<_>, _>>()?;
         if keep_display {
-            names.extend(StripChunks::KEEP_SAFE.iter().cloned());
+            names.extend(StripChunks::DISPLAY.iter().cloned());
         }
         opts.strip = StripChunks::Keep(names)
     }


### PR DESCRIPTION
This PR reverts #580 and introduces `--keep display` instead.

See discussion in #581.