### PR TITLE
Switch Docker image from `alpine` to `scratch`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -31,7 +31,7 @@ RUN --mount=type=cache,target=/root/.cargo/git/db \
     xx-verify /src/target/$(xx-cargo --print-target-triple)/release/oxipng && \
     cp /src/target/$(xx-cargo --print-target-triple)/release/oxipng /src/target/oxipng
 
-FROM alpine AS tool
+FROM scratch AS tool
 
 LABEL org.opencontainers.image.title="Oxipng"
 LABEL org.opencontainers.image.description="Multithreaded PNG optimizer written in Rust"
@@ -39,7 +39,7 @@ LABEL org.opencontainers.image.authors="Joshua Holmer <jholmer.in@gmail.com>"
 LABEL org.opencontainers.image.licenses="MIT"
 LABEL org.opencontainers.image.source="https://github.com/shssoichiro/oxipng"
 
-COPY --from=base /src/target/oxipng /usr/local/bin
+COPY --from=base /src/target/oxipng /usr/local/bin/oxipng
 
 WORKDIR /work
 ENTRYPOINT [ "oxipng" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,5 @@
 # syntax=docker/dockerfile:1
+# check=error=true
 FROM --platform=$BUILDPLATFORM tonistiigi/xx AS xx
 
 FROM --platform=$BUILDPLATFORM rust:1.74-alpine AS base


### PR DESCRIPTION
Following https://github.com/shssoichiro/oxipng/pull/642

- [x] Fail to build on linting errors
- [x] Switch Docker image from `alpine` to `scratch`

Reduce the image size roughly from 15Mb to 2Mb.

![image](https://github.com/user-attachments/assets/a0fee179-42d4-4558-b5f6-e469a769959a)

It doesn't break the usecase mentioned in the README, as well as people copying the binary in a Docker step.

I have considered making the image rootless but since it's doing file modifications it requires overwriting the user to bring back root in the README's usecase. The image would benefit of if using it only with stdin/stdout. Not sure it's worth it.

I have been working on enabling cross compilation for non-Tier 1 platforms, but no ETA yet.
