### PR TITLE
Tweak eval cmp key for more consistent results

### DIFF
--- a/src/evaluate.rs
+++ b/src/evaluate.rs
@@ -23,7 +23,7 @@ pub(crate) struct Candidate {
     pub idat_data: Vec<u8>,
     pub filtered: Vec<u8>,
     pub filter: RowFilter,
-    // first wins tie-breaker
+    // For determining tie-breaker
     nth: usize,
 }
 
@@ -32,9 +32,9 @@ impl Candidate {
         (
             self.idat_data.len() + self.image.key_chunks_size(),
             self.image.data.len(),
-            self.image.ihdr.bit_depth,
             self.filter,
-            self.nth,
+            // Prefer the later image added (e.g. baseline, which is always added last)
+            usize::MAX - self.nth,
         )
     }
 }


### PR DESCRIPTION
This changes the evaluator to prefer a later image instead of an earlier one in the case of a tie. This gives more consistent results since the baseline is always added last.

I also removed bit depth from the key since the uncompressed size should cover that.

Fixes #649.
(Mostly. I did discover another possible but very rare issue: if multiple colours tie for "most popular edge colour" in the luma sort, the sort may affect which one is actually picked and multiple runs may flip-flop back and forth)