### PR TITLE
Tiny collection cleanup/optimization

### DIFF
--- a/src/apng.rs
+++ b/src/apng.rs
@@ -1,5 +1,3 @@
-use std::io::Write;
-
 use crate::{
     PngResult,
     error::PngError,
@@ -52,15 +50,14 @@ impl Frame {
     #[must_use]
     pub fn fctl_data(&self, sequence_number: u32) -> Vec<u8> {
         let mut byte_data = Vec::with_capacity(26);
-        byte_data.write_all(&sequence_number.to_be_bytes()).unwrap();
-        byte_data.write_all(&self.width.to_be_bytes()).unwrap();
-        byte_data.write_all(&self.height.to_be_bytes()).unwrap();
-        byte_data.write_all(&self.x_offset.to_be_bytes()).unwrap();
-        byte_data.write_all(&self.y_offset.to_be_bytes()).unwrap();
-        byte_data.write_all(&self.delay_num.to_be_bytes()).unwrap();
-        byte_data.write_all(&self.delay_den.to_be_bytes()).unwrap();
-        byte_data.push(self.dispose_op);
-        byte_data.push(self.blend_op);
+        byte_data.extend_from_slice(&sequence_number.to_be_bytes());
+        byte_data.extend_from_slice(&self.width.to_be_bytes());
+        byte_data.extend_from_slice(&self.height.to_be_bytes());
+        byte_data.extend_from_slice(&self.x_offset.to_be_bytes());
+        byte_data.extend_from_slice(&self.y_offset.to_be_bytes());
+        byte_data.extend_from_slice(&self.delay_num.to_be_bytes());
+        byte_data.extend_from_slice(&self.delay_den.to_be_bytes());
+        byte_data.extend_from_slice(&[self.dispose_op, self.blend_op]);
         byte_data
     }
 

--- a/src/png/mod.rs
+++ b/src/png/mod.rs
@@ -1,4 +1,4 @@
-use std::{fs, io::Write, path::Path, sync::Arc};
+use std::{fs, path::Path, sync::Arc};
 
 use bitvec::bitarr;
 use libdeflater::{CompressionLvl, Compressor};
@@ -165,17 +165,15 @@ impl PngData {
         let mut output = vec![0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A];
         // IHDR
         let mut ihdr_data = Vec::with_capacity(13);
-        ihdr_data.write_all(&self.raw.ihdr.width.to_be_bytes()).ok();
-        ihdr_data
-            .write_all(&self.raw.ihdr.height.to_be_bytes())
-            .ok();
-        ihdr_data.write_all(&[self.raw.ihdr.bit_depth as u8]).ok();
-        ihdr_data
-            .write_all(&[self.raw.ihdr.color_type.png_header_code()])
-            .ok();
-        ihdr_data.write_all(&[0]).ok(); // Compression -- deflate
-        ihdr_data.write_all(&[0]).ok(); // Filter method -- 5-way adaptive filtering
-        ihdr_data.write_all(&[self.raw.ihdr.interlaced as u8]).ok();
+        ihdr_data.extend_from_slice(&self.raw.ihdr.width.to_be_bytes());
+        ihdr_data.extend_from_slice(&self.raw.ihdr.height.to_be_bytes());
+        ihdr_data.extend_from_slice(&[self.raw.ihdr.bit_depth as u8]);
+        ihdr_data.extend_from_slice(&[
+            self.raw.ihdr.color_type.png_header_code(),
+            0, // Compression -- deflate
+            0, // Filter method -- 5-way adaptive filtering
+            self.raw.ihdr.interlaced as u8,
+        ]);
         write_png_block(b"IHDR", &ihdr_data, &mut output);
         // Ancillary chunks - split into those that come before IDAT and those that come after
         let mut aux_split = self.aux_chunks.split(|c| &c.name == b"IDAT");


### PR DESCRIPTION
See commit descriptions.

~⚠️ adds a very small additional dependency. **arrayvec** is used and trusted by rustdoc, clippy and rustc itself. **tinyvec**, which also provides an `ArrayVec` type, is an alternative, **or just keeping the Vec but still using `extend_from_slice` etc.** I understand if you don't want to add a dep just for this.~

## Testing

All cargo tests pass with default and all features. ~Testing the CLI with some generic unoptimized PNG and APNG images with the default configuration gives bitwise identical results to those from Oxipng 9.1.5.~

~I have not ran any benchmarks, but I would expect performance to be a tiny (probably not measureable unless explicitly targeted in benchmarks) bit better in all cases, unless `ArrayVec::try_extend_from_slice` is somehow slower than what was used before despite most of its checks probably happening at compile time here. An `ArrayVec<u8, 20>` is the same size as an empty `Vec` on a 64-bit system.~