### PR TITLE
Include version info in verbose output

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -19,10 +19,10 @@ pub fn build_command() -> Command {
     // so that they can fit on a single line in an 80 character terminal.
     // Long help descriptions are soft wrapped here at 90 characters (column 91) but this does not
     // affect output, it simply matches what is rendered when help is output to a file.
-    Command::new("oxipng")
+    Command::new(env!("CARGO_PKG_NAME"))
         .version(env!("CARGO_PKG_VERSION"))
-        .author("Joshua Holmer <jholmer.in@gmail.com>")
-        .about("Losslessly improve compression of PNG files")
+        .author(env!("CARGO_PKG_AUTHORS"))
+        .about(env!("CARGO_PKG_DESCRIPTION"))
         .styles(STYLES)
         .arg(
             Arg::new("files")

--- a/src/main.rs
+++ b/src/main.rs
@@ -79,7 +79,12 @@ fn main() -> ExitCode {
         )
     };
 
+    // Include version info in verbose output
     let is_verbose = matches.get_count("verbose") > 0;
+    if is_verbose && !using_stdout {
+        println!("{} {}\n", env!("CARGO_PKG_NAME"), env!("CARGO_PKG_VERSION"));
+    }
+
     let print_summary = !matches.get_flag("quiet") && !using_stdout;
     let print_progress = print_summary && !is_verbose && stdout().is_terminal();
     let total_files = files.len();


### PR DESCRIPTION
Fixes #821 

Also changed the command info to use cargo env vars. The package description and the about were actually slightly different before but I don't think it matters much which text is used.