### PR TITLE
Add option for Zopfli iteration count

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -338,6 +338,17 @@ Recommended use is with '-o max' and '--fast'.")
                 .action(ArgAction::SetTrue),
         )
         .arg(
+            Arg::new("iterations")
+                .help("Number of Zopfli iterations")
+                .long_help("\
+Set the number of iterations to use for Zopfli compression. Using fewer iterations may \
+speed up compression for large files. This option requires '--zopfli' to be set.")
+                .long("zi")
+                .default_value("15")
+                .value_parser(1..=255)
+                .requires("zopfli"),
+        )
+        .arg(
             Arg::new("timeout")
                 .help("Maximum amount of time to spend on optimizations")
                 .long_help("\

--- a/src/main.rs
+++ b/src/main.rs
@@ -324,12 +324,14 @@ fn parse_opts_into_struct(
         opts.strip = StripChunks::Safe;
     }
 
+    #[cfg(feature = "zopfli")]
     if matches.get_flag("zopfli") {
-        #[cfg(feature = "zopfli")]
-        if let Some(iterations) = NonZeroU8::new(15) {
-            opts.deflate = Deflaters::Zopfli { iterations };
-        }
-    } else if let (Deflaters::Libdeflater { compression }, Some(x)) =
+        let iterations = *matches.get_one::<i64>("iterations").unwrap();
+        opts.deflate = Deflaters::Zopfli {
+            iterations: NonZeroU8::new(iterations as u8).unwrap(),
+        };
+    }
+    if let (Deflaters::Libdeflater { compression }, Some(x)) =
         (&mut opts.deflate, matches.get_one::<i64>("compression"))
     {
         *compression = *x as u8;


### PR DESCRIPTION
This PR extends the `--zopfli` argument with an optional iteration count. In my case, I have a bunch of very small images (a few kB or less), and I often like to use hundreds of iterations to squeeze off the last several bytes. (I know that this crate isn't intended for brute-force optimization, but I've found that some of its transformations and filter strategies can be more creative than `zopflipng`.) But this is also useful in the opposite direction, for allowing Zopfli compression on large images where 15 iterations would be prohibitive.