### PR TITLE
Remove crossbeam-channel dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -160,15 +160,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "crossbeam-channel"
-version = "0.5.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82b8f8f868b36967f9606790d1903570de9ceaf870a7bf9fbbd3016d636a2cb2"
-dependencies = [
- "crossbeam-utils",
-]
-
-[[package]]
 name = "crossbeam-deque"
 version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -399,7 +390,6 @@ version = "10.1.0"
 dependencies = [
  "bitvec",
  "clap",
- "crossbeam-channel",
  "env_logger",
  "glob",
  "image",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,7 +40,6 @@ required-features = ["zopfli"]
 [dependencies]
 bitvec = "1.0.1"
 clap = { version = "4.5.58", optional = true, features = ["wrap_help"] }
-crossbeam-channel = { version = "0.5.15", optional = true }
 env_logger = { version = "0.11.9", optional = true, default-features = false, features = ["auto-color"] }
 image = { version = "0.25.9", optional = true, default-features = false, features = ["png"] }
 indexmap = "2.13.0"
@@ -61,7 +60,7 @@ serde_json = "1.0.149"
 [features]
 binary = ["dep:clap", "dep:glob", "dep:env_logger", "dep:parse-size"]
 default = ["binary", "parallel", "zopfli"]
-parallel = ["dep:rayon", "indexmap/rayon", "dep:crossbeam-channel"]
+parallel = ["dep:rayon", "indexmap/rayon"]
 freestanding = ["libdeflater/freestanding"]
 sanity-checks = ["dep:image"]
 zopfli = ["dep:zopfli"]

--- a/src/evaluate.rs
+++ b/src/evaluate.rs
@@ -8,12 +8,12 @@ use std::sync::{
     atomic::{AtomicUsize, Ordering::*},
 };
 
-#[cfg(feature = "parallel")]
-use crossbeam_channel::{Receiver, Sender, unbounded};
 use deflate::Deflater;
 use indexmap::IndexSet;
 use log::trace;
 use rayon::prelude::*;
+#[cfg(feature = "parallel")]
+use std::sync::mpsc::{Receiver, Sender, channel};
 
 #[cfg(not(feature = "parallel"))]
 use crate::rayon;
@@ -73,7 +73,7 @@ impl Evaluator {
         final_round: bool,
     ) -> Self {
         #[cfg(feature = "parallel")]
-        let eval_channel = unbounded();
+        let eval_channel = channel();
         Self {
             deadline,
             filters,

--- a/tests/flags.rs
+++ b/tests/flags.rs
@@ -1,12 +1,11 @@
+use indexmap::indexset;
+use oxipng::{internal_tests::*, *};
+use serde_json::Value;
 use std::{
     fs::remove_file,
     path::{Path, PathBuf},
     process::Command,
 };
-
-use indexmap::indexset;
-use oxipng::{internal_tests::*, *};
-use serde_json::Value;
 
 const GRAY: u8 = 0;
 const RGB: u8 = 2;
@@ -97,13 +96,9 @@ fn test_it_converts(
 
 #[test]
 fn verbose_mode() {
-    use std::cell::RefCell;
-    #[cfg(not(feature = "parallel"))]
-    use std::sync::mpsc::{Sender, channel as unbounded};
-
-    #[cfg(feature = "parallel")]
-    use crossbeam_channel::{Sender, unbounded};
     use log::{Level, LevelFilter, Log, Metadata, Record, set_logger, set_max_level};
+    use std::cell::RefCell;
+    use std::sync::mpsc::{Sender, channel};
 
     // Rust runs tests in parallel by default.
     // We want to make sure that we verify only logs from our test.
@@ -143,7 +138,7 @@ fn verbose_mode() {
     let input = PathBuf::from("tests/files/verbose_mode.png");
     let (output, opts) = get_opts(&input);
 
-    let (sender, receiver) = unbounded();
+    let (sender, receiver) = channel();
 
     let thread_init = move || {
         // Initialise logs storage for all threads within our test.


### PR DESCRIPTION
[Since Rust 1.67](https://blog.rust-lang.org/2023/01/26/Rust-1.67.0/#std-sync-mpsc-implementation-updated), `std::sync::mpsc` is based on crossbeam-channel crate, so doesn't make sense to include additional dependency.