### PR TITLE
Make CI Clippy static analysis checks more robust

### DIFF
--- a/.github/workflows/oxipng.yml
+++ b/.github/workflows/oxipng.yml
@@ -156,6 +156,7 @@ jobs:
       - name: Upload analysis results to GitHub
         uses: github/codeql-action/upload-sarif@v3
         if: always() && matrix.target == 'x86_64-unknown-linux-gnu'
+        continue-on-error: true
         with:
           sarif_file: clippy-results.sarif
           category: clippy

--- a/.github/workflows/oxipng.yml
+++ b/.github/workflows/oxipng.yml
@@ -102,25 +102,33 @@ jobs:
       - name: Install nextest
         uses: taiki-e/install-action@nextest
 
+      - name: Install cargo-hack
+        if: matrix.target == 'x86_64-unknown-linux-gnu'
+        uses: taiki-e/install-action@cargo-hack
+
+      - name: Install clippy-sarif
+        if: matrix.target == 'x86_64-unknown-linux-gnu'
+        uses: taiki-e/install-action@v2
+        with:
+          tool: clippy-sarif
+
+      - name: Install sarif-fmt
+        if: matrix.target == 'x86_64-unknown-linux-gnu'
+        uses: taiki-e/install-action@v2
+        with:
+          tool: sarif-fmt
+
       - name: Run rustfmt
         if: matrix.target == 'x86_64-unknown-linux-gnu'
         run: cargo fmt --check
 
-      - name: Run Clippy (no default features)
+      - name: Run Clippy for all feature combinations
         if: matrix.target == 'x86_64-unknown-linux-gnu'
-        uses: giraffate/clippy-action@v1
-        with:
-          clippy_flags: --no-deps --all-targets --no-default-features -- -D warnings
-          reporter: github-check
-          fail_on_error: true
-
-      - name: Run Clippy (all features)
-        if: matrix.target == 'x86_64-unknown-linux-gnu'
-        uses: giraffate/clippy-action@v1
-        with:
-          clippy_flags: --no-deps --all-targets --all-features -- -D warnings
-          reporter: github-check
-          fail_on_error: true
+        run: >
+          cargo hack clippy --no-deps --all-targets --feature-powerset --exclude-features sanity-checks --message-format=json -- -D warnings
+          | clippy-sarif
+          | tee clippy-results.sarif
+          | sarif-fmt
 
       - name: Run tests
         run: |
@@ -144,6 +152,13 @@ jobs:
           path: |
             target/${{ env.CARGO_BUILD_TARGET }}/release/oxipng
             target/${{ env.CARGO_BUILD_TARGET }}/release/oxipng.exe
+
+      - name: Upload analysis results to GitHub
+        uses: github/codeql-action/upload-sarif@v3
+        if: always() && matrix.target == 'x86_64-unknown-linux-gnu'
+        with:
+          sarif_file: clippy-results.sarif
+          category: clippy
 
   msrv-check:
     name: MSRV check

--- a/src/main.rs
+++ b/src/main.rs
@@ -329,10 +329,10 @@ fn parse_opts_into_struct(
         if let Some(iterations) = NonZeroU8::new(15) {
             opts.deflate = Deflaters::Zopfli { iterations };
         }
-    } else if let Deflaters::Libdeflater { compression } = &mut opts.deflate {
-        if let Some(x) = matches.get_one::<i64>("compression") {
-            *compression = *x as u8;
-        }
+    } else if let (Deflaters::Libdeflater { compression }, Some(x)) =
+        (&mut opts.deflate, matches.get_one::<i64>("compression"))
+    {
+        *compression = *x as u8;
     }
 
     #[cfg(feature = "parallel")]

--- a/src/rayon.rs
+++ b/src/rayon.rs
@@ -1,3 +1,5 @@
+#![allow(dead_code)]
+
 pub mod prelude {
     pub use super::*;
 }

--- a/src/rayon.rs
+++ b/src/rayon.rs
@@ -72,12 +72,10 @@ where
 
 impl<I: Iterator> ParallelIterator for I {}
 
-#[allow(dead_code)]
 pub fn join<A, B>(a: impl FnOnce() -> A, b: impl FnOnce() -> B) -> (A, B) {
     (a(), b())
 }
 
-#[allow(dead_code)]
 pub fn spawn<A>(a: impl FnOnce() -> A) -> A {
     a()
 }


### PR DESCRIPTION
I have identified two potential improvements for how we perform static analysis on our code in our CI pipeline:

- The `giraffate/clippy-action` we currently use has not been updated to Node 20, and GitHub has repeatedly indicated that they will phase out actions that do not support the latest Node versions. [Despite my efforts to help with the update by submitting a pull request upstream](https://github.com/giraffate/clippy-action/pull/87), it has been ignored for months despite its perceived ease of review, raising concerns about the ongoing maintenance of the action. This situation suggests we should explore alternative methods for integrating Clippy with GitHub's UI.
- As evidenced by [PR 632](https://github.com/shssoichiro/oxipng/pull/632), thoroughly testing Rust crates for every possible feature combination is often overlooked due to the tedious nature of the task. Our current CI setup only checks two feature combinations, which is far from comprehensive.

To address the first improvement, these changes drop `clippy-action` entirely in favor of utilizing [GitHub's native CodeQL SARIF (Static Analysis Results Interchange Format) file integration](https://docs.github.com/en/code-security/code-scanning/integrating-with-code-scanning/uploading-a-sarif-file-to-github). Since Clippy cannot directly output lints in SARIF, [`clippy-sarif`](https://crates.io/crates/clippy-sarif) is used to convert Clippy's JSON output to SARIF. Additionally, `sarif-fmt` is added to turn SARIF into a human-friendly display format in the workflow run logs.

For the second improvement, let's use [`cargo hack` with the `--feature-powerset` flag](https://github.com/taiki-e/cargo-hack?tab=readme-ov-file#--feature-powerset) to run Clippy for every possible feature combination. This approach strikes a good balance between CI runtime and thoroughness, as the number of feature combinations grows superlinearly with the number of features: running `cargo nextest` for every powerset element would lead to excessively long CI times.

While at it, I have fixed the Clippy lints that were catched by the more exhaustive checks.