### PR TITLE
Remove filter restrictions for interlaced images

### DIFF
--- a/src/filters.rs
+++ b/src/filters.rs
@@ -85,7 +85,6 @@ impl Display for RowFilter {
 
 impl RowFilter {
     pub(crate) const ALL: [Self; 5] = [Self::None, Self::Sub, Self::Up, Self::Average, Self::Paeth];
-    pub(crate) const SINGLE_LINE: [Self; 2] = [Self::None, Self::Sub];
 
     pub(crate) fn filter_line(
         self,

--- a/src/png/mod.rs
+++ b/src/png/mod.rs
@@ -385,11 +385,8 @@ impl PngImage {
             // Alpha optimisation may alter the line data, so we need a mutable copy of it
             let mut line_data = line.data.to_vec();
 
-            if let FilterStrategy::Basic(mut filter) = strategy {
+            if let FilterStrategy::Basic(filter) = strategy {
                 // Standard filters
-                if prev_pass != line.pass && filter > RowFilter::Sub {
-                    filter = RowFilter::None;
-                }
                 filter.filter_line(bpp, &mut line_data, &prev_line, &mut f_buf, alpha_bytes);
                 filtered.extend_from_slice(&f_buf);
                 prev_line = line_data;
@@ -414,12 +411,7 @@ impl PngImage {
 
                 let mut best_line = Vec::new();
                 let mut best_line_raw = Vec::new();
-                // Avoid vertical filtering on first line of each interlacing pass
-                let try_filters = if prev_pass == line.pass {
-                    RowFilter::ALL.iter()
-                } else {
-                    RowFilter::SINGLE_LINE.iter()
-                };
+                let try_filters = RowFilter::ALL.iter();
                 match strategy {
                     FilterStrategy::MinSum => {
                         // MSAD algorithm mentioned in libpng reference docs


### PR DESCRIPTION
Filtering an interlaced image was previously avoiding vertical filters (up, average, paeth) for the first line of each interlacing pass. As best I can tell from the history, this was done because it wasn't zeroing out the previous line between each pass, so applying a vertical filter would have corrupted the image. Zeroing out the previous line has since been implemented, so there's no longer any reason to avoid vertical filters. Removing the restriction simplifies the code and can give a very small compression improvement for interlaced images.