### PR TITLE
Tweak output when not optimised

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -252,6 +252,7 @@ pub fn optimize(input: &InFile, output: &OutFile, opts: &Options) -> PngResult<(
             buffer
                 .write_all(&optimized_output)
                 .map_err(|e| PngError::WriteFailed("stdout".into(), e))?;
+            info!("{savings}: stdout");
         }
         (OutFile::Path { path, .. }, _) => {
             let output_path = path


### PR DESCRIPTION
Tweaks the output message when a file could not be optimised to be more consistent with other messages.
Also adds a missing result message when writing to stdout.

Closes #762