### PR TITLE
Balance adjustments to palette sorting

### DIFF
--- a/.github/workflows/oxipng.yml
+++ b/.github/workflows/oxipng.yml
@@ -167,7 +167,7 @@ jobs:
       - name: Install MSRV Rust toolchain
         uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
-          toolchain: 1.85.1
+          toolchain: 1.88.0
           cache-bin: false
           cache-shared-key: cache
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ license = "MIT"
 name = "oxipng"
 repository = "https://github.com/oxipng/oxipng"
 version = "10.1.1"
-rust-version = "1.85.1"
+rust-version = "1.88.0"
 
 [badges]
 travis-ci = { repository = "oxipng/oxipng", branch = "master" }

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 # check=error=true
 FROM --platform=$BUILDPLATFORM tonistiigi/xx AS xx
 
-FROM --platform=$BUILDPLATFORM rust:1.85.1-alpine AS base
+FROM --platform=$BUILDPLATFORM rust:1.88.0-alpine AS base
 
 RUN apk update && \
     apk add \

--- a/src/deflate/mod.rs
+++ b/src/deflate/mod.rs
@@ -32,10 +32,10 @@ impl Deflater {
             #[cfg(feature = "zopfli")]
             Self::Zopfli(options) => zopfli_deflate(data, options)?,
         };
-        if let Some(max) = max_size {
-            if compressed.len() > max {
-                return Err(PngError::DeflatedDataTooLong(max));
-            }
+        if let Some(max) = max_size
+            && compressed.len() > max
+        {
+            return Err(PngError::DeflatedDataTooLong(max));
         }
         Ok(compressed)
     }

--- a/src/evaluate.rs
+++ b/src/evaluate.rs
@@ -161,10 +161,10 @@ impl Evaluator {
 
                     // Skip if it exceeds best known size. (This is important to ensure
                     // the evaluator returns no result when all candidates are too large.)
-                    if let Some(max) = best_candidate_size.get() {
-                        if estimated_output_size > max {
-                            return;
-                        }
+                    if let Some(max) = best_candidate_size.get()
+                        && estimated_output_size > max
+                    {
+                        return;
                     }
 
                     // We only need to retain the IDAT data in the final round

--- a/src/filters/strategies.rs
+++ b/src/filters/strategies.rs
@@ -122,14 +122,14 @@ impl StrategyEvaluator for EntropyEvaluator {
         let mut hist1 = [0_u32; 0x100];
         let mut hist2 = [0_u32; 0x100];
         let mut hist3 = [0_u32; 0x100];
-        let mut chunks = output[offset..].chunks_exact(4);
-        for chunk in &mut chunks {
+        let (chunks, remainder) = output[offset..].as_chunks::<4>();
+        for chunk in chunks {
             hist0[chunk[0] as usize] += 1;
             hist1[chunk[1] as usize] += 1;
             hist2[chunk[2] as usize] += 1;
             hist3[chunk[3] as usize] += 1;
         }
-        for &i in chunks.remainder() {
+        for &i in remainder {
             hist0[i as usize] += 1;
         }
 

--- a/src/headers.rs
+++ b/src/headers.rs
@@ -198,7 +198,9 @@ fn palette_to_rgba(
 ) -> Result<Vec<RGBA8>, PngError> {
     let palette_data = palette_data.ok_or(PngError::ChunkMissing("PLTE"))?;
     let mut palette: Vec<_> = palette_data
-        .chunks_exact(3)
+        .as_chunks::<3>()
+        .0
+        .iter()
         .map(|color| RGBA8::new(color[0], color[1], color[2], 255))
         .collect();
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -488,11 +488,11 @@ fn parse_numeric_range_opts(
     let mut items = IndexSet::new();
 
     // one value
-    if let Ok(one_value) = input.parse::<u8>() {
-        if (min_value <= one_value) && (one_value <= max_value) {
-            items.insert(one_value);
-            return Ok(items);
-        }
+    if let Ok(one_value) = input.parse::<u8>()
+        && (min_value <= one_value && one_value <= max_value)
+    {
+        items.insert(one_value);
+        return Ok(items);
     }
 
     // a range ("A-B")
@@ -500,13 +500,13 @@ fn parse_numeric_range_opts(
     if range_values.len() == 2 {
         let first_opt = range_values[0].parse::<u8>();
         let second_opt = range_values[1].parse::<u8>();
-        if let (Ok(first), Ok(second)) = (first_opt, second_opt) {
-            if min_value <= first && first < second && second <= max_value {
-                for i in first..=second {
-                    items.insert(i);
-                }
-                return Ok(items);
+        if let (Ok(first), Ok(second)) = (first_opt, second_opt)
+            && (min_value <= first && first < second && second <= max_value)
+        {
+            for i in first..=second {
+                items.insert(i);
             }
+            return Ok(items);
         }
         return Err(ERROR_MESSAGE.to_owned());
     }
@@ -515,14 +515,12 @@ fn parse_numeric_range_opts(
     let list_items = input.split(',').collect::<Vec<&str>>();
     if list_items.len() > 1 {
         for value in list_items {
-            if let Ok(value_int) = value.parse::<u8>() {
-                if (min_value <= value_int)
-                    && (value_int <= max_value)
-                    && !items.contains(&value_int)
-                {
-                    items.insert(value_int);
-                    continue;
-                }
+            if let Ok(value_int) = value.parse::<u8>()
+                && (min_value <= value_int && value_int <= max_value)
+                && !items.contains(&value_int)
+            {
+                items.insert(value_int);
+                continue;
             }
             return Err(ERROR_MESSAGE.to_owned());
         }
@@ -533,11 +531,11 @@ fn parse_numeric_range_opts(
 }
 
 fn process_file(input: &InFile, output: &OutFile, opts: &Options) -> OptimizationResult {
-    if let (Some(max_size), InFile::Path(path)) = (opts.max_decompressed_size, input) {
-        if path.metadata().is_ok_and(|m| m.len() > max_size as u64) {
-            warn!("{input}: Skipped: File exceeds the maximum size ({max_size} bytes)");
-            return Err(PngError::InflatedDataTooLong(max_size));
-        }
+    if let (Some(max_size), InFile::Path(path)) = (opts.max_decompressed_size, input)
+        && path.metadata().is_ok_and(|m| m.len() > max_size as u64)
+    {
+        warn!("{input}: Skipped: File exceeds the maximum size ({max_size} bytes)");
+        return Err(PngError::InflatedDataTooLong(max_size));
     }
 
     let result = oxipng::optimize(input, output, opts);

--- a/src/png/mod.rs
+++ b/src/png/mod.rs
@@ -141,10 +141,10 @@ impl PngData {
             key_chunks.remove(b"PLTE"),
             key_chunks.remove(b"tRNS"),
         )?;
-        if let Some(max) = opts.max_decompressed_size {
-            if ihdr.raw_data_size() > max {
-                return Err(PngError::InflatedDataTooLong(max));
-            }
+        if let Some(max) = opts.max_decompressed_size
+            && ihdr.raw_data_size() > max
+        {
+            return Err(PngError::InflatedDataTooLong(max));
         }
 
         let raw = PngImage::new(ihdr, &idat_data)?;

--- a/src/png/scan_lines.rs
+++ b/src/png/scan_lines.rs
@@ -63,7 +63,7 @@ struct ScanLineRanges {
 }
 
 impl ScanLineRanges {
-    pub fn new(png: &PngImage, has_filter: bool) -> Self {
+    pub const fn new(png: &PngImage, has_filter: bool) -> Self {
         Self {
             bits_per_pixel: png.ihdr.bpp(),
             width: png.ihdr.width,

--- a/src/reduction/bit_depth.rs
+++ b/src/reduction/bit_depth.rs
@@ -15,14 +15,14 @@ pub fn reduced_bit_depth_16_to_8(png: &PngImage, force_scale: bool) -> Option<Pn
         return scaled_bit_depth_16_to_8(png);
     }
 
-    // Reduce from 16 to 8 bits per channel per pixel
-    if png.data.chunks_exact(2).any(|pair| pair[0] != pair[1]) {
+    let pixels = png.data.as_chunks::<2>().0;
+    if pixels.iter().any(|pair| pair[0] != pair[1]) {
         // Can't reduce
         return None;
     }
 
     Some(PngImage {
-        data: png.data.chunks_exact(2).map(|pair| pair[0]).collect(),
+        data: pixels.iter().map(|pair| pair[0]).collect(),
         ihdr: IhdrData {
             color_type: png.ihdr.color_type.clone(),
             bit_depth: BitDepth::Eight,
@@ -39,9 +39,9 @@ pub fn scaled_bit_depth_16_to_8(png: &PngImage) -> Option<PngImage> {
     }
 
     // Reduce from 16 to 8 bits per channel per pixel by scaling when necessary
-    let data = png
-        .data
-        .chunks_exact(2)
+    let pixels = png.data.as_chunks::<2>().0;
+    let data = pixels
+        .iter()
         .map(|pair| {
             if pair[0] == pair[1] {
                 return pair[0];

--- a/src/reduction/mod.rs
+++ b/src/reduction/mod.rs
@@ -150,19 +150,35 @@ pub(crate) fn perform_reductions(
         None
     };
 
-    // Attempt to sort the palette using the ezeng method
+    // Attempt additional palette sorting techniques
     if effort >= 3 && opts.palette_reduction && !deadline.passed() {
+        // Collect a list of palettes so we can avoid evaluating the same one twice
+        let mut palettes = vec![baseline.ihdr.color_type.clone()];
         // Make sure we use the `indexed` var as input if it exists
+        // This one doesn't need to be kept in the palette list as the sorters will fail if there's no change
         let input = indexed.as_ref().unwrap_or(&png);
         if let Some(matrix) = CoOccurrenceMatrix::from(input) {
-            // 50 is a good value for max_swap_dist to keep performance reasonable and can actually be
-            // better than the full 255 in some cases
-            if let Some(reduced) = sorted_palette_ezeng(input, &matrix, 50) {
-                // Skip evaluation if the palette is the same as the baseline
-                if reduced.ihdr.color_type != baseline.ihdr.color_type {
-                    eval.try_image_with_description(Arc::new(reduced), "Indexed (ezeng sort)");
-                    evaluation_added = true;
-                }
+            // Attempt to sort the palette using the ezeng method
+            // 50 is a good value for max_swap_dist to keep performance reasonable and can actually
+            // be better than the full 255 in some cases
+            if !deadline.passed()
+                && let Some(reduced) = sorted_palette_ezeng(input, &matrix, 50)
+                && !palettes.contains(&reduced.ihdr.color_type)
+            {
+                palettes.push(reduced.ihdr.color_type.clone());
+                eval.try_image_with_description(Arc::new(reduced), "Indexed (ezeng sort)");
+                evaluation_added = true;
+            }
+
+            // Attempt to sort the palette using the battiato method
+            if effort >= 4
+                && !deadline.passed()
+                && let Some(reduced) = sorted_palette_battiato(input, &matrix)
+                && !palettes.contains(&reduced.ihdr.color_type)
+            {
+                palettes.push(reduced.ihdr.color_type.clone());
+                eval.try_image_with_description(Arc::new(reduced), "Indexed (battiato sort)");
+                evaluation_added = true;
             }
         }
     }

--- a/src/reduction/mod.rs
+++ b/src/reduction/mod.rs
@@ -93,7 +93,8 @@ pub(crate) fn perform_reductions(
             png = Arc::new(reduced);
         }
         // If either action changed the data then enter this into the evaluator
-        if !Arc::ptr_eq(&png, &baseline) {
+        // (Skip for effort 2 - we'll rely on the ezeng sort later)
+        if effort != 2 && !Arc::ptr_eq(&png, &baseline) {
             eval.try_image_with_description(png.clone(), "Indexed (luma sort)");
             evaluation_added = true;
         }
@@ -151,7 +152,7 @@ pub(crate) fn perform_reductions(
     };
 
     // Attempt additional palette sorting techniques
-    if effort >= 3 && opts.palette_reduction && !deadline.passed() {
+    if effort >= 2 && opts.palette_reduction && !deadline.passed() {
         // Collect a list of palettes so we can avoid evaluating the same one twice
         let mut palettes = vec![baseline.ihdr.color_type.clone()];
         // Make sure we use the `indexed` var as input if it exists
@@ -160,9 +161,10 @@ pub(crate) fn perform_reductions(
         if let Some(matrix) = CoOccurrenceMatrix::from(input) {
             // Attempt to sort the palette using the ezeng method
             // 50 is a good value for max_swap_dist to keep performance reasonable and can actually
-            // be better than the full 255 in some cases
+            // be better than the full 255 in some cases. 1 is faster for low-effort.
+            let max_swap_dist = if effort >= 3 { 50 } else { 1 };
             if !deadline.passed()
-                && let Some(reduced) = sorted_palette_ezeng(input, &matrix, 50)
+                && let Some(reduced) = sorted_palette_ezeng(input, &matrix, max_swap_dist)
                 && !palettes.contains(&reduced.ihdr.color_type)
             {
                 palettes.push(reduced.ihdr.color_type.clone());

--- a/src/reduction/mod.rs
+++ b/src/reduction/mod.rs
@@ -20,10 +20,16 @@ pub(crate) fn perform_reductions(
     let mut evaluation_added = false;
 
     // At low compression levels, skip some transformations which are less likely to be effective
-    // This currently affects optimization presets 0-2
-    let cheap = match opts.deflater {
-        Deflater::Libdeflater { compression } => compression < 12 && opts.fast_evaluation,
-        _ => false,
+    // This primarily affects optimization presets 0-2
+    let effort = match opts.deflater {
+        Deflater::Libdeflater { compression } => match compression {
+            0..=9 => 0,
+            10 => 1,
+            11 if opts.fast_evaluation => 2,
+            11 => 3,
+            _ => 4,
+        },
+        _ => 4,
     };
 
     // Interlacing must be processed first in order to evaluate the rest correctly
@@ -111,7 +117,7 @@ pub(crate) fn perform_reductions(
 
     // Attempt to convert from indexed to channels
     // This may give a better result due to dropping the PLTE chunk
-    if !cheap
+    if effort >= 3
         && opts.color_type_reduction
         && !deadline.passed()
         && let Some(reduced) =
@@ -145,7 +151,7 @@ pub(crate) fn perform_reductions(
     };
 
     // Attempt to sort the palette using the ezeng method
-    if !cheap && opts.palette_reduction && !deadline.passed() {
+    if effort >= 3 && opts.palette_reduction && !deadline.passed() {
         // Make sure we use the `indexed` var as input if it exists
         let input = indexed.as_ref().unwrap_or(&png);
         if let Some(matrix) = CoOccurrenceMatrix::from(input) {
@@ -165,9 +171,9 @@ pub(crate) fn perform_reductions(
     if opts.bit_depth_reduction && !deadline.passed() {
         // First try the `png` var
         let reduced = reduced_bit_depth_8_or_less(&png);
-        // Then try the `indexed` var, unless we're doing cheap evaluations and already have a reduction
+        // Then try the `indexed` var, unless we're doing low-effort evaluations and already have a reduction
         // Only evaluate this if it's different from the first result (which must be grayscale if it exists)
-        if (!cheap || reduced.is_none())
+        if (effort >= 3 || reduced.is_none())
             && !deadline.passed()
             && let Some(indexed) = indexed.and_then(|png| reduced_bit_depth_8_or_less(&png))
             && reduced.as_ref().is_none_or(|r| r.data != indexed.data)

--- a/src/reduction/mod.rs
+++ b/src/reduction/mod.rs
@@ -27,42 +27,47 @@ pub(crate) fn perform_reductions(
     };
 
     // Interlacing must be processed first in order to evaluate the rest correctly
-    if let Some(interlacing) = opts.interlace {
-        if let Some(reduced) = png.change_interlacing(interlacing) {
-            png = Arc::new(reduced);
-        }
+    if let Some(interlacing) = opts.interlace
+        && let Some(reduced) = png.change_interlacing(interlacing)
+    {
+        png = Arc::new(reduced);
     }
 
     // If alpha optimization is enabled, clean the alpha channel before continuing
     // This can allow some color type reductions which may not have been possible otherwise
-    if opts.optimize_alpha && !deadline.passed() {
-        if let Some(reduced) = cleaned_alpha_channel(&png) {
-            png = Arc::new(reduced);
-        }
+    if opts.optimize_alpha
+        && !deadline.passed()
+        && let Some(reduced) = cleaned_alpha_channel(&png)
+    {
+        png = Arc::new(reduced);
     }
 
     // Attempt to reduce 16-bit to 8-bit
     // This is just removal of bytes and does not need to be evaluated
-    if opts.bit_depth_reduction && !deadline.passed() {
-        if let Some(reduced) = reduced_bit_depth_16_to_8(&png, opts.scale_16) {
-            png = Arc::new(reduced);
-        }
+    if opts.bit_depth_reduction
+        && !deadline.passed()
+        && let Some(reduced) = reduced_bit_depth_16_to_8(&png, opts.scale_16)
+    {
+        png = Arc::new(reduced);
     }
 
     // Attempt to reduce RGB to grayscale
     // This is just removal of bytes and does not need to be evaluated
-    if opts.color_type_reduction && opts.grayscale_reduction && !deadline.passed() {
-        if let Some(reduced) = reduced_rgb_to_grayscale(&png) {
-            png = Arc::new(reduced);
-        }
+    if opts.color_type_reduction
+        && opts.grayscale_reduction
+        && !deadline.passed()
+        && let Some(reduced) = reduced_rgb_to_grayscale(&png)
+    {
+        png = Arc::new(reduced);
     }
 
     // Attempt to expand the bit depth to 8
     // This does need to be evaluated but will be done so later when it gets reduced again
-    if opts.bit_depth_reduction && !deadline.passed() {
-        if let Some(reduced) = expanded_bit_depth_to_8(&png) {
-            png = Arc::new(reduced);
-        }
+    if opts.bit_depth_reduction
+        && !deadline.passed()
+        && let Some(reduced) = expanded_bit_depth_to_8(&png)
+    {
+        png = Arc::new(reduced);
     }
 
     // Now retain the current png for the evaluator baseline
@@ -89,50 +94,55 @@ pub(crate) fn perform_reductions(
     }
 
     // Attempt alpha removal
-    if opts.color_type_reduction && !deadline.passed() {
-        if let Some(reduced) = reduced_alpha_channel(&png, opts.optimize_alpha) {
-            png = Arc::new(reduced);
-            // For small differences, if a tRNS chunk is required then enter this into the evaluator
-            // Otherwise it is mostly just removal of bytes and should become the baseline
-            if png.ihdr.color_type.has_trns() && baseline.data.len() - png.data.len() <= 1000 {
-                eval.try_image(png.clone());
-                evaluation_added = true;
-            } else {
-                baseline = png.clone();
-            }
+    if opts.color_type_reduction
+        && !deadline.passed()
+        && let Some(reduced) = reduced_alpha_channel(&png, opts.optimize_alpha)
+    {
+        png = Arc::new(reduced);
+        // For small differences, if a tRNS chunk is required then enter this into the evaluator
+        // Otherwise it is mostly just removal of bytes and should become the baseline
+        if png.ihdr.color_type.has_trns() && baseline.data.len() - png.data.len() <= 1000 {
+            eval.try_image(png.clone());
+            evaluation_added = true;
+        } else {
+            baseline = png.clone();
         }
     }
 
     // Attempt to convert from indexed to channels
     // This may give a better result due to dropping the PLTE chunk
-    if !cheap && opts.color_type_reduction && !deadline.passed() {
-        if let Some(reduced) =
+    if !cheap
+        && opts.color_type_reduction
+        && !deadline.passed()
+        && let Some(reduced) =
             indexed_to_channels(&png, opts.grayscale_reduction, opts.optimize_alpha)
-        {
-            // This result should not be passed on to subsequent reductions
-            eval.try_image(Arc::new(reduced));
-            evaluation_added = true;
-        }
+    {
+        // This result should not be passed on to subsequent reductions
+        eval.try_image(Arc::new(reduced));
+        evaluation_added = true;
     }
 
     // Attempt to reduce to indexed
     // Keep the existing `png` var in case it is grayscale - we can test both for depth reduction later
-    let mut indexed = None;
-    if opts.color_type_reduction && opts.palette_reduction && !deadline.passed() {
-        if let Some(reduced) = reduced_to_indexed(&png, opts.grayscale_reduction) {
-            // Make sure the palette gets sorted (but don't bother evaluating both results)
-            let new = Arc::new(sorted_palette(&reduced).unwrap_or(reduced));
-            // For relatively small differences, enter this into the evaluator
-            // Otherwise we're confident enough for it to become the baseline
-            if png.data.len() - new.data.len() <= INDEXED_MAX_DIFF {
-                eval.try_image_with_description(new.clone(), "Indexed (luma sort)");
-                evaluation_added = true;
-            } else {
-                baseline = new.clone();
-            }
-            indexed = Some(new);
+    let indexed = if opts.color_type_reduction
+        && opts.palette_reduction
+        && !deadline.passed()
+        && let Some(reduced) = reduced_to_indexed(&png, opts.grayscale_reduction)
+    {
+        // Make sure the palette gets sorted (but don't bother evaluating both results)
+        let new = Arc::new(sorted_palette(&reduced).unwrap_or(reduced));
+        // For relatively small differences, enter this into the evaluator
+        // Otherwise we're confident enough for it to become the baseline
+        if png.data.len() - new.data.len() <= INDEXED_MAX_DIFF {
+            eval.try_image_with_description(new.clone(), "Indexed (luma sort)");
+            evaluation_added = true;
+        } else {
+            baseline = new.clone();
         }
-    }
+        Some(new)
+    } else {
+        None
+    };
 
     // Attempt to sort the palette using the ezeng method
     if !cheap && opts.palette_reduction && !deadline.passed() {
@@ -156,14 +166,14 @@ pub(crate) fn perform_reductions(
         // First try the `png` var
         let reduced = reduced_bit_depth_8_or_less(&png);
         // Then try the `indexed` var, unless we're doing cheap evaluations and already have a reduction
-        if (!cheap || reduced.is_none()) && !deadline.passed() {
-            if let Some(indexed) = indexed.and_then(|png| reduced_bit_depth_8_or_less(&png)) {
-                // Only evaluate this if it's different from the first result (which must be grayscale if it exists)
-                if reduced.as_ref().is_none_or(|r| r.data != indexed.data) {
-                    eval.try_image(Arc::new(indexed));
-                    evaluation_added = true;
-                }
-            }
+        // Only evaluate this if it's different from the first result (which must be grayscale if it exists)
+        if (!cheap || reduced.is_none())
+            && !deadline.passed()
+            && let Some(indexed) = indexed.and_then(|png| reduced_bit_depth_8_or_less(&png))
+            && reduced.as_ref().is_none_or(|r| r.data != indexed.data)
+        {
+            eval.try_image(Arc::new(indexed));
+            evaluation_added = true;
         }
         // Enter the first result into the evaluator
         if let Some(reduced) = reduced {

--- a/src/reduction/palette.rs
+++ b/src/reduction/palette.rs
@@ -134,7 +134,8 @@ pub fn sorted_palette(png: &PngImage) -> Option<PngImage> {
 #[must_use]
 pub fn sorted_palette_mzeng(png: &PngImage, matrix: &CoOccurrenceMatrix) -> Option<PngImage> {
     let mut remapping = mzeng_reindex(matrix);
-    apply_most_popular_color(png, &mut remapping, matrix);
+    // Put the most popular color first, but only if covers at least 15% of the image
+    apply_most_popular_color(&mut remapping, matrix, png.data.len() * 3 / 20);
     apply_palette_reorder(png, &remapping)
 }
 
@@ -148,7 +149,8 @@ pub fn sorted_palette_ezeng(
     let mut remapping = ezeng_reindex(matrix);
     // Perform additional optimization with pairwise swaps
     pairwise_swap_search(&mut remapping, matrix, max_swap_dist);
-    apply_most_popular_color(png, &mut remapping, matrix);
+    // Put the most popular color first, but only if covers at least 15% of the image
+    apply_most_popular_color(&mut remapping, matrix, png.data.len() * 3 / 20);
     apply_palette_reorder(png, &remapping)
 }
 
@@ -156,7 +158,8 @@ pub fn sorted_palette_ezeng(
 #[must_use]
 pub fn sorted_palette_battiato(png: &PngImage, matrix: &CoOccurrenceMatrix) -> Option<PngImage> {
     let mut remapping = battiato_reindex(matrix);
-    apply_most_popular_color(png, &mut remapping, matrix);
+    // Always put the most popular color first (this helps increase diversity vs zeng)
+    apply_most_popular_color(&mut remapping, matrix, 0);
     apply_palette_reorder(png, &remapping)
 }
 
@@ -215,11 +218,10 @@ fn most_popular_edge_color(num_colors: usize, png: &PngImage) -> Option<usize> {
     Some(max.0)
 }
 
-// Put the most popular color first
-fn apply_most_popular_color(png: &PngImage, remapping: &mut [usize], matrix: &CoOccurrenceMatrix) {
+// Put the most popular color first, if it meets a minmum threshold
+fn apply_most_popular_color(remapping: &mut [usize], matrix: &CoOccurrenceMatrix, min: usize) {
     let most_popular = matrix.most_popular_color();
-    // If the most popular color is less than 15% of the image, don't use it
-    if most_popular.1 < png.data.len() as u32 * 3 / 20 {
+    if most_popular.1 < min as u32 {
         return;
     }
     let first_idx = remapping.iter().position(|&i| i == most_popular.0).unwrap();

--- a/src/reduction/palette.rs
+++ b/src/reduction/palette.rs
@@ -153,7 +153,6 @@ pub fn sorted_palette_ezeng(
 }
 
 /// Sort the colors in the palette using the battiato technique, returning the sorted image if successful
-// (Note: This is currently unused as it is outclassed by the ezeng method)
 #[must_use]
 pub fn sorted_palette_battiato(png: &PngImage, matrix: &CoOccurrenceMatrix) -> Option<PngImage> {
     let mut remapping = battiato_reindex(matrix);


### PR DESCRIPTION
One more sorting PR before the next release!
- Reinstate Battiato method at o4 and higher. A few factors have allowed this back again:
  - Sorting performance improvements from #820, including now re-using the same matrix for multiple algorithms.
  - A kludgy way to infer the o-level from known options.
  - A tweak to the popular colour rule to get slightly more benefit from battiato.
- Enable ezeng at o2 (usually instead of luma). At this level we limit swap distance to 1 for performance.

I've also bumped MSRV to 1.88 to allow let-chaining, which can help to reduce nesting in some places.

| Level | Saved | Time |
|--|--|--|
| o2 master | 14.64% | 3.1s |
| o2 PR | 16.50% | 3.3s |
| o4 master | 17.20% | 16.3s |
| o4 PR | 17.24% | 16.7s |