### PR TITLE
Improve memory usage of evaluator

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -355,7 +355,7 @@ fn optimize_png(
     let max_size = if opts.force {
         None
     } else {
-        Some(png.estimated_output_size())
+        Some(png.raw.estimated_output_size(&png.idat_data))
     };
     if let Some(result) = optimize_raw(raw.clone(), &opts, deadline.clone(), max_size) {
         png.raw = result.image;
@@ -433,7 +433,13 @@ fn optimize_raw(
         indexset! {RowFilter::None, RowFilter::Bigrams}
     };
     // This will collect all versions of images and pick one that compresses best
-    let eval = Evaluator::new(deadline.clone(), eval_filters.clone(), eval_deflater, false);
+    let eval = Evaluator::new(
+        deadline.clone(),
+        eval_filters.clone(),
+        eval_deflater,
+        false,
+        opts.deflate == eval_deflater,
+    );
     let mut new_image = perform_reductions(image.clone(), opts, &deadline, &eval);
     let eval_result = eval.get_best_candidate();
     if let Some(ref result) = eval_result {
@@ -464,7 +470,9 @@ fn optimize_raw(
         (eval_result?, eval_deflater)
     };
 
-    if max_size.map_or(true, |max_size| result.estimated_output_size() < max_size) {
+    if !result.idat_data.is_empty()
+        && max_size.map_or(true, |max_size| result.estimated_output_size < max_size)
+    {
         debug!("Found better result:");
         debug!("    {}, f = {}", deflater, result.filter);
         return Some(result);
@@ -499,9 +507,10 @@ fn perform_trials(
                 filters,
                 eval_deflater,
                 opts.optimize_alpha,
+                opts.deflate == eval_deflater,
             );
             if let Some(result) = &eval_result {
-                eval.set_best_size(result.estimated_output_size());
+                eval.set_best_size(result.estimated_output_size);
             }
             eval.try_image(image.clone());
             if let Some(result) = eval.get_best_candidate() {
@@ -520,8 +529,9 @@ fn perform_trials(
         debug!("Trying filter {} with {}", result.filter, opts.deflate);
         match opts.deflate.deflate(&result.filtered, max_size) {
             Ok(idat_data) => {
+                result.estimated_output_size = result.image.estimated_output_size(&idat_data);
                 result.idat_data = idat_data;
-                trace!("{} bytes", result.estimated_output_size());
+                trace!("{} bytes", result.estimated_output_size);
             }
             Err(PngError::DeflatedDataTooLong(bytes)) => {
                 trace!(">{bytes} bytes");
@@ -545,7 +555,7 @@ fn perform_trials(
     }
 
     debug!("Trying {} filters with {}", filters.len(), opts.deflate);
-    let eval = Evaluator::new(deadline, filters, opts.deflate, opts.optimize_alpha);
+    let eval = Evaluator::new(deadline, filters, opts.deflate, opts.optimize_alpha, true);
     if let Some(max_size) = max_size {
         eval.set_best_size(max_size);
     }

--- a/src/png/mod.rs
+++ b/src/png/mod.rs
@@ -185,12 +185,6 @@ impl PngData {
         })
     }
 
-    /// Return an estimate of the output size which can help with evaluation of very small data
-    #[must_use]
-    pub fn estimated_output_size(&self) -> usize {
-        self.idat_data.len() + self.raw.key_chunks_size()
-    }
-
     /// Format the `PngData` struct into a valid PNG bytestream
     #[must_use]
     pub fn output(&self) -> Vec<u8> {
@@ -353,6 +347,12 @@ impl PngImage {
             ColorType::RGB { transparent_color } if transparent_color.is_some() => 12 + 6,
             _ => 0,
         }
+    }
+
+    /// Return an estimate of the output size which can help with evaluation of very small data
+    #[must_use]
+    pub fn estimated_output_size(&self, idat_data: &[u8]) -> usize {
+        idat_data.len() + self.key_chunks_size()
     }
 
     /// Return an iterator over the scanlines of the image


### PR DESCRIPTION
This adds a new `final_round` parameter to the evaluator, which allows us to determine when to keep the `filtered` data and when to keep the compressed `idat_data`. By only keeping one of these we can significantly improve memory usage.

Ref #683 