### PR TITLE
Warn when Zopfli --ziwi exceeds --zi

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -430,6 +430,16 @@ fn parse_opts_into_struct(
         let iterations_without_improvement = *matches
             .get_one::<NonZeroU64>("iterations-without-improvement")
             .unwrap_or(&NonZeroU64::MAX);
+
+        if iterations_without_improvement > iteration_count
+            && iterations_without_improvement != NonZeroU64::MAX
+        {
+            warn!(
+                "--ziwi ({}) is higher than --zi ({}) and will never be reached.",
+                iterations_without_improvement, iteration_count
+            );
+        }
+
         opts.deflater = Deflater::Zopfli(ZopfliOptions {
             iteration_count,
             iterations_without_improvement,


### PR DESCRIPTION
While manually optimizing PNG files via the CLI, I was using Zopfli and progressively increasing the `--ziwi` value to find the best compression threshold. Since I had already set a specific `--zi` value, I eventually reached a point where `--ziwi` exceeded it without me noticing, making the improvement check redundant.

This PR adds a warning when `--ziwi` is strictly greater than `--zi` to inform the user that the threshold is unreachable. While this specific case happened during manual fine-tuning, this warning will be useful for any user who might inadvertently set an inconsistent Zopfli configuration.