### PR TITLE
Create assets dir relative to OUT_DIR

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -90,6 +90,7 @@ jobs:
         run: |
           mkdir -p "target/${{ matrix.target }}/release"
           mv target/oxipng "target/${{ matrix.target }}/release"
+          mv target/debug/assets "target/${{ matrix.target }}/release"
           cargo install --locked cargo-deb
           cargo deb --target "${{ matrix.target }}" --no-build --no-strip
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -95,7 +95,7 @@ jobs:
           cargo deb --target "${{ matrix.target }}" --no-build --no-strip
 
       - name: Create release notes
-        run: tail -n +2 CHANGELOG.md | sed -e '/^$/,$d' > RELEASE_NOTES.txt
+        run: tail -n +3 CHANGELOG.md | sed -e '/^$/,$d' > RELEASE_NOTES.txt
 
       - name: Create release
         uses: softprops/action-gh-release@v2

--- a/.gitignore
+++ b/.gitignore
@@ -4,4 +4,3 @@ target
 *.out.png
 /.idea
 /node_modules
-/generated

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -104,7 +104,7 @@ panic = "abort"
 [package.metadata.deb]
 assets = [
     ["target/release/oxipng", "usr/bin/", "755"],
-    ["generated/assets/oxipng.1", "usr/share/man/man1/", "644"],
+    ["target/release/assets/oxipng.1", "usr/share/man/man1/", "644"],
     ["README.md", "usr/share/doc/oxipng/", "644"],
     ["CHANGELOG.md", "usr/share/doc/oxipng/", "644"],
 ]

--- a/build.rs
+++ b/build.rs
@@ -24,8 +24,14 @@ fn main() -> Result<(), Error> {
     println!("cargo:rerun-if-changed=src/cli.rs");
     println!("cargo:rerun-if-changed=src/display_chunks.rs");
 
-    // Create `generated/assets/` folder.
-    let path = env::current_dir()?.join("generated").join("assets");
+    // Create `target/<debug|release>/assets/` folder.
+    let outdir = match env::var_os("OUT_DIR") {
+        None => return Ok(()),
+        Some(outdir) => outdir,
+    };
+    let out_path = PathBuf::from(outdir);
+    let mut path = out_path.ancestors().nth(3).unwrap().to_owned();
+    path.push("assets");
     std::fs::create_dir_all(&path).unwrap();
 
     build_manpages(&path)?;


### PR DESCRIPTION
See https://github.com/shssoichiro/oxipng/pull/607#issuecomment-2068215565 and https://github.com/shssoichiro/oxipng/pull/612#issuecomment-2070916960.
Also fixes the release notes generation on deploy.

I know @AlexTMjugador had concerns about using the OUT_DIR in this way, but this does seem to be the current recommendation.

Closes #611 
Closes #612 