### PR TITLE
Prevent conversion to indexed when palette reduction is off

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -298,6 +298,8 @@ The default value depends on the optimization level preset.")
         .arg(
             Arg::new("no-palette-reduction")
                 .help("Do not change color palette")
+                .long_help("\
+Do not convert to indexed and do not modify an existing color palette.")
                 .long("np")
                 .action(ArgAction::SetTrue),
         )

--- a/src/reduction/mod.rs
+++ b/src/reduction/mod.rs
@@ -118,7 +118,7 @@ pub(crate) fn perform_reductions(
     // Attempt to reduce to indexed
     // Keep the existing `png` var in case it is grayscale - we can test both for depth reduction later
     let mut indexed = None;
-    if opts.color_type_reduction && !deadline.passed() {
+    if opts.color_type_reduction && opts.palette_reduction && !deadline.passed() {
         if let Some(reduced) = reduced_to_indexed(&png, opts.grayscale_reduction) {
             // Make sure the palette gets sorted (but don't bother evaluating both results)
             let new = Arc::new(sorted_palette(&reduced).unwrap_or(reduced));


### PR DESCRIPTION
~~Fixes 790.~~

@jonnyawsom3 Give the build artefact a test and let me know if this does what you need.

@AlexTMjugador I'm tempted to revert the previous change we made c71fd44 that prevents conversion _from_ grayscale. It's not intuitive that "no grayscale" would work that way and less flexible in the amount of control you have. If you need to prevent conversion from grayscale, you could still use `--nc` or `--np` with this new change. What do you think?