### PR TITLE
Add colors to --help/-h

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,9 +1,17 @@
 use std::{num::NonZeroU64, path::PathBuf};
 
+use clap::builder::Styles;
+use clap::builder::styling::{AnsiColor, Effects};
 use clap::{Arg, ArgAction, Command, builder::ArgPredicate, value_parser};
 use parse_size::parse_size;
 
 include!("display_chunks.rs");
+
+const STYLES: Styles = Styles::styled()
+    .header(AnsiColor::Green.on_default().effects(Effects::BOLD))
+    .usage(AnsiColor::Green.on_default().effects(Effects::BOLD))
+    .literal(AnsiColor::Cyan.on_default().effects(Effects::BOLD))
+    .placeholder(AnsiColor::Cyan.on_default());
 
 pub fn build_command() -> Command {
     // Note: clap 'wrap_help' is enabled to automatically wrap lines according to terminal width.
@@ -15,6 +23,7 @@ pub fn build_command() -> Command {
         .version(env!("CARGO_PKG_VERSION"))
         .author("Joshua Holmer <jholmer.in@gmail.com>")
         .about("Losslessly improve compression of PNG files")
+        .styles(STYLES)
         .arg(
             Arg::new("files")
                 .help("File(s) to compress (use '-' for stdin)")


### PR DESCRIPTION
~I used [clap-cargo](https://github.com/crate-ci/clap-cargo) as it's easy to use and provides sensible default styles.~
User can disable colors via `NO_COLOR=1` environment variable

Output of `oxipng --help`:
| before | after | `NO_COLOR=1` |
| - | - | - |
| <img width="1836" height="3667" alt="oxipng-before" src="https://github.com/user-attachments/assets/c23ac0ac-6333-4944-8f8f-9e3ae05d6c4c" /> | <img width="1836" height="3667" alt="oxipng-colors" src="https://github.com/user-attachments/assets/a4ee13d1-5920-4253-acf6-23481ac1c80f" /> | <img width="1836" height="3667" alt="oxipng-no-color" src="https://github.com/user-attachments/assets/4143bdd5-019f-4b2e-b93a-a176b58f3f54" /> |

