### PR TITLE
Use `PngResult` where applicable

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -15,9 +15,9 @@ pub enum PngError {
     InvalidData,
     InvalidDepthForType(BitDepth, ColorType),
     NotPNG,
-    ReadFailed(Box<str>, std::io::Error),
+    ReadFailed(String, std::io::Error),
     TruncatedData,
-    WriteFailed(Box<str>, std::io::Error),
+    WriteFailed(String, std::io::Error),
     Other(Box<str>),
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -257,9 +257,8 @@ pub fn optimize(input: &InFile, output: &OutFile, opts: &Options) -> PngResult<(
             let output_path = path
                 .as_ref()
                 .map_or_else(|| input.path().unwrap(), PathBuf::as_path);
-            let out_file = File::create(output_path).map_err(|err| {
-                PngError::WriteFailed(output_path.display().to_string().into_boxed_str(), err)
-            })?;
+            let out_file = File::create(output_path)
+                .map_err(|err| PngError::WriteFailed(output_path.display().to_string(), err))?;
             if let Some(metadata_input) = &opt_metadata_preserved {
                 copy_permissions(metadata_input, &out_file)?;
             }
@@ -269,9 +268,7 @@ pub fn optimize(input: &InFile, output: &OutFile, opts: &Options) -> PngResult<(
                 .write_all(&optimized_output)
                 // flush BufWriter so IO errors don't get swallowed silently on close() by drop!
                 .and_then(|()| buffer.flush())
-                .map_err(|e| {
-                    PngError::WriteFailed(output_path.display().to_string().into_boxed_str(), e)
-                })?;
+                .map_err(|e| PngError::WriteFailed(output_path.display().to_string(), e))?;
             // force drop and thereby closing of file handle before modifying any timestamp
             std::mem::drop(buffer);
             if let Some(metadata_input) = &opt_metadata_preserved {

--- a/src/png/mod.rs
+++ b/src/png/mod.rs
@@ -52,8 +52,7 @@ impl PngData {
     }
 
     pub fn read_file(filepath: &Path) -> PngResult<Vec<u8>> {
-        fs::read(filepath)
-            .map_err(|e| PngError::ReadFailed(filepath.display().to_string().into_boxed_str(), e))
+        fs::read(filepath).map_err(|e| PngError::ReadFailed(filepath.display().to_string(), e))
     }
 
     /// Create a new `PngData` struct by reading a slice


### PR DESCRIPTION
~This brings `PngError` from 40 to 32 bytes on a 64-bit system, and should only have a small cost in some cases when a `ReadFailed` or `WriteFailed` is created, which should be very rarely.~

Also uses `PngResult` everywhere instead of the type it's defined to. I don't think (?) this should be a breaking change. If it is then maybe it's not worth doing.