### PR TITLE
Move the location for generated man pages inside target dir

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -104,7 +104,7 @@ panic = "abort"
 [package.metadata.deb]
 assets = [
     ["target/release/oxipng", "usr/bin/", "755"],
-    ["generated/assets/oxipng.1", "usr/share/man/man1/", "644"],
+    ["target/generated/assets/oxipng.1", "usr/share/man/man1/", "644"],
     ["README.md", "usr/share/doc/oxipng/", "644"],
     ["CHANGELOG.md", "usr/share/doc/oxipng/", "644"],
 ]

--- a/build.rs
+++ b/build.rs
@@ -24,8 +24,15 @@ fn main() -> Result<(), Error> {
     println!("cargo:rerun-if-changed=src/cli.rs");
     println!("cargo:rerun-if-changed=src/display_chunks.rs");
 
-    // Create `generated/assets/` folder.
-    let path = env::current_dir()?.join("generated").join("assets");
+    // Create `target/generated/assets/` folder.
+    let path = Path::new(
+        env::var("CARGO_MANIFEST_DIR")
+            .expect("CARGO_MANIFEST_DIR not set, build environment is broken")
+            .as_str(),
+    )
+    .join("target")
+    .join("generated")
+    .join("assets");
     std::fs::create_dir_all(&path).unwrap();
 
     build_manpages(&path)?;


### PR DESCRIPTION
The cargo release process expects that the `build.rs` file will not modify anything outside of the `target` directory. Currently, we are doing this for the man pages, which results in the following error when running `cargo publish`:

```
  Source directory was modified by build.rs during cargo publish. Build scripts should not modify anything outside of OUT_DIR.
  Added: /home/soichiro/repos/oxipng/target/package/oxipng-9.1.0/generated
        /home/soichiro/repos/oxipng/target/package/oxipng-9.1.0/generated/assets
        /home/soichiro/repos/oxipng/target/package/oxipng-9.1.0/generated/assets/oxipng.1
```

This change moves the `generated` directory to within `target` in order to resolve this.

Fixes #611 (will need to tag a 9.1.1 and `cargo publish` after)