### PR TITLE
Fix size passed to fast filter evaluator

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -509,7 +509,7 @@ fn perform_trials(
                 opts.optimize_alpha,
             );
             if let Some(result) = &eval_result {
-                eval.set_best_size(result.idat_data.len());
+                eval.set_best_size(result.estimated_output_size());
             }
             eval.try_image(image.clone());
             if let Some(result) = eval.get_best_candidate() {


### PR DESCRIPTION
The evaluator uses the `estimated_output_size` internally but we were passing only the idat size in the fast filter evaluator. At level `o2`, or higher levels when using `--fast`, this could cause a slight bias towards the None and Bigrams filters for indexed images. The actual impact to results is incredibly minor but it's definitely incorrect so we should fix it.