### PR TITLE
Rework preserving attributes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -246,18 +246,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "filetime"
-version = "0.2.26"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc0505cd1b6fa6580283f6bdf70a73fcf4aba1184038c90902b92b3dd0df63ed"
-dependencies = [
- "cfg-if",
- "libc",
- "libredox",
- "windows-sys 0.60.2",
-]
-
-[[package]]
 name = "find-msvc-tools"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -347,17 +335,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "libredox"
-version = "0.1.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "416f7e718bdb06000964960ffa43b4335ad4012ae8b99060261aa4a8088d5ccb"
-dependencies = [
- "bitflags",
- "libc",
- "redox_syscall",
-]
-
-[[package]]
 name = "linux-raw-sys"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -412,7 +389,6 @@ dependencies = [
  "clap",
  "crossbeam-channel",
  "env_logger",
- "filetime",
  "glob",
  "image",
  "indexmap",
@@ -483,15 +459,6 @@ checksum = "22e18b0f0062d30d4230b2e85ff77fdfe4326feb054b9783a3460d8435c8ab91"
 dependencies = [
  "crossbeam-deque",
  "crossbeam-utils",
-]
-
-[[package]]
-name = "redox_syscall"
-version = "0.5.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5407465600fb0548f1442edf71dd20683c6ed326200ace4b1ef0763521bb3b77"
-dependencies = [
- "bitflags",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,10 +56,6 @@ version = "0.11.8"
 optional = true
 version = "0.5.15"
 
-[dependencies.filetime]
-optional = true
-version = "0.2.26"
-
 [dependencies.rayon]
 optional = true
 version = "1.11.0"
@@ -85,12 +81,11 @@ version = "0.25.9"
 
 [features]
 binary = ["dep:clap", "dep:glob", "dep:env_logger", "dep:parse-size"]
-default = ["binary", "parallel", "zopfli", "filetime"]
+default = ["binary", "parallel", "zopfli"]
 parallel = ["dep:rayon", "indexmap/rayon", "dep:crossbeam-channel"]
 freestanding = ["libdeflater/freestanding"]
 sanity-checks = ["dep:image"]
 zopfli = ["dep:zopfli"]
-filetime = ["dep:filetime"]
 system-libdeflate = ["libdeflater/dynamic"]
 
 [lib]


### PR DESCRIPTION
This PR changes the behaviour of the `--preserve` flag to show only warnings instead of aborting with an error if something goes wrong with the metadata. I don't think these constitute critical errors so aborting doesn't seem appropriate, especially given we've already created (and possibly written) the output file.

Additionally, timestamps are now supported since Rust 1.75 so we don't need the `filetime` dependency anymore.