### PR TITLE
Assume None if the line is all zeros

### DIFF
--- a/src/png/mod.rs
+++ b/src/png/mod.rs
@@ -360,6 +360,15 @@ impl PngImage {
                 prev_line = line_data;
             } else {
                 // Heuristic filter selection strategies
+
+                if line_data.iter().all(|&x| x == 0) {
+                    // Assume None if the line is all zeros
+                    filtered.push(RowFilter::None as u8);
+                    filtered.extend_from_slice(&line_data);
+                    prev_line = line_data;
+                    continue;
+                }
+
                 let mut best_line = Vec::new();
                 let mut best_line_raw = Vec::new();
                 // Avoid vertical filtering on first line of each interlacing pass


### PR DESCRIPTION
#648 may have been a bit hasty - I realised afterward that there's a simpler way to achieve the same thing, and include the Brute filter as well.

This reverts #648 and instead just picks None up front if the line is all zeros. This is guaranteed to be the chosen filter for MinSum, Entropy, Bigrams and BigEnt. It's almost certainly true for Brute as well but this is harder to prove. I've tested this across hundreds of images and found no change in output.