### PR TITLE
fix: downgrade libdeflater to version 1.24.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -102,9 +102,9 @@ checksum = "8f1fe948ff07f4bd06c30984e69f5b4899c516a3ef74f34df92a2df2ab535495"
 
 [[package]]
 name = "cc"
-version = "1.2.44"
+version = "1.2.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37521ac7aabe3d13122dc382493e20c9416f299d2ccd5b3a5340a2570cdeb0f3"
+checksum = "35900b6c8d709fb1d854671ae27aeaa9eec2f8b01b364e1619a40da3e6fe2afe"
 dependencies = [
  "find-msvc-tools",
  "shlex",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,7 +41,7 @@ required-features = ["zopfli"]
 zopfli = { version = "0.8.3", optional = true, default-features = false, features = ["std", "zlib"] }
 rgb = "0.8.52"
 indexmap = "2.12.0"
-libdeflater = "1.24.0"
+libdeflater = "1.25.0"
 log = "0.4.28"
 bitvec = "1.0.1"
 rustc-hash = "2.1.1"


### PR DESCRIPTION
I am not sure if this is the right apprach to fixing this.
Currently, oxipng does not build for musl due to kind of weird errors on `x86_unknown_linux_musl`.
Since a larger percentage of modern CPUs don't have AVX512 support, I think this is a buggy release, open to other oppinions 😉 


I know that this part might not be entirely supported by you https://github.com/oxipng/oxipng/issues/702

```log
warning: libdeflate-sys@1.25.0: In file included from libdeflate/lib/adler32.c:128:
warning: libdeflate-sys@1.25.0: In file included from libdeflate/lib/x86/adler32_impl.h:101:
warning: libdeflate-sys@1.25.0: libdeflate/lib/x86/adler32_template.h:197:21: error: always_inline function '_mm512_set1_epi8' requires target feature 'evex512', but would be inlined into function 'adler32_x86_avx512_vl512_vnni' that is compiled without support for 'evex512'
warning: libdeflate-sys@1.25.0:   197 |         const vec_t ones = VSET1_8(1);
warning: libdeflate-sys@1.25.0:       |                            ^
warning: libdeflate-sys@1.25.0: libdeflate/lib/x86/adler32_template.h:116:23: note: expanded from macro 'VSET1_8'
warning: libdeflate-sys@1.25.0:   116 | #  define VSET1_8(a)            _mm512_set1_epi8(a)
warning: libdeflate-sys@1.25.0:       |                                 ^
warning: libdeflate-sys@1.25.0: libdeflate/lib/x86/adler32_template.h:197:21: error: AVX vector return of type '__m512i' (vector of 8 'long long' values) without 'evex512' enabled changes the ABI
warning: libdeflate-sys@1.25.0: libdeflate/lib/x86/adler32_template.h:116:23: note: expanded from macro 'VSET1_8'
warning: libdeflate-sys@1.25.0:   116 | #  define VSET1_8(a)            _mm512_set1_epi8(a)
warning: libdeflate-sys@1.25.0:       |                                 ^
warning: libdeflate-sys@1.25.0: libdeflate/lib/x86/adler32_template.h:224:23: error: always_inline function '_mm512_setzero_si512' requires target feature 'evex512', but would be inlined into function 'adler32_x86_avx512_vl512_vnni' that is compiled without support for 'evex512'
warning: libdeflate-sys@1.25.0:   224 |         const vec_t zeroes = VSETZERO();
warning: libdeflate-sys@1.25.0:       |                              ^
warning: libdeflate-sys@1.25.0: libdeflate/lib/x86/adler32_template.h:118:23: note: expanded from macro 'VSETZERO'
warning: libdeflate-sys@1.25.0:   118 | #  define VSETZERO()            _mm512_setzero_si512()
warning: libdeflate-sys@1.25.0:       |                                 ^
warning: libdeflate-sys@1.25.0: libdeflate/lib/x86/adler32_template.h:224:23: error: AVX vector return of type '__m512i' (vector of 8 'long long' values) without 'evex512' enabled changes the ABI
warning: libdeflate-sys@1.25.0: libdeflate/lib/x86/adler32_template.h:118:23: note: expanded from macro 'VSETZERO'
warning: libdeflate-sys@1.25.0:   118 | #  define VSETZERO()            _mm512_setzero_si512()
warning: libdeflate-sys@1.25.0:       |                                 ^
warning: libdeflate-sys@1.25.0: fatal error: too many errors emitted, stopping now [-ferror-limit=]
warning: libdeflate-sys@1.25.0: 20 errors generated.
warning: libdeflate-sys@1.25.0: ToolExecError: command did not execute successfully (status code exit status: 1): LC_ALL="C" "/home/runner/.cache/cargo-zigbuild/0.20.1/zigcc-x86_64-unknown-linux-musl-ff6a.sh" "-O3" "-ffunction-sections" "-fdata-sections" "-fPIC" "-m64" "--target=x86_64-unknown-linux-musl" "-I" "libdeflate" "-o" "/home/runner/work/martin/martin/target/x86_64-unknown-linux-musl/release/build/libdeflate-sys-691e28f6d8d85fa7/out/lib/81d37bb229f1c0d9-crc32.o" "-c" "libdeflate/lib/crc32.c"
error: failed to run custom build command for `libdeflate-sys v1.25.0`
```

CC @nyurik