### PR TITLE
Expose zc level 0 (uncompressed) 🚀

### DIFF
--- a/MANUAL.txt
+++ b/MANUAL.txt
@@ -132,7 +132,7 @@ Options:
           CPU cores.
 
       --zc <level>
-          Deflate compression level (1-12) for main compression trials. The levels here are defined
+          Deflate compression level (0-12) for main compression trials. The levels here are defined
           by the libdeflate compression library.
           
           The default value depends on the optimization level preset.

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -259,15 +259,15 @@ CPU cores.")
         )
         .arg(
             Arg::new("compression")
-                .help("Deflate compression level (1-12)")
+                .help("Deflate compression level (0-12)")
                 .long_help("\
-Deflate compression level (1-12) for main compression trials. The levels here are defined \
+Deflate compression level (0-12) for main compression trials. The levels here are defined \
 by the libdeflate compression library.
 
 The default value depends on the optimization level preset.")
                 .long("zc")
                 .value_name("level")
-                .value_parser(1..=12)
+                .value_parser(0..=12)
                 .conflicts_with("zopfli"),
         )
         .arg(

--- a/src/deflate/mod.rs
+++ b/src/deflate/mod.rs
@@ -16,7 +16,7 @@ pub use zopfli_oxipng::deflate as zopfli_deflate;
 pub enum Deflaters {
     /// Use libdeflater.
     Libdeflater {
-        /// Which compression level to use on the file (1-12)
+        /// Which compression level to use on the file (0-12)
         compression: u8,
     },
     #[cfg(feature = "zopfli")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -413,7 +413,7 @@ fn optimize_raw(
     deadline: Arc<Deadline>,
     max_size: Option<usize>,
 ) -> Option<PngData> {
-    // Libdeflate has four algorithms: 1-4 = 'greedy', 5-7 = 'lazy', 8-9 = 'lazy2', 10-12 = 'near-optimal'
+    // Libdeflate has four algorithms: 0 = 'uncompressed', 1-4 = 'greedy', 5-7 = 'lazy', 8-9 = 'lazy2', 10-12 = 'near-optimal'
     // 5 is the minimumm required for a decent evaluation result
     // 7 is not noticeably slower than 5 and improves evaluation of filters in 'fast' mode (o2 and lower)
     // 8 is a little slower but not noticeably when used only for reductions (o3 and higher)


### PR DESCRIPTION
Allow the creation of PNGs with uncompressed deflate streams via level 0 of libdeflate. If you want a glorified BMP with delta filters, this change will make your dreams come true 🙂.