### PR TITLE
Add modified zeng palette sorting method

### DIFF
--- a/benches/reductions.rs
+++ b/benches/reductions.rs
@@ -301,6 +301,16 @@ fn reductions_palette_sort(b: &mut Bencher) {
 }
 
 #[bench]
+fn reductions_palette_sort_mzeng(b: &mut Bencher) {
+    let input = test::black_box(PathBuf::from(
+        "tests/files/palette_8_should_be_palette_8.png",
+    ));
+    let png = PngData::new(&input, &Options::default()).unwrap();
+
+    b.iter(|| palette::sorted_palette_mzeng(&png.raw));
+}
+
+#[bench]
 fn reductions_palette_sort_battiato(b: &mut Bencher) {
     let input = test::black_box(PathBuf::from(
         "tests/files/palette_8_should_be_palette_8.png",

--- a/src/reduction/palette.rs
+++ b/src/reduction/palette.rs
@@ -319,7 +319,6 @@ fn mzeng_reindex(num_colors: usize, edges: Vec<(usize, usize)>, matrix: &[Vec<u3
         sums.push(sum);
     }
 
-    let mut shift = 0;
     while !sums.is_empty() {
         let best_index = best_sum.0;
         // Compute delta to know if we need to prepend or append the best index.
@@ -330,7 +329,6 @@ fn mzeng_reindex(num_colors: usize, edges: Vec<(usize, usize)>, matrix: &[Vec<u3
         }
         if delta > 0 {
             remapping.insert(0, best_index);
-            shift += 1;
         } else {
             remapping.push(best_index);
         }
@@ -349,8 +347,6 @@ fn mzeng_reindex(num_colors: usize, edges: Vec<(usize, usize)>, matrix: &[Vec<u3
             }
         }
     }
-    // Keep the original best index first
-    remapping.rotate_left(shift);
 
     // Return the completed remapping
     remapping


### PR DESCRIPTION
This PR adds the modified zeng ("mzeng") palette sorting method, in addition to the existing luma and battiato methods. Speed is very similar to the battiato method with slightly better results on average.

Resulting sizes from two different image sets (all indexed or able to be indexed):
| | master | PR |
|-|-|-|
| Set 1 | 29,647,156 | 29,555,697 |
| Set 2 | 23,732,133 | 23,570,862 |

Additionally, I've added a new "first colour" heuristic for both the mzeng and battiato methods: We use the most popular colour overall, but only if it covers at least 15% of the image. This provided 13k savings on Set 2 vs the edge colour heuristic (which is still used in the luma sort).