### PR TITLE
Make `keep` more robust

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -133,9 +133,10 @@ Strip metadata chunks, where <mode> is one of:
 
 CAUTION: 'all' will convert APNGs to standard PNGs.
 
-Please note that regardless of any options set, some chunks will necessarily be stripped \
-when invalidated by the optimization:
-    bKGD, sBIT, hIST: Stripped if the color type or bit depth changes.
+Please note that some chunks will necessarily be stripped when invalidated by the \
+optimization:
+    bKGD, sBIT, hIST: Stripped if the color type or bit depth changes. If explicitly \
+    retained by `--keep`, reductions will be disabled.
     caBX, iDOT: Stripped by default. If explicitly retained by `--keep`, optimization will \
     be aborted.
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -136,9 +136,8 @@ CAUTION: 'all' will convert APNGs to standard PNGs.
 Please note that regardless of any options set, some chunks will necessarily be stripped \
 when invalidated by the optimization:
     bKGD, sBIT, hIST: Stripped if the color type or bit depth changes.
-    iDOT: Always stripped.
-    caBX: Stripped if it contains C2PA metadata. If explicitly retained by `--keep`, \
-    optimization will be aborted.
+    caBX, iDOT: Stripped by default. If explicitly retained by `--keep`, optimization will \
+    be aborted.
 
 The default when --strip is not passed is to keep all chunks that remain valid.",
                        DISPLAY_CHUNKS

--- a/src/error.rs
+++ b/src/error.rs
@@ -8,6 +8,7 @@ pub enum PngError {
     APNGOutOfOrder,
     C2PAMetadataPreventsChanges,
     ChunkMissing(&'static str),
+    ChunkPreventsChanges([u8; 4]),
     CRCMismatch([u8; 4]),
     DeflatedDataTooLong(usize),
     IncorrectDataLength(usize, usize),
@@ -33,6 +34,11 @@ impl fmt::Display for PngError {
                 "The image contains C2PA manifest that would be invalidated by any file changes",
             ),
             Self::ChunkMissing(s) => write!(f, "Chunk {s} missing or empty"),
+            Self::ChunkPreventsChanges(ref c) => write!(
+                f,
+                "The image contains a {} chunk that would be invalidated by any file changes",
+                String::from_utf8_lossy(c)
+            ),
             Self::CRCMismatch(ref c) => write!(
                 f,
                 "CRC mismatch in {} chunk; May be recoverable by using --fix",

--- a/src/headers.rs
+++ b/src/headers.rs
@@ -112,36 +112,6 @@ pub struct RawChunk<'a> {
     pub data: &'a [u8],
 }
 
-impl RawChunk<'_> {
-    // Is it a chunk for C2PA/CAI JUMBF metadata
-    pub(crate) fn is_c2pa(&self) -> bool {
-        if self.name == *b"caBX" {
-            if let Some((b"jumb", data)) = parse_jumbf_box(self.data) {
-                if let Some((b"jumd", data)) = parse_jumbf_box(data) {
-                    if data.get(..4) == Some(b"c2pa") {
-                        return true;
-                    }
-                }
-            }
-        }
-        false
-    }
-}
-
-fn parse_jumbf_box(data: &[u8]) -> Option<(&[u8], &[u8])> {
-    if data.len() < 8 {
-        return None;
-    }
-    let (len, rest) = data.split_at(4);
-    let len = read_be_u32(len) as usize;
-    if len < 8 || len > data.len() {
-        return None;
-    }
-    let (box_name, data) = rest.split_at(4);
-    let data = data.get(..len - 8)?;
-    Some((box_name, data))
-}
-
 pub fn parse_next_chunk<'a>(
     byte_data: &'a [u8],
     byte_offset: &mut usize,
@@ -410,16 +380,4 @@ pub fn postprocess_chunks(aux_chunks: &mut Vec<Chunk>, ihdr: &IhdrData, orig_ihd
             !invalid
         });
     }
-
-    // Remove iDOT which will necessarily be invalid after successful optimization
-    aux_chunks.retain(|c| {
-        let invalid = &c.name == b"iDOT";
-        if invalid {
-            trace!(
-                "Removing {} chunk as it no longer matches the IDAT",
-                std::str::from_utf8(&c.name).unwrap()
-            );
-        }
-        !invalid
-    });
 }

--- a/src/headers.rs
+++ b/src/headers.rs
@@ -69,6 +69,9 @@ pub struct Chunk {
     pub name: [u8; 4],
     pub data: Vec<u8>,
 }
+impl Chunk {
+    const REDUCTION_CONFLICTS: [[u8; 4]; 3] = [*b"bKGD", *b"sBIT", *b"hIST"];
+}
 
 /// [`Options`][crate::Options] to use when stripping chunks (metadata)
 #[derive(Debug, PartialEq, Eq, Clone)]
@@ -345,7 +348,20 @@ pub fn preprocess_chunks(aux_chunks: &mut Vec<Chunk>, opts: &mut Options) {
         opts.bit_depth_reduction = false;
         opts.color_type_reduction = false;
         opts.palette_reduction = false;
-        opts.grayscale_reduction = false;
+    } else if let StripChunks::Keep(names) = &opts.strip {
+        // Check for explicitly kept chunks that will prevent reductions
+        for name in Chunk::REDUCTION_CONFLICTS {
+            if names.contains(&name) && aux_chunks.iter().any(|c| c.name == name) {
+                warn!(
+                    "{} chunk explicitly kept, disabling all reductions",
+                    std::str::from_utf8(&name).unwrap()
+                );
+                opts.bit_depth_reduction = false;
+                opts.color_type_reduction = false;
+                opts.palette_reduction = false;
+                break;
+            }
+        }
     }
 }
 
@@ -356,14 +372,14 @@ pub fn postprocess_chunks(aux_chunks: &mut Vec<Chunk>, ihdr: &IhdrData, orig_ihd
     // generally more trouble than they're worth
     if orig_ihdr.bit_depth != ihdr.bit_depth || orig_ihdr.color_type != ihdr.color_type {
         aux_chunks.retain(|c| {
-            let invalid = &c.name == b"bKGD" || &c.name == b"sBIT" || &c.name == b"hIST";
-            if invalid {
+            if Chunk::REDUCTION_CONFLICTS.contains(&c.name) {
                 warn!(
                     "Removing {} chunk as it no longer matches the image data",
                     std::str::from_utf8(&c.name).unwrap()
                 );
+                return false;
             }
-            !invalid
+            true
         });
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -124,7 +124,7 @@ fn main() -> ExitCode {
                     num_not_optimized += 1;
                 }
             }
-            Err(PngError::C2PAMetadataPreventsChanges | PngError::InflatedDataTooLong(_)) => {}
+            Err(PngError::ChunkPreventsChanges(_) | PngError::InflatedDataTooLong(_)) => {}
             Err(_) => num_failed += 1,
         }
     }
@@ -543,7 +543,7 @@ fn process_file(input: &InFile, output: &OutFile, opts: &Options) -> Optimizatio
     let result = oxipng::optimize(input, output, opts);
     match &result {
         Ok(_) => {}
-        Err(e @ PngError::C2PAMetadataPreventsChanges | e @ PngError::InflatedDataTooLong(_)) => {
+        Err(e @ PngError::ChunkPreventsChanges(_) | e @ PngError::InflatedDataTooLong(_)) => {
             warn!("{input}: Skipped: {e}");
         }
         Err(e) => {

--- a/src/main.rs
+++ b/src/main.rs
@@ -391,7 +391,7 @@ fn parse_opts_into_struct(
                 }
                 Some(match parse_chunk_name(x) {
                     Ok(name) if FORBIDDEN_CHUNKS.contains(&name) => Err(format!(
-                        "{x} chunk is controlled internally may not be explicitly kept"
+                        "{x} chunk is controlled internally and may not be explicitly kept"
                     )),
                     name => name,
                 })

--- a/src/main.rs
+++ b/src/main.rs
@@ -379,16 +379,22 @@ fn parse_opts_into_struct(
         };
     }
 
+    const FORBIDDEN_CHUNKS: [[u8; 4]; 5] = [*b"IHDR", *b"IDAT", *b"tRNS", *b"PLTE", *b"IEND"];
     if let Some(keep) = matches.get_one::<String>("keep") {
         let mut keep_display = false;
         let mut names = keep
             .split(',')
-            .filter_map(|name| {
-                if name == "display" {
+            .filter_map(|x| {
+                if x == "display" {
                     keep_display = true;
                     return None;
                 }
-                Some(parse_chunk_name(name))
+                Some(match parse_chunk_name(x) {
+                    Ok(name) if FORBIDDEN_CHUNKS.contains(&name) => Err(format!(
+                        "{x} chunk is controlled internally may not be explicitly kept"
+                    )),
+                    name => name,
+                })
             })
             .collect::<Result<IndexSet<_>, _>>()?;
         if keep_display {
@@ -403,8 +409,6 @@ fn parse_opts_into_struct(
         } else if strip == "all" {
             opts.strip = StripChunks::All;
         } else {
-            const FORBIDDEN_CHUNKS: [[u8; 4]; 5] =
-                [*b"IHDR", *b"IDAT", *b"tRNS", *b"PLTE", *b"IEND"];
             let names = strip
                 .split(',')
                 .map(|x| {

--- a/src/png/mod.rs
+++ b/src/png/mod.rs
@@ -85,14 +85,18 @@ impl PngData {
                     key_chunks.insert(chunk.name, chunk.data.to_owned());
                 }
                 _ if opts.strip.keep(&chunk.name) => {
-                    if chunk.is_c2pa() {
-                        // StripChunks::None is the default value, so to keep optimizing by default,
-                        // interpret it as stripping the C2PA metadata.
-                        // The C2PA metadata is invalidated if the file changes, so it shouldn't be kept.
-                        if opts.strip == StripChunks::None {
-                            continue;
+                    if chunk.name == *b"caBX" || chunk.name == *b"iDOT" {
+                        // caBX (C2PA manifest) and iDOT (data offsets) are necessarily invalidated
+                        // by changes to the file. If these chunks have been explicitly kept then
+                        // return an error, otherwise strip them automatically.
+                        if matches!(opts.strip, StripChunks::Keep(_)) {
+                            return Err(PngError::ChunkPreventsChanges(chunk.name));
                         }
-                        return Err(PngError::C2PAMetadataPreventsChanges);
+                        warn!(
+                            "Stripping {} chunk which will be invalidated by file changes",
+                            std::str::from_utf8(&chunk.name).unwrap()
+                        );
+                        continue;
                     }
                     if chunk.name == *b"fcTL" || chunk.name == *b"fdAT" {
                         // Validate the sequence number

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -52,7 +52,7 @@ fn skip_c2pa() {
             ..Options::default()
         },
     );
-    assert!(matches!(result, Err(PngError::C2PAMetadataPreventsChanges)));
+    assert!(matches!(result, Err(PngError::ChunkPreventsChanges(_))));
 }
 
 #[test]


### PR DESCRIPTION
- Disallow protected chunks with `--keep` (the same set that we already do not allow with `--strip`).
- Add new `ChunkPreventsChanges` error, thrown if `iDOT` or `caBX` is explicitly kept.
  - The jumbf parsing to check for C2PA has been removed. The `caBX` chunk is specifically for storing a C2PA manifest, so there's no reason to check for this.
- Explicitly kept `bKGD`, `sBIT` or `hIST` chunks will now disable reductions rather than stripping them regardless.

All of this means there should no longer be any case where a chunk specified in `--keep` is still stripped anyway. Other strip modes may still strip these chunks, as documented in the help.

Closes #836.