### PR TITLE
Refactor filtering

### DIFF
--- a/src/filters.rs
+++ b/src/filters.rs
@@ -101,7 +101,6 @@ impl RowFilter {
             self.optimize_alpha(bpp, data, prev_line, bpp - alpha_bytes);
         }
 
-        buf.clear();
         buf.reserve(data.len() + 1);
         buf.push(self as u8);
         match self {
@@ -225,17 +224,19 @@ impl RowFilter {
         prev_line: &[u8],
         buf: &mut Vec<u8>,
     ) {
-        buf.clear();
-        buf.reserve(data.len());
         assert!(data.len() >= bpp);
         assert_eq!(data.len(), prev_line.len());
+        let offset = buf.len();
+        buf.reserve(data.len());
         match self {
             Self::None => {
                 buf.extend_from_slice(data);
             }
             Self::Sub => {
                 for (i, &cur) in data.iter().enumerate() {
-                    let prev_byte = i.checked_sub(bpp).and_then(|x| buf.get(x).copied());
+                    let prev_byte = i
+                        .checked_sub(bpp)
+                        .and_then(|x| buf.get(offset + x).copied());
                     buf.push(prev_byte.map_or(cur, |b| cur.wrapping_add(b)));
                 }
             }
@@ -248,7 +249,9 @@ impl RowFilter {
             }
             Self::Average => {
                 for (i, (&cur, &last)) in data.iter().zip(prev_line).enumerate() {
-                    let prev_byte = i.checked_sub(bpp).and_then(|x| buf.get(x).copied());
+                    let prev_byte = i
+                        .checked_sub(bpp)
+                        .and_then(|x| buf.get(offset + x).copied());
                     buf.push(cur.wrapping_add(prev_byte.map_or_else(
                         || last >> 1,
                         |b| ((u16::from(b) + u16::from(last)) >> 1) as u8,
@@ -260,7 +263,7 @@ impl RowFilter {
                     buf.push(
                         match i
                             .checked_sub(bpp)
-                            .map(|x| (buf.get(x).copied(), prev_line.get(x).copied()))
+                            .map(|x| (buf.get(offset + x).copied(), prev_line.get(x).copied()))
                         {
                             Some((Some(left), Some(left_up))) => {
                                 cur.wrapping_add(paeth_predictor(left, up, left_up))

--- a/src/filters/mod.rs
+++ b/src/filters/mod.rs
@@ -81,20 +81,31 @@ impl RowFilter {
                 );
             }
             Self::Average => {
-                for (i, byte) in data.iter().enumerate() {
-                    buf.push(byte.wrapping_sub(i.checked_sub(bpp).map_or_else(
-                        || prev_line[i] >> 1,
-                        |x| ((u16::from(data[x]) + u16::from(prev_line[i])) >> 1) as u8,
-                    )));
-                }
+                buf.extend(
+                    data.iter()
+                        .zip(prev_line.iter())
+                        .take(bpp)
+                        .map(|(cur, &up)| cur.wrapping_sub(up >> 1)),
+                );
+                buf.extend(data.iter().enumerate().skip(bpp).map(|(i, &cur)| {
+                    let left = data[i - bpp];
+                    let up = prev_line[i];
+                    cur.wrapping_sub(((u16::from(left) + u16::from(up)) >> 1) as u8)
+                }));
             }
             Self::Paeth => {
-                for (i, byte) in data.iter().enumerate() {
-                    buf.push(byte.wrapping_sub(i.checked_sub(bpp).map_or_else(
-                        || prev_line[i],
-                        |x| paeth_predictor(data[x], prev_line[i], prev_line[x]),
-                    )));
-                }
+                buf.extend(
+                    data.iter()
+                        .zip(prev_line.iter())
+                        .take(bpp)
+                        .map(|(cur, &up)| cur.wrapping_sub(up)),
+                );
+                buf.extend(data.iter().enumerate().skip(bpp).map(|(i, &cur)| {
+                    let left = data[i - bpp];
+                    let up = prev_line[i];
+                    let left_up = prev_line[i - bpp];
+                    cur.wrapping_sub(paeth_predictor(left, up, left_up))
+                }));
             }
         }
     }
@@ -190,11 +201,10 @@ impl RowFilter {
                 buf.extend_from_slice(data);
             }
             Self::Sub => {
-                for (i, &cur) in data.iter().enumerate() {
-                    let prev_byte = i
-                        .checked_sub(bpp)
-                        .and_then(|x| buf.get(offset + x).copied());
-                    buf.push(prev_byte.map_or(cur, |b| cur.wrapping_add(b)));
+                buf.extend_from_slice(&data[0..bpp]);
+                for i in bpp..data.len() {
+                    let left = buf[offset + i - bpp];
+                    buf.push(data[i].wrapping_add(left));
                 }
             }
             Self::Up => {
@@ -205,29 +215,24 @@ impl RowFilter {
                 );
             }
             Self::Average => {
-                for (i, (&cur, &last)) in data.iter().zip(prev_line).enumerate() {
-                    let prev_byte = i
-                        .checked_sub(bpp)
-                        .and_then(|x| buf.get(offset + x).copied());
-                    buf.push(cur.wrapping_add(prev_byte.map_or_else(
-                        || last >> 1,
-                        |b| ((u16::from(b) + u16::from(last)) >> 1) as u8,
-                    )));
+                for (cur, &up) in data.iter().take(bpp).zip(prev_line.iter().take(bpp)) {
+                    buf.push(cur.wrapping_add(up >> 1));
+                }
+                for i in bpp..data.len() {
+                    let left = buf[offset + i - bpp];
+                    let up = prev_line[i];
+                    buf.push(data[i].wrapping_add(((u16::from(left) + u16::from(up)) >> 1) as u8));
                 }
             }
             Self::Paeth => {
-                for (i, (&cur, &up)) in data.iter().zip(prev_line).enumerate() {
-                    buf.push(
-                        match i
-                            .checked_sub(bpp)
-                            .map(|x| (buf.get(offset + x).copied(), prev_line.get(x).copied()))
-                        {
-                            Some((Some(left), Some(left_up))) => {
-                                cur.wrapping_add(paeth_predictor(left, up, left_up))
-                            }
-                            _ => cur.wrapping_add(up),
-                        },
-                    );
+                for (cur, &up) in data.iter().take(bpp).zip(prev_line.iter().take(bpp)) {
+                    buf.push(cur.wrapping_add(up));
+                }
+                for i in bpp..data.len() {
+                    let left = buf[offset + i - bpp];
+                    let up = prev_line[i];
+                    let left_up = prev_line[i - bpp];
+                    buf.push(data[i].wrapping_add(paeth_predictor(left, up, left_up)));
                 }
             }
         }

--- a/src/filters/mod.rs
+++ b/src/filters/mod.rs
@@ -1,50 +1,7 @@
 use std::{fmt, fmt::Display, mem::transmute};
 
-/// Filtering strategy for use in [`Options`][crate::Options]
-#[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Clone, Hash)]
-pub enum FilterStrategy {
-    /// Same filter for all rows
-    Basic(RowFilter),
-    /// Minimum sum of absolute differences
-    MinSum,
-    /// Shannon entropy
-    Entropy,
-    /// Count of distinct bigrams
-    Bigrams,
-    /// Shannon entropy of bigrams
-    BigEnt,
-    /// Deflate compression
-    Brute {
-        /// The number of lines to compress at once
-        num_lines: usize,
-        /// The compression level to use (1-12)
-        level: u8,
-    },
-    /// Predefined filter for each row
-    Predefined(Vec<RowFilter>),
-}
-
-impl FilterStrategy {
-    pub const NONE: Self = Self::Basic(RowFilter::None);
-    pub const SUB: Self = Self::Basic(RowFilter::Sub);
-    pub const UP: Self = Self::Basic(RowFilter::Up);
-    pub const AVERAGE: Self = Self::Basic(RowFilter::Average);
-    pub const PAETH: Self = Self::Basic(RowFilter::Paeth);
-}
-
-impl Display for FilterStrategy {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self {
-            Self::Basic(filter) => filter.fmt(f),
-            Self::MinSum => "MinSum".fmt(f),
-            Self::Entropy => "Entropy".fmt(f),
-            Self::Bigrams => "Bigrams".fmt(f),
-            Self::BigEnt => "BigEnt".fmt(f),
-            Self::Brute { .. } => "Brute".fmt(f),
-            Self::Predefined(_) => "Predefined".fmt(f),
-        }
-    }
-}
+mod strategies;
+pub use strategies::FilterStrategy;
 
 /// PNG delta filters
 #[repr(u8)]

--- a/src/filters/strategies.rs
+++ b/src/filters/strategies.rs
@@ -103,13 +103,11 @@ impl StrategyEvaluator for MinSumEvaluator {
 // Shannon entropy algorithm, from LodePNG
 // https://github.com/lvandeve/lodepng
 struct EntropyEvaluator {
-    counts: [u32; 0x100],
     best_size: i32,
 }
 impl EntropyEvaluator {
     const fn new() -> Self {
         Self {
-            counts: [0; 0x100],
             best_size: i32::MIN,
         }
     }
@@ -119,11 +117,24 @@ impl StrategyEvaluator for EntropyEvaluator {
         self.best_size = i32::MIN;
     }
     fn evaluate(&mut self, output: &[u8], offset: usize) -> bool {
-        self.counts.fill(0);
-        for &i in &output[offset..] {
-            self.counts[i as usize] += 1;
+        // SIMD-friendly histogram construction
+        let mut hist0 = [0_u32; 0x100];
+        let mut hist1 = [0_u32; 0x100];
+        let mut hist2 = [0_u32; 0x100];
+        let mut hist3 = [0_u32; 0x100];
+        let mut chunks = output[offset..].chunks_exact(4);
+        for chunk in &mut chunks {
+            hist0[chunk[0] as usize] += 1;
+            hist1[chunk[1] as usize] += 1;
+            hist2[chunk[2] as usize] += 1;
+            hist3[chunk[3] as usize] += 1;
         }
-        let size = self.counts.iter().fold(0, |acc, &x| {
+        for &i in chunks.remainder() {
+            hist0[i as usize] += 1;
+        }
+
+        let size = (0..0x100).fold(0, |acc, i| {
+            let x = hist0[i] + hist1[i] + hist2[i] + hist3[i];
             if x == 0 {
                 return acc;
             }

--- a/src/filters/strategies.rs
+++ b/src/filters/strategies.rs
@@ -1,0 +1,261 @@
+use libdeflater::{CompressionLvl, Compressor};
+use rustc_hash::FxHashMap;
+use std::{fmt, fmt::Display};
+
+use crate::RowFilter;
+
+/// Filtering strategy for use in [`Options`][crate::Options]
+#[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Clone, Hash)]
+pub enum FilterStrategy {
+    /// Same filter for all rows
+    Basic(RowFilter),
+    /// Minimum sum of absolute differences
+    MinSum,
+    /// Shannon entropy
+    Entropy,
+    /// Count of distinct bigrams
+    Bigrams,
+    /// Shannon entropy of bigrams
+    BigEnt,
+    /// Deflate compression
+    Brute {
+        /// The number of lines to compress at once
+        num_lines: usize,
+        /// The compression level to use (1-12)
+        level: u8,
+    },
+    /// Predefined filter for each row
+    Predefined(Vec<RowFilter>),
+}
+
+impl FilterStrategy {
+    pub const NONE: Self = Self::Basic(RowFilter::None);
+    pub const SUB: Self = Self::Basic(RowFilter::Sub);
+    pub const UP: Self = Self::Basic(RowFilter::Up);
+    pub const AVERAGE: Self = Self::Basic(RowFilter::Average);
+    pub const PAETH: Self = Self::Basic(RowFilter::Paeth);
+
+    /// For heuristic strategies, get an evaluator to determine the best filter for each row.
+    pub(crate) fn evaluator(&self) -> Option<Box<dyn StrategyEvaluator>> {
+        match self {
+            Self::MinSum => Some(Box::new(MinSumEvaluator::new())),
+            Self::Entropy => Some(Box::new(EntropyEvaluator::new())),
+            Self::Bigrams => Some(Box::new(BigramsEvaluator::new())),
+            Self::BigEnt => Some(Box::new(BigEntEvaluator::new())),
+            Self::Brute { num_lines, level } => {
+                Some(Box::new(BruteEvaluator::new(*num_lines, *level)))
+            }
+            _ => None,
+        }
+    }
+}
+
+impl Display for FilterStrategy {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Basic(filter) => filter.fmt(f),
+            Self::MinSum => "MinSum".fmt(f),
+            Self::Entropy => "Entropy".fmt(f),
+            Self::Bigrams => "Bigrams".fmt(f),
+            Self::BigEnt => "BigEnt".fmt(f),
+            Self::Brute { .. } => "Brute".fmt(f),
+            Self::Predefined(_) => "Predefined".fmt(f),
+        }
+    }
+}
+
+pub(crate) trait StrategyEvaluator {
+    /// Reset any state for a new line, if necessary.
+    fn reset(&mut self, _line_len: usize) {}
+    /// Evaluate the output of a filter attempt, returning true if it's the best so far.
+    fn evaluate(&mut self, output: &[u8], offset: usize) -> bool;
+}
+
+// MSAD algorithm mentioned in libpng reference docs
+// http://www.libpng.org/pub/png/book/chapter09.html
+struct MinSumEvaluator {
+    best_size: usize,
+}
+impl MinSumEvaluator {
+    const fn new() -> Self {
+        Self {
+            best_size: usize::MAX,
+        }
+    }
+}
+impl StrategyEvaluator for MinSumEvaluator {
+    fn reset(&mut self, _line_len: usize) {
+        self.best_size = usize::MAX;
+    }
+    fn evaluate(&mut self, output: &[u8], offset: usize) -> bool {
+        let size = output[offset..].iter().fold(0, |acc, &x| {
+            let signed = x as i8;
+            acc + signed.unsigned_abs() as usize
+        });
+        if size < self.best_size {
+            self.best_size = size;
+            return true;
+        }
+        false
+    }
+}
+
+// Shannon entropy algorithm, from LodePNG
+// https://github.com/lvandeve/lodepng
+struct EntropyEvaluator {
+    counts: [u32; 0x100],
+    best_size: i32,
+}
+impl EntropyEvaluator {
+    const fn new() -> Self {
+        Self {
+            counts: [0; 0x100],
+            best_size: i32::MIN,
+        }
+    }
+}
+impl StrategyEvaluator for EntropyEvaluator {
+    fn reset(&mut self, _line_len: usize) {
+        self.best_size = i32::MIN;
+    }
+    fn evaluate(&mut self, output: &[u8], offset: usize) -> bool {
+        self.counts.fill(0);
+        for &i in &output[offset..] {
+            self.counts[i as usize] += 1;
+        }
+        let size = self.counts.iter().fold(0, |acc, &x| {
+            if x == 0 {
+                return acc;
+            }
+            acc + ilog2i(x)
+        }) as i32;
+        if size > self.best_size {
+            self.best_size = size;
+            return true;
+        }
+        false
+    }
+}
+
+// Count distinct bigrams, from pngwolf
+// https://bjoern.hoehrmann.de/pngwolf/
+struct BigramsEvaluator {
+    seen: [bool; 0x10000],
+    touched: Vec<u16>,
+    best_size: usize,
+}
+impl BigramsEvaluator {
+    const fn new() -> Self {
+        Self {
+            seen: [false; 0x10000],
+            touched: Vec::new(),
+            best_size: usize::MAX,
+        }
+    }
+}
+impl StrategyEvaluator for BigramsEvaluator {
+    fn reset(&mut self, _line_len: usize) {
+        self.best_size = usize::MAX;
+    }
+    fn evaluate(&mut self, output: &[u8], offset: usize) -> bool {
+        // Clear only the entries that were touched
+        for &idx in &self.touched {
+            self.seen[idx as usize] = false;
+        }
+        self.touched.clear();
+        let mut count = 0;
+        for pair in output[offset..].windows(2) {
+            let bigram = ((pair[0] as usize) << 8) | pair[1] as usize;
+            if !self.seen[bigram] {
+                count += 1;
+                if count >= self.best_size {
+                    return false;
+                }
+                self.seen[bigram] = true;
+                self.touched.push(bigram as u16);
+            }
+        }
+        self.best_size = count;
+        true
+    }
+}
+
+// Bigram entropy, combined from Entropy and Bigrams filters
+struct BigEntEvaluator {
+    counts: FxHashMap<u16, u32>,
+    best_size: i32,
+}
+impl BigEntEvaluator {
+    fn new() -> Self {
+        Self {
+            counts: FxHashMap::default(),
+            best_size: i32::MIN,
+        }
+    }
+}
+impl StrategyEvaluator for BigEntEvaluator {
+    fn reset(&mut self, _line_len: usize) {
+        self.best_size = i32::MIN;
+    }
+    fn evaluate(&mut self, output: &[u8], offset: usize) -> bool {
+        self.counts.clear();
+        for pair in output[offset..].windows(2) {
+            let bigram = (u16::from(pair[0]) << 8) | u16::from(pair[1]);
+            self.counts
+                .entry(bigram)
+                .and_modify(|e| *e += 1)
+                .or_insert(1);
+        }
+        let size = self.counts.values().fold(0, |acc, &x| acc + ilog2i(x)) as i32;
+        if size > self.best_size {
+            self.best_size = size;
+            return true;
+        }
+        false
+    }
+}
+
+// Brute force by compressing each filter attempt
+// Similar to that of LodePNG but includes some previous lines for context
+struct BruteEvaluator {
+    num_lines: usize,
+    compressor: Compressor,
+    limit: usize,
+    buffer: Vec<u8>,
+}
+impl BruteEvaluator {
+    fn new(num_lines: usize, level: u8) -> Self {
+        let compressor = Compressor::new(CompressionLvl::new(level.into()).unwrap());
+        Self {
+            num_lines,
+            compressor,
+            limit: 0,
+            buffer: Vec::new(),
+        }
+    }
+}
+impl StrategyEvaluator for BruteEvaluator {
+    fn reset(&mut self, line_len: usize) {
+        self.limit = line_len * self.num_lines;
+        let capacity = self.compressor.deflate_compress_bound(self.limit);
+        self.buffer.resize(capacity, 0);
+    }
+    fn evaluate(&mut self, output: &[u8], _offset: usize) -> bool {
+        let offset = output.len().saturating_sub(self.limit);
+        // Rely on the compressor to fail if the output is larger than our best size (the buffer size)
+        let Ok(size) = self
+            .compressor
+            .deflate_compress(&output[offset..], &mut self.buffer)
+        else {
+            return false;
+        };
+        self.buffer.truncate(size - 1);
+        true
+    }
+}
+
+// Integer approximation for i * log2(i) - much faster than float calculations
+const fn ilog2i(i: u32) -> u32 {
+    let log = 32 - i.leading_zeros() - 1;
+    i * log + ((i - (1 << log)) << 1)
+}

--- a/src/png/mod.rs
+++ b/src/png/mod.rs
@@ -1,8 +1,6 @@
-use std::{fs, path::Path, sync::Arc};
-
-use libdeflater::{CompressionLvl, Compressor};
 use log::warn;
 use rustc_hash::FxHashMap;
+use std::{fs, path::Path, sync::Arc};
 
 use crate::{
     Options, PngResult,
@@ -368,12 +366,7 @@ impl PngImage {
         let mut prev_pass: Option<u8> = None;
         // For heuristic strategies, keep track of the actual filter used for each line
         let mut filters_used = Vec::new();
-        // Pre-allocate buffers for the Bigrams strategy to avoid per-line allocations
-        let (mut bigram_seen, mut bigram_touched) = if matches!(strategy, FilterStrategy::Bigrams) {
-            (vec![false; 0x10000], Vec::<u16>::new())
-        } else {
-            (Vec::new(), Vec::new())
-        };
+        let mut strategy_evaluator = strategy.evaluator();
         for (i, line) in self.scan_lines(false).enumerate() {
             if prev_pass != line.pass || prev_line.is_empty() {
                 prev_line = vec![0; line.data.len()];
@@ -406,134 +399,20 @@ impl PngImage {
                 continue;
             }
 
-            let mut best_line = vec![0; line_data.len() + 1];
-            let mut best_line_raw = Vec::with_capacity(line_data.len());
+            let line_len = line.data.len() + 1;
+            let mut best_line = vec![0; line_len];
+            let mut best_line_raw = Vec::with_capacity(line.data.len());
             let offset = output.len();
-            match strategy {
-                FilterStrategy::MinSum => {
-                    // MSAD algorithm mentioned in libpng reference docs
-                    // http://www.libpng.org/pub/png/book/chapter09.html
-                    let mut best_size = usize::MAX;
-                    for f in RowFilter::ALL {
-                        f.filter_line(bpp, &mut line_data, &prev_line, &mut output, alpha_bytes);
-                        let size = output[offset..].iter().fold(0, |acc, &x| {
-                            let signed = x as i8;
-                            acc + signed.unsigned_abs() as usize
-                        });
-                        if size < best_size {
-                            best_size = size;
-                            best_line.clone_from_slice(&output[offset..]);
-                            best_line_raw.clone_from(&line_data);
-                            best_filter = f;
-                        }
-                        output.truncate(offset);
-                    }
+            let evaluator = strategy_evaluator.as_mut().unwrap();
+            evaluator.reset(line_len);
+            for f in RowFilter::ALL {
+                f.filter_line(bpp, &mut line_data, &prev_line, &mut output, alpha_bytes);
+                if evaluator.evaluate(&output, offset) {
+                    best_line.clone_from_slice(&output[offset..]);
+                    best_line_raw.clone_from(&line_data);
+                    best_filter = f;
                 }
-                FilterStrategy::Entropy => {
-                    // Shannon entropy algorithm, from LodePNG
-                    // https://github.com/lvandeve/lodepng
-                    let mut best_size = i32::MIN;
-                    for f in RowFilter::ALL {
-                        f.filter_line(bpp, &mut line_data, &prev_line, &mut output, alpha_bytes);
-                        let mut counts = vec![0; 0x100];
-                        for &i in &output[offset..] {
-                            counts[i as usize] += 1;
-                        }
-                        let size = counts.into_iter().fold(0, |acc, x| {
-                            if x == 0 {
-                                return acc;
-                            }
-                            acc + ilog2i(x)
-                        }) as i32;
-                        if size > best_size {
-                            best_size = size;
-                            best_line.clone_from_slice(&output[offset..]);
-                            best_line_raw.clone_from(&line_data);
-                            best_filter = f;
-                        }
-                        output.truncate(offset);
-                    }
-                }
-                FilterStrategy::Bigrams => {
-                    // Count distinct bigrams, from pngwolf
-                    // https://bjoern.hoehrmann.de/pngwolf/
-                    let mut best_size = usize::MAX;
-                    for f in RowFilter::ALL {
-                        f.filter_line(bpp, &mut line_data, &prev_line, &mut output, alpha_bytes);
-                        let mut count = 0;
-                        for pair in output[offset..].windows(2) {
-                            let bigram = ((pair[0] as usize) << 8) | pair[1] as usize;
-                            if !bigram_seen[bigram] {
-                                count += 1;
-                                if count >= best_size {
-                                    break;
-                                }
-                                bigram_seen[bigram] = true;
-                                bigram_touched.push(bigram as u16);
-                            }
-                        }
-                        // Clear only the entries that were touched
-                        for &idx in &bigram_touched {
-                            bigram_seen[idx as usize] = false;
-                        }
-                        bigram_touched.clear();
-                        if count < best_size {
-                            best_size = count;
-                            best_line.clone_from_slice(&output[offset..]);
-                            best_line_raw.clone_from(&line_data);
-                            best_filter = f;
-                        }
-                        output.truncate(offset);
-                    }
-                }
-                FilterStrategy::BigEnt => {
-                    // Bigram entropy, combined from Entropy and Bigrams filters
-                    let mut best_size = i32::MIN;
-                    // FxHasher is the fastest rust hasher currently available for this purpose
-                    let mut counts = FxHashMap::<u16, u32>::default();
-                    for f in RowFilter::ALL {
-                        f.filter_line(bpp, &mut line_data, &prev_line, &mut output, alpha_bytes);
-                        counts.clear();
-                        for pair in output[offset..].windows(2) {
-                            let bigram = (u16::from(pair[0]) << 8) | u16::from(pair[1]);
-                            counts.entry(bigram).and_modify(|e| *e += 1).or_insert(1);
-                        }
-                        let size = counts.values().fold(0, |acc, &x| acc + ilog2i(x)) as i32;
-                        if size > best_size {
-                            best_size = size;
-                            best_line.clone_from_slice(&output[offset..]);
-                            best_line_raw.clone_from(&line_data);
-                            best_filter = f;
-                        }
-                        output.truncate(offset);
-                    }
-                }
-                FilterStrategy::Brute { num_lines, level } => {
-                    // Brute force by compressing each filter attempt
-                    // Similar to that of LodePNG but includes some previous lines for context
-                    let mut best_size = usize::MAX;
-                    let line_len = line.data.len() + 1;
-                    let mut compressor =
-                        Compressor::new(CompressionLvl::new(level.into()).unwrap());
-                    let limit = (offset + line_len).min(line_len * num_lines);
-                    let capacity = compressor.deflate_compress_bound(limit);
-                    let mut dest = vec![0; capacity];
-
-                    for f in RowFilter::ALL {
-                        f.filter_line(bpp, &mut line_data, &prev_line, &mut output, alpha_bytes);
-                        let size = compressor
-                            .deflate_compress(&output[output.len() - limit..], &mut dest)
-                            .unwrap_or(usize::MAX);
-                        if size < best_size {
-                            best_size = size;
-                            best_line.clone_from_slice(&output[offset..]);
-                            best_line_raw.clone_from(&line_data);
-                            best_filter = f;
-                        }
-                        output.truncate(offset);
-                    }
-                }
-                _ => unreachable!(),
+                output.truncate(offset);
             }
             output.extend_from_slice(&best_line);
             prev_line = best_line_raw;
@@ -557,10 +436,4 @@ fn write_png_block(key: &[u8], chunk: &[u8], output: &mut Vec<u8>) {
     let crc = deflate::crc32(&chunk_data);
     output.append(&mut chunk_data);
     output.extend_from_slice(&crc.to_be_bytes());
-}
-
-// Integer approximation for i * log2(i) - much faster than float calculations
-const fn ilog2i(i: u32) -> u32 {
-    let log = 32 - i.leading_zeros() - 1;
-    i * log + ((i - (1 << log)) << 1)
 }

--- a/src/png/mod.rs
+++ b/src/png/mod.rs
@@ -333,20 +333,17 @@ impl PngImage {
     fn unfilter_image(&self) -> PngResult<Vec<u8>> {
         let mut unfiltered = Vec::with_capacity(self.data.len());
         let bpp = self.bytes_per_channel() * self.channels_per_pixel();
-        let mut last_line: Vec<u8> = Vec::new();
-        let mut last_pass = None;
-        let mut unfiltered_buf = Vec::new();
+        let mut prev_line: Vec<u8> = Vec::new();
+        let mut prev_pass = None;
         for line in self.scan_lines(true) {
-            if last_pass != line.pass {
-                last_line.clear();
-                last_pass = line.pass;
+            if prev_pass != line.pass || prev_line.is_empty() {
+                prev_line = vec![0; line.data.len()];
+                prev_pass = line.pass;
             }
-            last_line.resize(line.data.len(), 0);
+            let offset = unfiltered.len();
             let filter = RowFilter::try_from(line.filter).map_err(|()| PngError::InvalidData)?;
-            filter.unfilter_line(bpp, line.data, &last_line, &mut unfiltered_buf);
-            unfiltered.extend_from_slice(&unfiltered_buf);
-            std::mem::swap(&mut last_line, &mut unfiltered_buf);
-            unfiltered_buf.clear();
+            filter.unfilter_line(bpp, line.data, &prev_line, &mut unfiltered);
+            prev_line.clone_from_slice(&unfiltered[offset..]);
         }
         Ok(unfiltered)
     }
@@ -358,7 +355,7 @@ impl PngImage {
         strategy: FilterStrategy,
         optimize_alpha: bool,
     ) -> (Vec<u8>, FilterStrategy) {
-        let mut filtered = Vec::with_capacity(self.data.len());
+        let mut output = Vec::with_capacity(self.ihdr.raw_data_size());
         let bpp = self.bytes_per_channel() * self.channels_per_pixel();
         // If alpha optimization is enabled, determine how many bytes of alpha there are per pixel
         let alpha_bytes = if optimize_alpha && self.ihdr.color_type.has_alpha() {
@@ -369,7 +366,6 @@ impl PngImage {
 
         let mut prev_line = Vec::new();
         let mut prev_pass: Option<u8> = None;
-        let mut f_buf = Vec::new();
         // For heuristic strategies, keep track of the actual filter used for each line
         let mut filters_used = Vec::new();
         // Pre-allocate buffers for the Bigrams strategy to avoid per-line allocations
@@ -379,175 +375,175 @@ impl PngImage {
             (Vec::new(), Vec::new())
         };
         for (i, line) in self.scan_lines(false).enumerate() {
-            if prev_pass != line.pass || line.data.len() != prev_line.len() {
+            if prev_pass != line.pass || prev_line.is_empty() {
                 prev_line = vec![0; line.data.len()];
+                prev_pass = line.pass;
             }
             // Alpha optimisation may alter the line data, so we need a mutable copy of it
             let mut line_data = line.data.to_vec();
 
             if let FilterStrategy::Basic(filter) = strategy {
                 // Standard filters
-                filter.filter_line(bpp, &mut line_data, &prev_line, &mut f_buf, alpha_bytes);
-                filtered.extend_from_slice(&f_buf);
+                filter.filter_line(bpp, &mut line_data, &prev_line, &mut output, alpha_bytes);
                 prev_line = line_data;
+                continue;
             } else if let FilterStrategy::Predefined(lines) = &strategy {
                 // Predefined filter for each line
                 let filter = lines.get(i).unwrap_or(&RowFilter::None);
-                filter.filter_line(bpp, &mut line_data, &prev_line, &mut f_buf, alpha_bytes);
-                filtered.extend_from_slice(&f_buf);
+                filter.filter_line(bpp, &mut line_data, &prev_line, &mut output, alpha_bytes);
                 prev_line = line_data;
-            } else {
-                // Heuristic filter selection strategies
-
-                let mut best_filter = RowFilter::None;
-                if line_data.iter().all(|&x| x == 0) {
-                    // Assume None if the line is all zeros
-                    filtered.push(best_filter as u8);
-                    filtered.extend_from_slice(&line_data);
-                    prev_line = line_data;
-                    filters_used.push(best_filter);
-                    continue;
-                }
-
-                let mut best_line = Vec::new();
-                let mut best_line_raw = Vec::new();
-                let try_filters = RowFilter::ALL.iter();
-                match strategy {
-                    FilterStrategy::MinSum => {
-                        // MSAD algorithm mentioned in libpng reference docs
-                        // http://www.libpng.org/pub/png/book/chapter09.html
-                        let mut best_size = usize::MAX;
-                        for f in try_filters {
-                            f.filter_line(bpp, &mut line_data, &prev_line, &mut f_buf, alpha_bytes);
-                            let size = f_buf.iter().fold(0, |acc, &x| {
-                                let signed = x as i8;
-                                acc + signed.unsigned_abs() as usize
-                            });
-                            if size < best_size {
-                                best_size = size;
-                                std::mem::swap(&mut best_line, &mut f_buf);
-                                best_line_raw.clone_from(&line_data);
-                                best_filter = *f;
-                            }
-                        }
-                    }
-                    FilterStrategy::Entropy => {
-                        // Shannon entropy algorithm, from LodePNG
-                        // https://github.com/lvandeve/lodepng
-                        let mut best_size = i32::MIN;
-                        for f in try_filters {
-                            f.filter_line(bpp, &mut line_data, &prev_line, &mut f_buf, alpha_bytes);
-                            let mut counts = vec![0; 0x100];
-                            for &i in &f_buf {
-                                counts[i as usize] += 1;
-                            }
-                            let size = counts.into_iter().fold(0, |acc, x| {
-                                if x == 0 {
-                                    return acc;
-                                }
-                                acc + ilog2i(x)
-                            }) as i32;
-                            if size > best_size {
-                                best_size = size;
-                                std::mem::swap(&mut best_line, &mut f_buf);
-                                best_line_raw.clone_from(&line_data);
-                                best_filter = *f;
-                            }
-                        }
-                    }
-                    FilterStrategy::Bigrams => {
-                        // Count distinct bigrams, from pngwolf
-                        // https://bjoern.hoehrmann.de/pngwolf/
-                        let mut best_size = usize::MAX;
-                        for f in try_filters {
-                            f.filter_line(bpp, &mut line_data, &prev_line, &mut f_buf, alpha_bytes);
-                            let mut count = 0;
-                            for pair in f_buf.windows(2) {
-                                let bigram = ((pair[0] as usize) << 8) | pair[1] as usize;
-                                if !bigram_seen[bigram] {
-                                    count += 1;
-                                    if count >= best_size {
-                                        break;
-                                    }
-                                    bigram_seen[bigram] = true;
-                                    bigram_touched.push(bigram as u16);
-                                }
-                            }
-                            if count < best_size {
-                                best_size = count;
-                                std::mem::swap(&mut best_line, &mut f_buf);
-                                best_line_raw.clone_from(&line_data);
-                                best_filter = *f;
-                            }
-                            // Clear only the entries that were touched
-                            for &idx in &bigram_touched {
-                                bigram_seen[idx as usize] = false;
-                            }
-                            bigram_touched.clear();
-                        }
-                    }
-                    FilterStrategy::BigEnt => {
-                        // Bigram entropy, combined from Entropy and Bigrams filters
-                        let mut best_size = i32::MIN;
-                        // FxHasher is the fastest rust hasher currently available for this purpose
-                        let mut counts = FxHashMap::<u16, u32>::default();
-                        for f in try_filters {
-                            f.filter_line(bpp, &mut line_data, &prev_line, &mut f_buf, alpha_bytes);
-                            counts.clear();
-                            for pair in f_buf.windows(2) {
-                                let bigram = (u16::from(pair[0]) << 8) | u16::from(pair[1]);
-                                counts.entry(bigram).and_modify(|e| *e += 1).or_insert(1);
-                            }
-                            let size = counts.values().fold(0, |acc, &x| acc + ilog2i(x)) as i32;
-                            if size > best_size {
-                                best_size = size;
-                                std::mem::swap(&mut best_line, &mut f_buf);
-                                best_line_raw.clone_from(&line_data);
-                                best_filter = *f;
-                            }
-                        }
-                    }
-                    FilterStrategy::Brute { num_lines, level } => {
-                        // Brute force by compressing each filter attempt
-                        // Similar to that of LodePNG but includes some previous lines for context
-                        let mut best_size = usize::MAX;
-                        let line_start = filtered.len();
-                        filtered.resize(filtered.len() + line.data.len() + 1, 0);
-                        let mut compressor =
-                            Compressor::new(CompressionLvl::new(level.into()).unwrap());
-                        let limit = filtered.len().min((line.data.len() + 1) * num_lines);
-                        let capacity = compressor.deflate_compress_bound(limit);
-                        let mut dest = vec![0; capacity];
-
-                        for f in try_filters {
-                            f.filter_line(bpp, &mut line_data, &prev_line, &mut f_buf, alpha_bytes);
-                            filtered[line_start..].copy_from_slice(&f_buf);
-                            let size = compressor
-                                .deflate_compress(&filtered[filtered.len() - limit..], &mut dest)
-                                .unwrap_or(usize::MAX);
-                            if size < best_size {
-                                best_size = size;
-                                std::mem::swap(&mut best_line, &mut f_buf);
-                                best_line_raw.clone_from(&line_data);
-                                best_filter = *f;
-                            }
-                        }
-                        filtered.resize(line_start, 0);
-                    }
-                    _ => unreachable!(),
-                }
-                filtered.extend_from_slice(&best_line);
-                prev_line = best_line_raw;
-                filters_used.push(best_filter);
+                continue;
             }
 
-            prev_pass = line.pass;
+            // Heuristic filter selection strategies
+
+            let mut best_filter = RowFilter::None;
+            if line_data.iter().all(|&x| x == 0) {
+                // Assume None if the line is all zeros
+                best_filter.filter_line(bpp, &mut line_data, &prev_line, &mut output, alpha_bytes);
+                prev_line = line_data;
+                filters_used.push(best_filter);
+                continue;
+            }
+
+            let mut best_line = vec![0; line_data.len() + 1];
+            let mut best_line_raw = Vec::with_capacity(line_data.len());
+            let offset = output.len();
+            match strategy {
+                FilterStrategy::MinSum => {
+                    // MSAD algorithm mentioned in libpng reference docs
+                    // http://www.libpng.org/pub/png/book/chapter09.html
+                    let mut best_size = usize::MAX;
+                    for f in RowFilter::ALL {
+                        f.filter_line(bpp, &mut line_data, &prev_line, &mut output, alpha_bytes);
+                        let size = output[offset..].iter().fold(0, |acc, &x| {
+                            let signed = x as i8;
+                            acc + signed.unsigned_abs() as usize
+                        });
+                        if size < best_size {
+                            best_size = size;
+                            best_line.clone_from_slice(&output[offset..]);
+                            best_line_raw.clone_from(&line_data);
+                            best_filter = f;
+                        }
+                        output.truncate(offset);
+                    }
+                }
+                FilterStrategy::Entropy => {
+                    // Shannon entropy algorithm, from LodePNG
+                    // https://github.com/lvandeve/lodepng
+                    let mut best_size = i32::MIN;
+                    for f in RowFilter::ALL {
+                        f.filter_line(bpp, &mut line_data, &prev_line, &mut output, alpha_bytes);
+                        let mut counts = vec![0; 0x100];
+                        for &i in &output[offset..] {
+                            counts[i as usize] += 1;
+                        }
+                        let size = counts.into_iter().fold(0, |acc, x| {
+                            if x == 0 {
+                                return acc;
+                            }
+                            acc + ilog2i(x)
+                        }) as i32;
+                        if size > best_size {
+                            best_size = size;
+                            best_line.clone_from_slice(&output[offset..]);
+                            best_line_raw.clone_from(&line_data);
+                            best_filter = f;
+                        }
+                        output.truncate(offset);
+                    }
+                }
+                FilterStrategy::Bigrams => {
+                    // Count distinct bigrams, from pngwolf
+                    // https://bjoern.hoehrmann.de/pngwolf/
+                    let mut best_size = usize::MAX;
+                    for f in RowFilter::ALL {
+                        f.filter_line(bpp, &mut line_data, &prev_line, &mut output, alpha_bytes);
+                        let mut count = 0;
+                        for pair in output[offset..].windows(2) {
+                            let bigram = ((pair[0] as usize) << 8) | pair[1] as usize;
+                            if !bigram_seen[bigram] {
+                                count += 1;
+                                if count >= best_size {
+                                    break;
+                                }
+                                bigram_seen[bigram] = true;
+                                bigram_touched.push(bigram as u16);
+                            }
+                        }
+                        // Clear only the entries that were touched
+                        for &idx in &bigram_touched {
+                            bigram_seen[idx as usize] = false;
+                        }
+                        bigram_touched.clear();
+                        if count < best_size {
+                            best_size = count;
+                            best_line.clone_from_slice(&output[offset..]);
+                            best_line_raw.clone_from(&line_data);
+                            best_filter = f;
+                        }
+                        output.truncate(offset);
+                    }
+                }
+                FilterStrategy::BigEnt => {
+                    // Bigram entropy, combined from Entropy and Bigrams filters
+                    let mut best_size = i32::MIN;
+                    // FxHasher is the fastest rust hasher currently available for this purpose
+                    let mut counts = FxHashMap::<u16, u32>::default();
+                    for f in RowFilter::ALL {
+                        f.filter_line(bpp, &mut line_data, &prev_line, &mut output, alpha_bytes);
+                        counts.clear();
+                        for pair in output[offset..].windows(2) {
+                            let bigram = (u16::from(pair[0]) << 8) | u16::from(pair[1]);
+                            counts.entry(bigram).and_modify(|e| *e += 1).or_insert(1);
+                        }
+                        let size = counts.values().fold(0, |acc, &x| acc + ilog2i(x)) as i32;
+                        if size > best_size {
+                            best_size = size;
+                            best_line.clone_from_slice(&output[offset..]);
+                            best_line_raw.clone_from(&line_data);
+                            best_filter = f;
+                        }
+                        output.truncate(offset);
+                    }
+                }
+                FilterStrategy::Brute { num_lines, level } => {
+                    // Brute force by compressing each filter attempt
+                    // Similar to that of LodePNG but includes some previous lines for context
+                    let mut best_size = usize::MAX;
+                    let line_len = line.data.len() + 1;
+                    let mut compressor =
+                        Compressor::new(CompressionLvl::new(level.into()).unwrap());
+                    let limit = (offset + line_len).min(line_len * num_lines);
+                    let capacity = compressor.deflate_compress_bound(limit);
+                    let mut dest = vec![0; capacity];
+
+                    for f in RowFilter::ALL {
+                        f.filter_line(bpp, &mut line_data, &prev_line, &mut output, alpha_bytes);
+                        let size = compressor
+                            .deflate_compress(&output[output.len() - limit..], &mut dest)
+                            .unwrap_or(usize::MAX);
+                        if size < best_size {
+                            best_size = size;
+                            best_line.clone_from_slice(&output[offset..]);
+                            best_line_raw.clone_from(&line_data);
+                            best_filter = f;
+                        }
+                        output.truncate(offset);
+                    }
+                }
+                _ => unreachable!(),
+            }
+            output.extend_from_slice(&best_line);
+            prev_line = best_line_raw;
+            filters_used.push(best_filter);
         }
 
         if filters_used.is_empty() {
-            (filtered, strategy)
+            (output, strategy)
         } else {
-            (filtered, FilterStrategy::Predefined(filters_used))
+            (output, FilterStrategy::Predefined(filters_used))
         }
     }
 }


### PR DESCRIPTION
#804 highlighted the deficiency in the current filtering architecture, where different strategies need different vars to operate efficiently. This PR refactors all the heuristic strategies out into StrategyEvaluator structs where they can manage their own state as necessary. The filter_image function is much tidier and we get a few performance wins.

- Basic filters benefit from correct allocation of the output buffer up-front, and directly writing to that same buffer without a copy.
- Average and Paeth benefit significantly from avoiding `checked_sub` and using extend rather pushing one element at a time. This in turn brings significant benefits to all the heuristic strategies.
- Entropy sees a big win from an SIMD-friendly implementation (now faster than Bigrams again).
- Bigrams benefits fractionally, possibly due to not needing the `match` in filter_image?
- BigEnt benefits from only initialising the hash map once.
- Brute benefits from only initialising the compressor and buffer once, and allowing early returns.

Master:
```
test filters_8_bits_filter_0  ... bench:      40,350.92 ns/iter (+/- 1,120.84)
test filters_8_bits_filter_1  ... bench:      55,808.75 ns/iter (+/- 2,830.63)
test filters_8_bits_filter_2  ... bench:      70,306.90 ns/iter (+/- 12,643.25)
test filters_8_bits_filter_3  ... bench:     682,808.30 ns/iter (+/- 15,094.18)
test filters_8_bits_filter_4  ... bench:   1,164,927.10 ns/iter (+/- 27,906.60)

test filters_bigent  ... bench:  15,316,187.60 ns/iter (+/- 91,517.83)
test filters_bigrams ... bench:   5,128,375.00 ns/iter (+/- 27,954.71)
test filters_brute   ... bench:  38,962,745.80 ns/iter (+/- 185,544.27)
test filters_entropy ... bench:   6,821,429.10 ns/iter (+/- 37,562.12)
test filters_minsum  ... bench:   1,967,637.40 ns/iter (+/- 24,759.92)
```

PR:
```
test filters_8_bits_filter_0  ... bench:      31,273.37 ns/iter (+/- 943.61)
test filters_8_bits_filter_1  ... bench:      37,839.40 ns/iter (+/- 960.99)
test filters_8_bits_filter_2  ... bench:      38,238.71 ns/iter (+/- 205.69)
test filters_8_bits_filter_3  ... bench:      42,219.17 ns/iter (+/- 356.06)
test filters_8_bits_filter_4  ... bench:     203,984.40 ns/iter (+/- 1,486.36)

test filters_bigent  ... bench:  10,888,270.80 ns/iter (+/- 63,726.27)
test filters_bigrams ... bench:   3,470,237.60 ns/iter (+/- 17,436.08)
test filters_brute   ... bench:  34,646,812.50 ns/iter (+/- 270,427.50)
test filters_entropy ... bench:   2,021,437.50 ns/iter (+/- 15,171.58)
test filters_minsum  ... bench:     432,016.65 ns/iter (+/- 3,334.32)
```