### PR TITLE
Release/9.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,16 @@
+## Version 9.1.0
+
+- [Improvement] Add `--keep display` equivalent to `--strip safe`.
+- [Improvement] Add modified zeng palette sorting method, improving optimization of indexed images.
+- [Improvement] If only one filter is specified, guarantee to only use this one.
+- [Improvement] Evaluate low-depth indexed even if low-depth grayscale was already achieved.
+- [Bugfix] Fix battiato palette sorting method not being used if the input was not already indexed.
+- [Bugfix] Fix rare crash caused by a truncated palette.
+- [Build] Reduce size of binaries.
+- [Build] Add man page generation.
+- [Build] Publish deb archives for Linux.
+- [Misc] Bump minimum Rust version to 1.74.0.
+
 ## Version 9.0.0
 
 - [Breaking] Remove `--backup` option. Use `--out` or `--dir` to preserve existing files.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -369,7 +369,7 @@ dependencies = [
 
 [[package]]
 name = "oxipng"
-version = "9.0.0"
+version = "9.1.0"
 dependencies = [
  "bitvec",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ homepage = "https://github.com/shssoichiro/oxipng"
 license = "MIT"
 name = "oxipng"
 repository = "https://github.com/shssoichiro/oxipng"
-version = "9.0.0"
+version = "9.1.0"
 rust-version = "1.74.0"
 
 [badges]

--- a/MANUAL.txt
+++ b/MANUAL.txt
@@ -1,4 +1,4 @@
-oxipng 9.0.0
+oxipng 9.1.0
 Losslessly improve compression of PNG files
 
 Usage: oxipng [OPTIONS] <files>...
@@ -13,14 +13,14 @@ Options:
           compression. Lower levels are faster, higher levels provide better compression, though
           with increasingly diminishing returns.
           
-          0   => --zc 5 --fast               (1 trial, determined heuristically)
-          1   => --zc 10 --fast              (1 trial, determined heuristically)
-          2   => --zc 11 -f 0,1,6,7 --fast   (4 fast trials, 1 main trial)
-          3   => --zc 11 -f 0,7,8,9          (4 trials)
-          4   => --zc 12 -f 0,7,8,9          (4 trials)
-          5   => --zc 12 -f 0,1,2,5,6,7,8,9  (8 trials)
-          6   => --zc 12 -f 0-9              (10 trials)
-          max =>                             (stable alias for the max level)
+              0   => --zc 5 --fast               (1 trial, determined heuristically)
+              1   => --zc 10 --fast              (1 trial, determined heuristically)
+              2   => --zc 11 -f 0,1,6,7 --fast   (4 fast trials, 1 main trial)
+              3   => --zc 11 -f 0,7,8,9          (4 trials)
+              4   => --zc 12 -f 0,7,8,9          (4 trials)
+              5   => --zc 12 -f 0,1,2,5,6,7,8,9  (8 trials)
+              6   => --zc 12 -f 0-9              (10 trials)
+              max =>                             (stable alias for the max level)
           
           Manually specifying a compression option (zc, f, etc.) will override the optimization
           preset, regardless of the order you write the arguments.
@@ -54,18 +54,24 @@ Options:
       --strip <mode>
           Strip metadata chunks, where <mode> is one of:
           
-          safe    =>  Strip all non-critical chunks, except for the following:
-                          cICP, iCCP, sRGB, pHYs, acTL, fcTL, fdAT
-          all     =>  Strip all non-critical chunks
-          <list>  =>  Strip chunks in the comma-separated list, e.g. 'bKGD,cHRM'
+              safe    =>  Strip all non-critical chunks, except for the following:
+                              cICP, iCCP, sRGB, pHYs, acTL, fcTL, fdAT
+              all     =>  Strip all non-critical chunks
+              <list>  =>  Strip chunks in the comma-separated list, e.g. 'bKGD,cHRM'
           
           CAUTION: 'all' will convert APNGs to standard PNGs.
           
           Note that 'bKGD', 'sBIT' and 'hIST' will be forcibly stripped if the color type or bit
           depth is changed, regardless of any options set.
+          
+          The default when --strip is not passed is to keep all metadata.
 
       --keep <list>
-          Strip all metadata except in the comma-separated list
+          Strip all metadata chunks except those in the comma-separated list. The special value
+          'display' includes chunks that affect the image appearance, equivalent to '--strip safe'.
+          
+          E.g. '--keep eXIf,display' will strip chunks, keeping only eXIf and those that affect the
+          image appearance.
 
   -a, --alpha
           Perform additional optimization on images with an alpha channel, by altering the color
@@ -76,9 +82,9 @@ Options:
   -i, --interlace <type>
           Set the PNG interlacing type, where <type> is one of:
           
-          0     =>  Remove interlacing from all images that are processed
-          1     =>  Apply Adam7 interlacing on all images that are processed
-          keep  =>  Keep the existing interlacing type of each image
+              0     =>  Remove interlacing from all images that are processed
+              1     =>  Apply Adam7 interlacing on all images that are processed
+              keep  =>  Keep the existing interlacing type of each image
           
           Note that interlacing can add 25-50% to the size of an optimized image. Only use it if you
           believe the benefits outweigh the costs for your use case.
@@ -110,6 +116,7 @@ Options:
               2  =>  Up
               3  =>  Average
               4  =>  Paeth
+          
           Heuristic strategies (try to find the best delta filter for each line)
               5  =>  MinSum    Minimum sum of absolute differences
               6  =>  Entropy   Highest Shannon entropy

--- a/scripts/manual.sh
+++ b/scripts/manual.sh
@@ -2,4 +2,5 @@
 cargo build
 
 ./target/debug/oxipng -V > MANUAL.txt
-./target/debug/oxipng --help >> MANUAL.txt
+#Redirect all streams to prevent detection of the terminal width and force an internal default of 100
+./target/debug/oxipng --help >> MANUAL.txt 2>/dev/null </dev/null


### PR DESCRIPTION
- Update changelog
- Bump version
- Regenerate manual (note the script required a tweak due to an update of `terminal-size`)

Changes in whitespace are due to previous changes made for mangen.