### PR TITLE
Show eval sort method in verbose output

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -449,7 +449,7 @@ fn optimize_raw(
         || png.ihdr.interlaced != image.ihdr.interlaced;
 
     if reduction_occurred {
-        report_format("Reducing image to ", &png);
+        report_format("Transformed image to ", &png);
     }
 
     if opts.idat_recoding || reduction_occurred {

--- a/src/reduction/mod.rs
+++ b/src/reduction/mod.rs
@@ -83,7 +83,7 @@ pub(crate) fn perform_reductions(
         }
         // If either action changed the data then enter this into the evaluator
         if !Arc::ptr_eq(&png, &baseline) {
-            eval.try_image(png.clone());
+            eval.try_image_with_description(png.clone(), "Indexed (luma sort)");
             evaluation_added = true;
         }
     }
@@ -123,7 +123,7 @@ pub(crate) fn perform_reductions(
             // For relatively small differences, enter this into the evaluator
             // Otherwise we're confident enough for it to become the baseline
             if png.data.len() - new.data.len() <= INDEXED_MAX_DIFF {
-                eval.try_image(new.clone());
+                eval.try_image_with_description(new.clone(), "Indexed (luma sort)");
                 evaluation_added = true;
             } else {
                 baseline = new.clone();
@@ -149,7 +149,10 @@ pub(crate) fn perform_reductions(
                 if let ColorType::Indexed { palette } = &reduced.ihdr.color_type {
                     if !palettes.contains(palette) {
                         palettes.push(palette.clone());
-                        eval.try_image(Arc::new(reduced));
+                        eval.try_image_with_description(
+                            Arc::new(reduced),
+                            "Indexed (battiato sort)",
+                        );
                         evaluation_added = true;
                     }
                 }
@@ -162,7 +165,7 @@ pub(crate) fn perform_reductions(
                 if let ColorType::Indexed { palette } = &reduced.ihdr.color_type {
                     if !palettes.contains(palette) {
                         palettes.push(palette.clone());
-                        eval.try_image(Arc::new(reduced));
+                        eval.try_image_with_description(Arc::new(reduced), "Indexed (mzeng sort)");
                         evaluation_added = true;
                     }
                 }


### PR DESCRIPTION
This changes verbose output logging to show the palette sort method used for eval trials. Additionally it changes the line "Reducing image to..." to "Transformed image to..." to be more correct.
Example output:
```
Eval: 8-bit Indexed (luma sort)     None       6495 bytes
Eval: 8-bit Indexed (luma sort)     Bigrams    6133 bytes
Eval: 8-bit Indexed (battiato sort) None       6607 bytes
Eval: 8-bit Indexed (battiato sort) Bigrams    6441 bytes
Eval: 8-bit Indexed (mzeng sort)    None       6410 bytes
Eval: 8-bit Indexed (248 colors)    None       6478 bytes
Eval: 8-bit Indexed (248 colors)    Bigrams   >6133 bytes
Eval: 8-bit Indexed (mzeng sort)    Bigrams    6045 bytes
Transformed image to 8-bit Indexed (248 colors), non-interlaced
```
Note the sort method is not known after evaluations are complete, so it can't be shown in any later lines. In the above example we know it selected the mzeng sort because it's smallest.