### PR TITLE
Add feature flag to use system libdeflate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -331,6 +331,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2f4ae7b48098016dc3bc64a35605668f0af4425ec1a4a175ce2d0c1129067932"
 dependencies = [
  "cc",
+ "pkg-config",
 ]
 
 [[package]]
@@ -415,6 +416,12 @@ dependencies = [
  "rustc-hash",
  "zopfli",
 ]
+
+[[package]]
+name = "pkg-config"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "953ec861398dccce10c670dfeaf3ec4911ca479e9c02154b3a215178c5f566f2"
 
 [[package]]
 name = "png"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -87,6 +87,7 @@ freestanding = ["libdeflater/freestanding"]
 sanity-checks = ["dep:image"]
 zopfli = ["dep:zopfli"]
 filetime = ["dep:filetime"]
+system-libdeflate = ["libdeflater/dynamic"]
 
 [lib]
 name = "oxipng"


### PR DESCRIPTION
This need was raised in https://bugs.gentoo.org/944285. Can be enabled with `--features system-libdeflate` to use the libdeflate located on the user's system instead of building our own.