### PR TITLE
Improve APNG support

### DIFF
--- a/src/apng.rs
+++ b/src/apng.rs
@@ -1,0 +1,75 @@
+use std::io::Write;
+
+use crate::{
+    error::PngError,
+    headers::{read_be_u16, read_be_u32},
+    PngResult,
+};
+
+#[derive(Debug, Clone)]
+/// Animated PNG frame
+pub struct Frame {
+    /// Width of the frame
+    pub width: u32,
+    /// Height of the frame
+    pub height: u32,
+    /// X offset of the frame
+    pub x_offset: u32,
+    /// Y offset of the frame
+    pub y_offset: u32,
+    /// Frame delay numerator
+    pub delay_num: u16,
+    /// Frame delay denominator
+    pub delay_den: u16,
+    /// Frame disposal operation
+    pub dispose_op: u8,
+    /// Frame blend operation
+    pub blend_op: u8,
+    /// Frame data, from fdAT chunks
+    pub data: Vec<u8>,
+}
+
+impl Frame {
+    /// Construct a new Frame from the data in a fcTL chunk
+    pub fn from_fctl_data(byte_data: &[u8]) -> PngResult<Frame> {
+        if byte_data.len() < 26 {
+            return Err(PngError::TruncatedData);
+        }
+        Ok(Frame {
+            width: read_be_u32(&byte_data[4..8]),
+            height: read_be_u32(&byte_data[8..12]),
+            x_offset: read_be_u32(&byte_data[12..16]),
+            y_offset: read_be_u32(&byte_data[16..20]),
+            delay_num: read_be_u16(&byte_data[20..22]),
+            delay_den: read_be_u16(&byte_data[22..24]),
+            dispose_op: byte_data[24],
+            blend_op: byte_data[25],
+            data: vec![],
+        })
+    }
+
+    /// Construct the data for a fcTL chunk using the given sequence number
+    #[must_use]
+    pub fn fctl_data(&self, sequence_number: u32) -> Vec<u8> {
+        let mut byte_data = Vec::with_capacity(26);
+        byte_data.write_all(&sequence_number.to_be_bytes()).unwrap();
+        byte_data.write_all(&self.width.to_be_bytes()).unwrap();
+        byte_data.write_all(&self.height.to_be_bytes()).unwrap();
+        byte_data.write_all(&self.x_offset.to_be_bytes()).unwrap();
+        byte_data.write_all(&self.y_offset.to_be_bytes()).unwrap();
+        byte_data.write_all(&self.delay_num.to_be_bytes()).unwrap();
+        byte_data.write_all(&self.delay_den.to_be_bytes()).unwrap();
+        byte_data.push(self.dispose_op);
+        byte_data.push(self.blend_op);
+        byte_data
+    }
+
+    /// Construct the data for a fdAT chunk using the given sequence number
+    #[must_use]
+    pub fn fdat_data(&self, sequence_number: u32) -> Vec<u8> {
+        let mut byte_data = Vec::with_capacity(4 + self.data.len());
+        byte_data.write_all(&sequence_number.to_be_bytes()).unwrap();
+        byte_data.write_all(&self.data).unwrap();
+        byte_data
+    }
+}

--- a/src/error.rs
+++ b/src/error.rs
@@ -9,6 +9,7 @@ pub enum PngError {
     TimedOut,
     NotPNG,
     APNGNotSupported,
+    APNGOutOfOrder,
     InvalidData,
     TruncatedData,
     ChunkMissing(&'static str),
@@ -33,6 +34,7 @@ impl fmt::Display for PngError {
                 f.write_str("Missing data in the file; the file is truncated")
             }
             PngError::APNGNotSupported => f.write_str("APNG files are not (yet) supported"),
+            PngError::APNGOutOfOrder => f.write_str("APNG chunks are out of order"),
             PngError::ChunkMissing(s) => write!(f, "Chunk {s} missing or empty"),
             PngError::InvalidDepthForType(d, ref c) => {
                 write!(f, "Invalid bit depth {d} for color type {c}")

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -59,6 +59,7 @@ pub use crate::{
     options::{InFile, Options, OutFile},
 };
 
+mod apng;
 mod atomicmin;
 mod colors;
 mod deflate;
@@ -530,6 +531,7 @@ fn optimize_raw(
                 raw: png,
                 idat_data,
                 aux_chunks: Vec::new(),
+                frames: Vec::new(),
             };
             if image.estimated_output_size() < max_size.unwrap_or(usize::MAX) {
                 debug!("Found better combination:");
@@ -549,6 +551,7 @@ fn optimize_raw(
             raw: result.image,
             idat_data: result.idat_data,
             aux_chunks: Vec::new(),
+            frames: Vec::new(),
         };
         if image.estimated_output_size() < max_size.unwrap_or(usize::MAX) {
             debug!("Found better combination:");

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -365,6 +365,7 @@ fn optimize_png(
     if let Some(new_png) = optimize_raw(raw.clone(), &opts, deadline.clone(), max_size) {
         png.raw = new_png.raw;
         png.idat_data = new_png.idat_data;
+        png.filter = new_png.filter;
     }
 
     postprocess_chunks(png, &opts, &raw.ihdr);
@@ -533,6 +534,7 @@ fn optimize_raw(
                 idat_data,
                 aux_chunks: Vec::new(),
                 frames: Vec::new(),
+                filter: Some(filter),
             };
             if image.estimated_output_size() < max_size.unwrap_or(usize::MAX) {
                 debug!("Found better combination:");
@@ -553,6 +555,7 @@ fn optimize_raw(
             idat_data: result.idat_data,
             aux_chunks: Vec::new(),
             frames: Vec::new(),
+            filter: Some(result.filter),
         };
         if image.estimated_output_size() < max_size.unwrap_or(usize::MAX) {
             debug!("Found better combination:");


### PR DESCRIPTION
Two improvements to APNG support:
1. fcTL and fdAT chunks are parsed into Frames, allowing us to consolidate multiple fdATs for a frame and re-sequence the chunks. This means we can now recompress all frames, rather than only in the case where there's a single fdAT for the frame.
2. Following on from this, we can now also re-filter the frames, including alpha optimisation when enabled. We use the same filter that was selected for the IDAT.

Reductions are still disabled.

Results on a set of 32 apngs, optimised with `-sao6`:

source | size
--|--
original | 20,022,193 
master | 19,412,724 (3.0% smaller)
with full recompression only | 16,494,618 (17.6% smaller)
with refiltering | 15,583,118 (22.2% smaller)
apngopt* (default) | 13,520,262 (32.5% smaller)
apngopt + oxipng | 13,341,852 (33.4% smaller)

(There was a particularly large and poorly compressed file in the set which may be skewing the results a little.)

*Note that apngopt does not guard against writing a larger file than the input. The results here could be slightly smaller if I retained the originals where they were better. 

[edit] A second set:
source | size
--|--
original | 165,721,029 
master | 165,048,775 (0.4% smaller)
with full recompression only | 163,422,620 (1.4% smaller)
with refiltering | 162,850,831 (1.7% smaller)
apngopt (default) | 164,919,387 (0.5% smaller)
apngopt + oxipng | 162,474,452 (2.0% smaller)