### PR TITLE
Improve CI efficiency: Add merge_group support and concurrency limits

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,4 +1,7 @@
-scripts
-.github
-.editorconfig
-.pre-commit-hooks.yaml
+/.editorconfig
+/.git/
+/.github/
+/.gitignore
+/.pre-commit-hooks.yaml
+/scripts/
+/target/

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -58,9 +58,9 @@ jobs:
 
       - name: Get the Oxipng version
         id: oxipngMeta
-        run:
-          echo "version=$(cargo metadata --format-version 1 --no-deps | jq -r '.packages[] | select(.name == "oxipng").version')"
-          >> "$GITHUB_OUTPUT"
+        run: |
+          VERSION=$(cargo metadata --format-version 1 --no-deps | jq -r '.packages[] | select(.name == "oxipng").version')
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
 
       - name: Retrieve ${{ matrix.target }} binary
         uses: dawidd6/action-download-artifact@v20

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -66,7 +66,7 @@ jobs:
         uses: dawidd6/action-download-artifact@v20
         with:
           workflow: oxipng.yml
-          commit: ${{ env.GITHUB_SHA }}
+          commit: ${{ github.sha }}
           name: Oxipng binary (${{ matrix.target }})
           path: target
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -5,6 +5,10 @@ on:
     tags:
       - "v*.*.*"
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 permissions:
   actions: read
   contents: write

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -7,6 +7,8 @@ on:
       - 'v*.*.*'
   pull_request:
   merge_group:
+    types:
+      - checks_requested
   workflow_dispatch:
     inputs:
       use_cache:

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -36,7 +36,7 @@ jobs:
       context: . # Use local checkout to support GitHub Merge Queue
       output: image
       platforms: linux/amd64,linux/arm64
-      push: ${{ github.event_name != 'pull_request' && github.event_name != 'merge_group' }}
+      push: ${{ github.event_name == 'push' || github.event_name == 'workflow_dispatch' }}
       cache: ${{ github.event_name != 'workflow_dispatch' || inputs.use_cache }}
       # We don't sign the image because ghcr.io doesn't support OCI Referrers API yet, and the fallback relies on pushing new tags on each build
       # https://github.com/docker/github-builder/issues/109#issuecomment-3885082486

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -18,14 +18,18 @@ on:
         default: true
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.event.merge_group.head_ref || github.ref }}
+  group: >-
+    ${{ github.workflow }}-
+    ${{ github.event.pull_request.number ||
+        (github.event_name == 'merge_group' && format('mq-{0}', github.event.merge_group.head_ref)) ||
+        github.ref }}
   cancel-in-progress: true
 
 jobs:
   build:
     uses: docker/github-builder/.github/workflows/build.yml@v1
-    # Exclude 'push' events from the Merge Queue to avoid a race condition where
-    # the 'push' event might cancel the 'merge_group' event via the concurrency group.
+    # Exclude 'push' events on Merge Queue branches, as they are already
+    # handled by the 'merge_group' event.
     if: (!(github.event_name == 'push' && startsWith(github.ref, 'refs/heads/gh-readonly-queue/')))
     permissions:
       contents: read

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -6,9 +6,7 @@ on:
     tags:
       - 'v*.*.*'
   pull_request:
-    types:
-      - opened
-      - synchronize
+  merge_group:
   workflow_dispatch:
     inputs:
       use_cache:
@@ -16,6 +14,10 @@ on:
         required: true
         type: boolean
         default: true
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
 
 jobs:
   build:

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -18,7 +18,7 @@ on:
         default: true
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.event.merge_group.head_ref || github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -24,6 +24,9 @@ concurrency:
 jobs:
   build:
     uses: docker/github-builder/.github/workflows/build.yml@v1
+    # Exclude 'push' events from the Merge Queue to avoid a race condition where
+    # the 'push' event might cancel the 'merge_group' event via the concurrency group.
+    if: (!(github.event_name == 'push' && startsWith(github.ref, 'refs/heads/gh-readonly-queue/')))
     permissions:
       contents: read
       packages: write

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -18,11 +18,7 @@ on:
         default: true
 
 concurrency:
-  group: >-
-    ${{ github.workflow }}-
-    ${{ github.event.pull_request.number ||
-        (github.event_name == 'merge_group' && format('mq-{0}', github.event.merge_group.head_ref)) ||
-        github.ref }}
+  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -30,6 +30,7 @@ jobs:
       id-token: write
       attestations: write
     with:
+      context: . # Use local checkout to support GitHub Merge Queue
       output: image
       platforms: linux/amd64,linux/arm64
       push: ${{ github.event_name != 'pull_request' }}

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -36,7 +36,7 @@ jobs:
       context: . # Use local checkout to support GitHub Merge Queue
       output: image
       platforms: linux/amd64,linux/arm64
-      push: ${{ github.event_name != 'pull_request' }}
+      push: ${{ github.event_name != 'pull_request' && github.event_name != 'merge_group' }}
       cache: ${{ github.event_name != 'workflow_dispatch' || inputs.use_cache }}
       # We don't sign the image because ghcr.io doesn't support OCI Referrers API yet, and the fallback relies on pushing new tags on each build
       # https://github.com/docker/github-builder/issues/109#issuecomment-3885082486

--- a/.github/workflows/oxipng.yml
+++ b/.github/workflows/oxipng.yml
@@ -9,11 +9,7 @@ on:
   workflow_dispatch:
 
 concurrency:
-  group: >-
-    ${{ github.workflow }}-
-    ${{ github.event.pull_request.number ||
-        (github.event_name == 'merge_group' && format('mq-{0}', github.event.merge_group.head_ref)) ||
-        github.ref }}
+  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/oxipng.yml
+++ b/.github/workflows/oxipng.yml
@@ -9,7 +9,7 @@ on:
   workflow_dispatch:
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.event.merge_group.head_ref || github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/oxipng.yml
+++ b/.github/workflows/oxipng.yml
@@ -19,8 +19,14 @@ jobs:
     runs-on: ${{ matrix.os }}
     timeout-minutes: 60
 
-    # Prevent tags and in-repo PRs from triggering this workflow more than once for a commit
-    if: github.ref_type != 'tag' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.fork)
+    # Prevent tags and in-repo PRs from triggering this workflow more than once for a commit.
+    # We also exclude 'push' events from the Merge Queue (gh-readonly-queue/) because they
+    # trigger alongside the 'merge_group' event. Without this, a race condition in the
+    # concurrency group could cause the 'push' event to cancel the 'merge_group' event.
+    if: >-
+      github.ref_type != 'tag' &&
+      (github.event_name != 'pull_request' || github.event.pull_request.head.repo.fork) &&
+      (!(github.event_name == 'push' && startsWith(github.ref, 'refs/heads/gh-readonly-queue/')))
 
     strategy:
       fail-fast: false
@@ -154,8 +160,14 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
 
-    # Prevent tags and in-repo PRs from triggering this workflow more than once for a commit
-    if: github.ref_type != 'tag' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.fork)
+    # Prevent tags and in-repo PRs from triggering this workflow more than once for a commit.
+    # We also exclude 'push' events from the Merge Queue (gh-readonly-queue/) because they
+    # trigger alongside the 'merge_group' event. Without this, a race condition in the
+    # concurrency group could cause the 'push' event to cancel the 'merge_group' event.
+    if: >-
+      github.ref_type != 'tag' &&
+      (github.event_name != 'pull_request' || github.event.pull_request.head.repo.fork) &&
+      (!(github.event_name == 'push' && startsWith(github.ref, 'refs/heads/gh-readonly-queue/')))
 
     steps:
       - name: Checkout source

--- a/.github/workflows/oxipng.yml
+++ b/.github/workflows/oxipng.yml
@@ -3,10 +3,12 @@ name: oxipng
 on:
   push:
   pull_request:
-    types:
-      - opened
-      - synchronize
+  merge_group:
   workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
 
 jobs:
   ci:

--- a/.github/workflows/oxipng.yml
+++ b/.github/workflows/oxipng.yml
@@ -4,6 +4,8 @@ on:
   push:
   pull_request:
   merge_group:
+    types:
+      - checks_requested
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/oxipng.yml
+++ b/.github/workflows/oxipng.yml
@@ -9,7 +9,11 @@ on:
   workflow_dispatch:
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.event.merge_group.head_ref || github.ref }}
+  group: >-
+    ${{ github.workflow }}-
+    ${{ github.event.pull_request.number ||
+        (github.event_name == 'merge_group' && format('mq-{0}', github.event.merge_group.head_ref)) ||
+        github.ref }}
   cancel-in-progress: true
 
 jobs:
@@ -20,9 +24,8 @@ jobs:
     timeout-minutes: 60
 
     # Prevent tags and in-repo PRs from triggering this workflow more than once for a commit.
-    # We also exclude 'push' events from the Merge Queue (gh-readonly-queue/) because they
-    # trigger alongside the 'merge_group' event. Without this, a race condition in the
-    # concurrency group could cause the 'push' event to cancel the 'merge_group' event.
+    # We also exclude 'push' events on Merge Queue branches, as they are already
+    # handled by the 'merge_group' event.
     if: >-
       github.ref_type != 'tag' &&
       (github.event_name != 'pull_request' || github.event.pull_request.head.repo.fork) &&
@@ -161,9 +164,8 @@ jobs:
     timeout-minutes: 30
 
     # Prevent tags and in-repo PRs from triggering this workflow more than once for a commit.
-    # We also exclude 'push' events from the Merge Queue (gh-readonly-queue/) because they
-    # trigger alongside the 'merge_group' event. Without this, a race condition in the
-    # concurrency group could cause the 'push' event to cancel the 'merge_group' event.
+    # We also exclude 'push' events on Merge Queue branches, as they are already
+    # handled by the 'merge_group' event.
     if: >-
       github.ref_type != 'tag' &&
       (github.event_name != 'pull_request' || github.event.pull_request.head.repo.fork) &&

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,6 @@
-target
 *.bk
-.DS_Store
 *.out.png
-/.idea
-/node_modules
+.DS_Store
+/.idea/
+/node_modules/
+/target/


### PR DESCRIPTION
This PR addresses #814 by optimizing the GitHub Actions workflows for the native Merge Queue feature and streamlining event triggers.

### Changes

* **Merge Queue Support**: Added the `merge_group` trigger to `oxipng.yml` and `docker.yml` to support the native GitHub queue logic.
* **Push Restriction**: Restricted the `push` trigger to the `master` branch and version tags. This avoids duplicate runs when a Pull Request is already open.
* **Concurrency Control**: Added `concurrency` groups with `cancel-in-progress: true` to all workflows. Obsolete runs will now be automatically cancelled when a new commit is pushed.
* **Simplified PR Triggers**: Removed explicit `types` from `pull_request` events to include the default `reopened` trigger.

### Benefits

* Ensures smooth integration with the GitHub Merge Queue.
* Removes redundant "Push" runs that overlap with "Pull Request" events.
* Automatically cancels stale builds, providing faster feedback on the latest commits.

### Note for Contributors

**CI runs are no longer automatically triggered on simple pushes to non-master branches.**

* The test suite will trigger automatically once a Pull Request is opened (including Draft PRs).
* Manual runs can still be initiated via the **workflow_dispatch** button in the Actions tab for any branch.

**Note:** I have since reverted the **Push Restriction** based on the discussion below. CI will still trigger on all branch pushes to allow testing before a PR is opened. While this means some redundancy remains, the new **concurrency control** will still handle canceling any stale builds.

Fixes #814