### PR TITLE
Fix manpage for `--zi`

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -344,6 +344,7 @@ Recommended use is with '-o max' and '--fast'.")
 Set the number of iterations to use for Zopfli compression. Using fewer iterations may \
 speed up compression for large files. This option requires '--zopfli' to be set.")
                 .long("zi")
+                .value_name("iterations")
                 .default_value("15")
                 .value_parser(1..=255)
                 .requires("zopfli"),


### PR DESCRIPTION
I don't know if this is a bug in the mangen but it seems to require explicitly setting the value name to display correctly.
Before:
```
       --zi [default: 15]
              Set the number of iterations to use for Zopfli compression.
```

After:
```
       --zi=iterations [default: 15]
              Set the number of iterations to use for Zopfli compression.
```

This does not affect MANUAL.txt or the built-in help.