### PR TITLE
Workaround weird regression with &[u8] and zopfli

### DIFF
--- a/src/deflate/zopfli_oxipng.rs
+++ b/src/deflate/zopfli_oxipng.rs
@@ -8,7 +8,9 @@ pub fn deflate(data: &[u8], iterations: NonZeroU8) -> PngResult<Vec<u8>> {
         iteration_count: iterations.into(),
         ..Default::default()
     };
-    match zopfli::compress(options, zopfli::Format::Zlib, data, &mut output) {
+    // Since Rust v1.74, passing &[u8] directly into zopfli causes a regression in compressed size
+    // for some files. Wrapping the slice in another Read implementer such as Box fixes it for now.
+    match zopfli::compress(options, zopfli::Format::Zlib, Box::new(data), &mut output) {
         Ok(_) => (),
         Err(_) => return Err(PngError::new("Failed to compress in zopfli")),
     };


### PR DESCRIPTION
Fixes #579. In lack of a proper understanding of what's going on here and why the issue is happening, this workaround will do for now.